### PR TITLE
ENH: facilitated installs for developers in setup.py, enhances #211

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,25 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": PACKAGE_DIR},
     install_requires=["numpy", "pandas", "plotly", "scitrack", "tqdm", "tinydb"],
+    extras_require={
+        "dev": [
+            "pytest-azurepipelines",
+            "jupyterlab",
+            "ipykernel",
+            "ipywidgets",
+            "click",
+            "sphinx",
+            "sphinx_rtd_theme",
+            "nbsphinx",
+            "jupytext",
+            "pytest",
+            "pytest-cov",
+            "pytest>=4.3.0",
+            "tox",
+            "black",
+            "isort",
+        ]
+    },
     ext_modules=cythonize(
         [
             CythonExtension("cogent3.align._compare"),

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ setup(
             "click",
             "sphinx",
             "sphinx_rtd_theme",
+            "sphinx-autobuild",
             "nbsphinx",
             "jupytext",
             "pytest",


### PR DESCRIPTION
to execute the extras_require installs: 

`cd path/to/cogent3`

`pip install -e .[dev]`