### PR TITLE
ENH: added cogent3.util.misc.path_exists function

### DIFF
--- a/src/cogent3/util/deserialise.py
+++ b/src/cogent3/util/deserialise.py
@@ -9,7 +9,7 @@ import cogent3
 from cogent3.core.alignment import Aligned
 from cogent3.core.genetic_code import get_code
 from cogent3.core.moltype import _CodonAlphabet, get_moltype
-from cogent3.util.misc import open_
+from cogent3.util.misc import open_, path_exists
 
 
 __author__ = ["Gavin Huttley"]
@@ -266,11 +266,7 @@ def deserialise_object(data):
     If the dict from json.loads does not contain a "type" key, the object will
     be returned as is. Otherwise, it will be deserialised to a cogent3 object.
     """
-    try:
-        is_path = os.path.exists(data)
-    except (ValueError, TypeError):
-        is_path = False
-    if type(data) is str and is_path:
+    if path_exists(data):
         with open_(data) as infile:
             data = json.load(infile)
 

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -5,6 +5,7 @@ import zipfile
 
 from bz2 import open as bzip_open
 from gzip import open as gzip_open
+from os import path as os_path
 from os import remove
 from pathlib import Path
 from random import choice, randint
@@ -1104,6 +1105,17 @@ def get_object_provenance(obj):
     else:
         result = ".".join([mod, name])
     return result
+
+
+def path_exists(path):
+    """whether path is a valid path and it exists"""
+    if not (isinstance(path, str) or isinstance(path, Path)):
+        return False
+    try:
+        is_path = os_path.exists(str(path))
+    except (ValueError, TypeError):
+        is_path = False
+    return is_path
 
 
 def extend_docstring_from(source, pre=False):

--- a/tests/test_util/test_misc.py
+++ b/tests/test_util/test_misc.py
@@ -2,6 +2,8 @@
 
 """Unit tests for utility functions and classes.
 """
+import pathlib
+
 from copy import copy, deepcopy
 from os import remove, rmdir
 from os.path import exists
@@ -39,6 +41,7 @@ from cogent3.util.misc import (
     iterable,
     list_flatten,
     not_list_tuple,
+    path_exists,
     recursive_flatten,
     remove_files,
 )
@@ -494,6 +497,18 @@ class UtilsTests(TestCase):
         knowns = ((3, False), (9, False), (5, True))
         for arg2, result in knowns:
             self.assertEqual(curry_test(arg2), result)
+
+    def test_path_exists(self):
+        """robustly identifies whether an object is a valid path and exists"""
+        self.assertFalse(path_exists({}))
+        self.assertFalse(path_exists("not an existing path"))
+        self.assertFalse(path_exists("(a,b,(c,d))"))
+        self.assertFalse(path_exists("(a:0.1,b:0.1,(c:0.1,d:0.1):0.1)"))
+        # works for a Path instance
+        p = pathlib.Path(__file__)
+        self.assertTrue(path_exists(p))
+        # or string instance
+        self.assertTrue(path_exists(__file__))
 
 
 class _my_dict(dict):


### PR DESCRIPTION
[NEW] robust handling of input data (anything other than a string or Path
    returns False) and arbitrary string data (for example a phylogenetic
    tree), returning True only if its a valid path and exists