### PR TITLE
TST: fixed test_mpi failure

### DIFF
--- a/tests/test_app/test_app_mpi.py
+++ b/tests/test_app/test_app_mpi.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, main
+from unittest import TestCase, main, skipUnless
 
 from cogent3.app import align as align_app
 from cogent3.app import io as io_app
@@ -19,6 +19,7 @@ __status__ = "Alpha"
 class MPITests(TestCase):
     basedir = "data"
 
+    @skipUnless(parallel.USING_MPI, reason="Not using MPI")
     def test_write_db(self):
         """writing with overwrite in MPI should reset db"""
         dstore = io_app.get_data_store("data", suffix="fasta")
@@ -44,3 +45,7 @@ class MPITests(TestCase):
         got = [str(m) for m in result]
 
         assert got == expect
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
[FIXED] test only makes sense when it's being run by MPI. Now use
    unittest.skipUnless decorator to check for this.
[CHANGED] moved file to test_app/test_app_mpi.py, since that's
    what it's really about