### PR TITLE
ENH: additional meta-data added to alignment.info by TreeAlign

### DIFF
--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -114,6 +114,13 @@ def TreeAlign(
         LF.set_sequences(seqs)
     edge = LF.get_log_likelihood().edge
     align = edge.get_viterbi_path().get_alignment()
-    param_vals.update(dict(indel_length=indel_length, indel_rate=indel_rate))
+    param_vals.update(
+        dict(
+            indel_length=indel_length,
+            indel_rate=indel_rate,
+            guide_tree=tree.get_newick(with_distances=True),
+            model=model.name,
+        )
+    )
     align.info["align_params"] = param_vals
     return align, tree


### PR DESCRIPTION
[CHANGED] now add the name of the substitution model and the
    guide tree newick string to the info attribute of the returned alignment
    object.