### PR TITLE
BUG: discrete time model get_annotated_tree(length_as="paralinear") w…

### DIFF
--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -600,8 +600,8 @@ class LikelihoodFunction(ParameterController):
 
             if not is_discrete:
                 edge.params["ENS"] = ens[edge.name]
-                edge.params["length"] = lengths[edge.name]
 
+            edge.params["length"] = lengths[edge.name]
             edge.params["paralinear"] = plin[edge.name]
             edge.params["mprobs"] = mprobs[edge.name].to_dict()
             for par in d:

--- a/tests/test_app/test_result.py
+++ b/tests/test_app/test_result.py
@@ -114,6 +114,9 @@ class TestGenericResult(TestCase):
         )
         result = model1(aln)
         got = result.tree
+        self.assertEqual(
+            got.children[0].params["length"], got.children[0].params["paralinear"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…orks

[FIXED] the length attribute now correctly updated when it's either
    continuous- or discrete-time