### PR TITLE
API: the app.io.load_(un)aligned only loads from file, fixes #180

### DIFF
--- a/doc/app/align-codon.rst
+++ b/doc/app/align-codon.rst
@@ -41,7 +41,7 @@ The distance measures available are the same as for the nucleotide case (percent
 
 .. doctest::
     
-    >>> nt_aligner = progressive_align("nucleotide", distance="paralinear")
+    >>> nt_aligner = progressive_align("codon", distance="paralinear")
     >>> aligned = nt_aligner(seqs)
     >>> aligned
     6 x 2478 dna alignment...

--- a/doc/app/align-protein.rst
+++ b/doc/app/align-protein.rst
@@ -33,7 +33,7 @@ The distance measures available are percent or paralinear.
 
 .. doctest::
     
-    >>> nt_aligner = progressive_align("nucleotide", distance="paralinear")
-    >>> aligned = nt_aligner(seqs)
+    >>> aa_aligner = progressive_align("protein", distance="paralinear")
+    >>> aligned = aa_aligner(seqs)
     >>> aligned
-    6 x 2478 dna alignment...
+    6 x 825 protein alignment...

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -133,16 +133,10 @@ class _seq_loader:
             # we use a data store as it's read() handles compression
             path = SingleReadDataStore(path)[0]
 
-        if hasattr(path, "read"):
-            data = path.read().splitlines()
-            data = dict(record for record in self._parser(data))
-            seqs = self.klass(data=data, moltype=self.moltype)
-            seqs.info.source = abs_path
-        elif not isinstance(path, SequenceCollection):
-            func = _load_aligned_seqs if self.aligned else _load_unaligned_seqs
-            seqs = func(path, moltype=self.moltype)
-        else:
-            seqs = path  # it is a SequenceCollection
+        data = path.read().splitlines()
+        data = dict(record for record in self._parser(data))
+        seqs = self.klass(data=data, moltype=self.moltype)
+        seqs.info.source = abs_path
 
         if self._output_types & {"sequences"}:
             seqs = seqs.degap()
@@ -195,14 +189,7 @@ class load_unaligned(ComposableSeq, _seq_loader):
         super(ComposableSeq, self).__init__(
             input_types=None,
             output_types=(SEQUENCE_TYPE, SERIALISABLE_TYPE),
-            data_types=(
-                "DataStoreMember",
-                "str",
-                "Path",
-                "ArrayAlignment",
-                "Alignment",
-                "SequenceCollection",
-            ),
+            data_types=("DataStoreMember", "str", "Path"),
         )
         _seq_loader.__init__(self)
         self._formatted_params()

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -138,10 +138,10 @@ class TestIo(TestCase):
             self.assertTrue("-" not in "".join(seqs.to_dict().values()))
             self.assertEqual(seqs.info.source, fasta_paths[i])
 
-        # should also handle case where it's given an alignment/sequence
+        # returns NotCompleted when it's given an alignment/sequence
         # collection
         got = fasta_loader(seqs)
-        self.assertEqual(got, seqs)
+        self.assertIsInstance(got, NotCompleted)
 
     def test_write_seqs(self):
         """correctly writes sequences out"""


### PR DESCRIPTION
[FIXED] simplifies logic and makes function name consistent with
    top level standalone funcs, i.e. load means read from file