### PR TITLE
TST: add test of a solved substitution model

### DIFF
--- a/src/cogent3/evolve/solved_models.py
+++ b/src/cogent3/evolve/solved_models.py
@@ -74,7 +74,7 @@ class PredefinedNucleotide(TimeReversibleNucleotide):
         assert_allclose(P1, P2)
 
 
-def _solvedNucleotide(name, predicates, rate_matrix_required=True, **kw):
+def _solved_nucleotide(name, predicates, rate_matrix_required=True, **kw):
     if _solved_models is not None and not rate_matrix_required:
         klass = PredefinedNucleotide
     else:
@@ -91,16 +91,16 @@ kappa = (kappa_y | kappa_r).aliased("kappa")
 def TN93(**kw):
     """Tamura and Nei 1993 model"""
     kw["recode_gaps"] = True
-    return _solvedNucleotide("TN93", [kappa_y, kappa_r], **kw)
+    return _solved_nucleotide("TN93", [kappa_y, kappa_r], **kw)
 
 
 def HKY85(**kw):
     """Hasegawa, Kishino and Yanamo 1985 model"""
     kw["recode_gaps"] = True
-    return _solvedNucleotide("HKY85", [kappa], **kw)
+    return _solved_nucleotide("HKY85", [kappa], **kw)
 
 
 def F81(**kw):
     """Felsenstein's 1981 model"""
     kw["recode_gaps"] = True
-    return _solvedNucleotide("F81", [], **kw)
+    return _solved_nucleotide("F81", [], **kw)

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -177,7 +177,7 @@ class LikelihoodCalcs(TestCase):
         one = aln.pop("Mouse")
         aln["root"] = one
         aln = make_aligned_seqs(data=aln)
-        submod = TimeReversibleNucleotide()
+        submod = get_model("TN93")
         tree = make_tree("%s" % str(tuple(aln.names)))
         lf = submod.make_likelihood_function(tree)
         try:
@@ -280,6 +280,16 @@ class LikelihoodCalcs(TestCase):
         self.assertEqual(likelihood_function.get_num_free_params(), 0)
         evolve_lnL = likelihood_function.get_log_likelihood()
         self.assertFloatEqual(evolve_lnL, -148.6455087258624)
+
+    def test_solved_nucleotide(self):
+        """test a solved nucleotide model."""
+        submod = get_model("TN93", rate_matrix_required=False)
+        # now do using the evolve
+        lf = submod.make_likelihood_function(self.tree)
+        lf.set_alignment(self.alignment)
+        self.assertEqual(lf.get_num_free_params(), 5)
+        lf.optimise(show_progress=False, max_evaluations=20, limit_action="ignore")
+        self.assertTrue(lf.lnL > -152)
 
     def test_discrete_nucleotide(self):
         """test that partially discrete nucleotide model can be constructed, 


### PR DESCRIPTION
[NEW] invoke test of solved substitution model in likelihood calculation,
    setting rate_matrix_required=False
[CHANGED] refactored _solvedNucleotide function to _solved_nucleotide