### PR TITLE
to_rich_dict works on annotated annotations

### DIFF
--- a/src/cogent3/core/annotation.py
+++ b/src/cogent3/core/annotation.py
@@ -257,6 +257,15 @@ class _Serialisable:
         data = dict(annotation_construction=data)
         data["type"] = get_object_provenance(self)
         data["version"] = __version__
+
+        try:
+            annotations = [a.to_rich_dict() for a in self.annotations]
+        except AttributeError:
+            annotations = []
+
+        if annotations:
+            data["annotations"] = annotations
+
         return data
 
     def to_json(self):

--- a/src/cogent3/core/annotation.py
+++ b/src/cogent3/core/annotation.py
@@ -260,11 +260,10 @@ class _Serialisable:
 
         try:
             annotations = [a.to_rich_dict() for a in self.annotations]
+            if annotations:
+                data["annotations"] = annotations
         except AttributeError:
-            annotations = []
-
-        if annotations:
-            data["annotations"] = annotations
+            pass
 
         return data
 

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -629,8 +629,8 @@ class FeaturesTest(TestCase):
         """check the get_slice method works on nested annotations"""
         self.assertEqual(self.nested_feature.get_slice(), "CCC")
 
-    def test_nested_deserialise_annotation(self):
-        """check the deserialise_annotation method works with nested annotations"""
+    def test_nested_to_rich_dict(self):
+        """check the to_rich_dict method works with nested annotations"""
         self.assertEqual(
             self.exon1.to_rich_dict()["annotations"][0],
             self.nested_feature.to_rich_dict(),

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -26,6 +26,7 @@ class FeaturesTest(TestCase):
         )
         self.exon1 = self.s.add_annotation(Feature, "exon", "fred", [(10, 15)])
         self.exon2 = self.s.add_annotation(Feature, "exon", "trev", [(30, 40)])
+        self.nested_feature = self.exon1.add_feature("repeat", "C", [(2, 5)])
 
     def test_exon_extraction(self):
         """exon feature used to slice or directly access sequence"""
@@ -626,8 +627,14 @@ class FeaturesTest(TestCase):
 
     def test_nested_get_slice(self):
         """check the get_slice method works on nested annotations"""
-        nested_feature = self.exon1.add_feature("repeat", "C", [(2, 5)])
-        self.assertEqual(nested_feature.get_slice(), "CCC")
+        self.assertEqual(self.nested_feature.get_slice(), "CCC")
+
+    def test_nested_deserialise_annotation(self):
+        """check the deserialise_annotation method works with nested annotations"""
+        self.assertEqual(
+            self.exon1.to_rich_dict()["annotations"][0],
+            self.nested_feature.to_rich_dict(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -26,7 +26,7 @@ class FeaturesTest(TestCase):
         )
         self.exon1 = self.s.add_annotation(Feature, "exon", "fred", [(10, 15)])
         self.exon2 = self.s.add_annotation(Feature, "exon", "trev", [(30, 40)])
-        self.nested_feature = self.exon1.add_feature("repeat", "C", [(2, 5)])
+        self.nested_feature = self.exon1.add_feature("repeat", "bob", [(2, 5)])
 
     def test_exon_extraction(self):
         """exon feature used to slice or directly access sequence"""


### PR DESCRIPTION
Copied the annotation writing from SequenceI.to_rich_dict() into _Serialisable.to_rich_dict().
Could not find a good way to remove this code duplication without adding complexity.

Added a test to demonstrate this working.