### PR TITLE
SequenceCollection.annotate_from_gff works in Alignment subclass, but not in the generic SequenceCollection class

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -4007,6 +4007,10 @@ class ArrayAlignment(AlignmentI, SequenceCollection):
 
         return identical_sets
 
+    def annotate_from_gff(self, f):
+        """Override annotate_from_gff since an ArrayAlignment cannot be annotated"""
+        raise TypeError("not supported on ArrayAlignment, use to_type(array_align=True) to convert")
+
 
 class CodonArrayAlignment(ArrayAlignment):
     """Stores alignment of gapped codons, no degenerate symbols."""

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -878,22 +878,26 @@ class SequenceCollectionBaseTests(object):
             ["seq5", "prog2", "snp", "2", "3", "1.0", "+", "1", '"yyy"'],
         ]
         gff = list(map("\t".join, gff))
-        aln.annotate_from_gff(gff)
-        aln_seq_1 = aln.named_seqs["seq1"]
-        if not hasattr(aln_seq_1, "annotations"):
-            aln_seq_1 = aln_seq_1.data
-        aln_seq_2 = aln.named_seqs["seq2"]
-        if not hasattr(aln_seq_2, "annotations"):
-            aln_seq_2 = aln_seq_2.data
-        self.assertEqual(len(aln_seq_1.annotations), 1)
-        self.assertEqual(aln_seq_1.annotations[0].name, "abc")
-        self.assertEqual(len(aln_seq_2.annotations), 0)
+        if isinstance(aln, ArrayAlignment):
+            with self.assertRaises(TypeError):
+                aln.annotate_from_gff(gff)
+        else:
+            aln.annotate_from_gff(gff)
+            aln_seq_1 = aln.named_seqs["seq1"]
+            if not hasattr(aln_seq_1, "annotations"):
+                aln_seq_1 = aln_seq_1.data
+            aln_seq_2 = aln.named_seqs["seq2"]
+            if not hasattr(aln_seq_2, "annotations"):
+                aln_seq_2 = aln_seq_2.data
+            self.assertEqual(len(aln_seq_1.annotations), 1)
+            self.assertEqual(aln_seq_1.annotations[0].name, "abc")
+            self.assertEqual(len(aln_seq_2.annotations), 0)
 
-        aln_seq_3 = aln.named_seqs["seq3"]
-        if not hasattr(aln_seq_3, "annotations"):
-            aln_seq_3 = aln_seq_3.data
-        matches = [m for m in aln_seq_3.get_annotations_matching("*")]
-        self.assertFalse('-' in matches[0].get_slice())
+            aln_seq_3 = aln.named_seqs["seq3"]
+            if not hasattr(aln_seq_3, "annotations"):
+                aln_seq_3 = aln_seq_3.data
+            matches = [m for m in aln_seq_3.get_annotations_matching("*")]
+            # self.assertFalse('-' in matches[0].get_slice())
 
     def test_add(self):
         """__add__ should concatenate sequence data, by name"""

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -881,17 +881,18 @@ class SequenceCollectionBaseTests(object):
         if isinstance(aln, ArrayAlignment):
             with self.assertRaises(TypeError):
                 aln.annotate_from_gff(gff)
-        else:
-            aln.annotate_from_gff(gff)
-            aln_seq_1 = aln.named_seqs["seq1"]
-            if not hasattr(aln_seq_1, "annotations"):
-                aln_seq_1 = aln_seq_1.data
-            aln_seq_2 = aln.named_seqs["seq2"]
-            if not hasattr(aln_seq_2, "annotations"):
-                aln_seq_2 = aln_seq_2.data
-            self.assertEqual(len(aln_seq_1.annotations), 1)
-            self.assertEqual(aln_seq_1.annotations[0].name, "abc")
-            self.assertEqual(len(aln_seq_2.annotations), 0)
+            return
+        
+        aln.annotate_from_gff(gff)
+        aln_seq_1 = aln.named_seqs["seq1"]
+        if not hasattr(aln_seq_1, "annotations"):
+            aln_seq_1 = aln_seq_1.data
+        aln_seq_2 = aln.named_seqs["seq2"]
+        if not hasattr(aln_seq_2, "annotations"):
+            aln_seq_2 = aln_seq_2.data
+        self.assertEqual(len(aln_seq_1.annotations), 1)
+        self.assertEqual(aln_seq_1.annotations[0].name, "abc")
+        self.assertEqual(len(aln_seq_2.annotations), 0)
 
         if isinstance(aln, Alignment):
             aln_seq_3 = aln.get_seq("seq3")

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -881,9 +881,9 @@ class SequenceCollectionBaseTests(object):
         if isinstance(aln, ArrayAlignment):
             with self.assertRaises(TypeError):
                 aln.annotate_from_gff(gff)
-        elif isinstance(aln, Alignment):
+        else:
             aln.annotate_from_gff(gff)
-            aln_seq_1 = aln.get_seq("seq1")
+            aln_seq_1 = aln.named_seqs["seq1"]
             if not hasattr(aln_seq_1, "annotations"):
                 aln_seq_1 = aln_seq_1.data
             aln_seq_2 = aln.named_seqs["seq2"]
@@ -893,6 +893,7 @@ class SequenceCollectionBaseTests(object):
             self.assertEqual(aln_seq_1.annotations[0].name, "abc")
             self.assertEqual(len(aln_seq_2.annotations), 0)
 
+        if isinstance(aln, Alignment):
             aln_seq_3 = aln.get_seq("seq3")
             matches = [m for m in aln_seq_3.get_annotations_matching("*")]
             self.assertFalse("-" in matches[0].get_slice())

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -871,9 +871,10 @@ class SequenceCollectionBaseTests(object):
 
     def test_annotate_from_gff(self):
         """SequenceCollection.annotate_from_gff should read gff features"""
-        aln = self.Class({"seq1": "ACGU", "seq2": "CGUA", "seq3": "CCGU"})
+        aln = self.Class({"seq1": "ACGU", "seq2": "CGUA", "seq3": "C-GU"})
         gff = [
             ["seq1", "prog1", "snp", "1", "2", "1.0", "+", "1", '"abc"'],
+            ["seq3", "prog2", "del", "1", "3", "1.0", "+", "1", '"xyz"'],
             ["seq5", "prog2", "snp", "2", "3", "1.0", "+", "1", '"yyy"'],
         ]
         gff = list(map("\t".join, gff))
@@ -887,6 +888,12 @@ class SequenceCollectionBaseTests(object):
         self.assertEqual(len(aln_seq_1.annotations), 1)
         self.assertEqual(aln_seq_1.annotations[0].name, "abc")
         self.assertEqual(len(aln_seq_2.annotations), 0)
+
+        aln_seq_3 = aln.named_seqs["seq3"]
+        if not hasattr(aln_seq_3, "annotations"):
+            aln_seq_3 = aln_seq_3.data
+        matches = [m for m in aln_seq_3.get_annotations_matching("*")]
+        self.assertFalse('-' in matches[0].get_slice())
 
     def test_add(self):
         """__add__ should concatenate sequence data, by name"""

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -881,9 +881,9 @@ class SequenceCollectionBaseTests(object):
         if isinstance(aln, ArrayAlignment):
             with self.assertRaises(TypeError):
                 aln.annotate_from_gff(gff)
-        else:
+        elif isinstance(aln, Alignment):
             aln.annotate_from_gff(gff)
-            aln_seq_1 = aln.named_seqs["seq1"]
+            aln_seq_1 = aln.get_seq("seq1")
             if not hasattr(aln_seq_1, "annotations"):
                 aln_seq_1 = aln_seq_1.data
             aln_seq_2 = aln.named_seqs["seq2"]
@@ -893,11 +893,9 @@ class SequenceCollectionBaseTests(object):
             self.assertEqual(aln_seq_1.annotations[0].name, "abc")
             self.assertEqual(len(aln_seq_2.annotations), 0)
 
-            aln_seq_3 = aln.named_seqs["seq3"]
-            if not hasattr(aln_seq_3, "annotations"):
-                aln_seq_3 = aln_seq_3.data
+            aln_seq_3 = aln.get_seq("seq3")
             matches = [m for m in aln_seq_3.get_annotations_matching("*")]
-            # self.assertFalse('-' in matches[0].get_slice())
+            self.assertFalse("-" in matches[0].get_slice())
 
     def test_add(self):
         """__add__ should concatenate sequence data, by name"""

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -878,7 +878,7 @@ class SequenceCollectionBaseTests(object):
             ["seq5", "prog2", "snp", "2", "3", "1.0", "+", "1", '"yyy"'],
         ]
         gff = list(map("\t".join, gff))
-        if isinstance(aln, ArrayAlignment):
+        if self.Class == ArrayAlignment:
             with self.assertRaises(TypeError):
                 aln.annotate_from_gff(gff)
             return
@@ -894,7 +894,7 @@ class SequenceCollectionBaseTests(object):
         self.assertEqual(aln_seq_1.annotations[0].name, "abc")
         self.assertEqual(len(aln_seq_2.annotations), 0)
 
-        if isinstance(aln, Alignment):
+        if self.Class == Alignment:
             aln_seq_3 = aln.get_seq("seq3")
             matches = [m for m in aln_seq_3.get_annotations_matching("*")]
             self.assertFalse("-" in matches[0].get_slice())


### PR DESCRIPTION
Changing the .named_seqs attribute to .get_seq(name) had no effect on the gaps, as .get_seq directly calls .named_seqs. 

However the current implementation does remove gaps if using the Alignment class, but not the SequenceCollection class. I have made a test to demonstrate this.