### PR TITLE
Refactored parse.gff

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -64,7 +64,7 @@ from cogent3.format.fasta import alignment_to_fasta
 from cogent3.format.nexus import nexus_from_alignment
 from cogent3.format.phylip import alignment_to_phylip
 from cogent3.maths.stats.number import CategoryCounter
-from cogent3.parse.gff import GffParser, parse_attributes
+from cogent3.parse.gff import gff2_parser, parse_attributes
 from cogent3.util import progress_display as UI
 from cogent3.util.dict_array import DictArrayTemplate
 from cogent3.util.misc import (
@@ -1135,7 +1135,7 @@ class SequenceCollection(object):
             frame,
             attributes,
             comments,
-        ) in GffParser(f):
+        ) in gff2_parser(f):
             if name in self.named_seqs:
                 self.named_seqs[name].add_feature(
                     feature, parse_attributes(attributes), [(start, end)]

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -749,7 +749,7 @@ class Sequence(_Annotatable, SequenceI):
             frame,
             attributes,
             comments,
-        ) in gff.GffParser(f):
+        ) in gff.gff2_parser(f):
             if first_seqname is None:
                 first_seqname = seqname
             else:

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -2,15 +2,27 @@
 
 __author__ = "Peter Maxwell"
 __copyright__ = "Copyright 2007-2019, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Matthew Wakefield", "Gavin Huttley"]
+__credits__ = ["Peter Maxwell", "Matthew Wakefield", "Gavin Huttley", "Christopher Bradley"]
 __license__ = "BSD-3"
 __version__ = "2019.10.24a"
 __maintainer__ = "Peter Maxwell"
 __email__ = "pm67nz@gmail.com"
 __status__ = "Production"
 
+from pathlib import Path
+from cogent3.util.misc import open_
+from io import StringIO
 
-def GffParser(f):
+def gff_parser(f):
+    if isinstance(f, str) or isinstance(f, Path):
+        with open_(f) as infile:
+            gff2_parser(infile)
+    elif isinstance(f, StringIO):
+        return gff2_parser(f)
+    else:
+        raise TypeError
+
+def gff2_parser(f):
     assert not isinstance(f, str)
     for line in f:
         # comments and blank lines

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -2,23 +2,30 @@
 
 __author__ = "Peter Maxwell"
 __copyright__ = "Copyright 2007-2019, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Matthew Wakefield", "Gavin Huttley", "Christopher Bradley"]
+__credits__ = [
+    "Peter Maxwell",
+    "Matthew Wakefield",
+    "Gavin Huttley",
+    "Christopher Bradley",
+]
 __license__ = "BSD-3"
 __version__ = "2019.10.24a"
 __maintainer__ = "Peter Maxwell"
 __email__ = "pm67nz@gmail.com"
 __status__ = "Production"
 
-from pathlib import Path
-from cogent3.util.misc import open_
 from io import StringIO
+from pathlib import Path
+
+from cogent3.util.misc import open_
+
 
 def gff_parser(f):
     if isinstance(f, str) or isinstance(f, Path):
         with open_(f) as infile:
-            gff2_parser(infile)
+            yield from gff2_parser(infile)
     elif isinstance(f, StringIO):
-        return gff2_parser(f)
+        yield from gff2_parser(f)
     else:
         raise TypeError
 

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -22,7 +22,7 @@ from cogent3.util.misc import open_
 
 def gff_parser(f):
     if isinstance(f, str) or isinstance(f, Path):
-        with open_(f) as infile:
+        with open(f) as infile:
             yield from gff2_parser(infile)
     elif isinstance(f, StringIO):
         yield from gff2_parser(f)

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -21,11 +21,10 @@ from cogent3.util.misc import open_
 
 
 def gff_parser(f):
-    if isinstance(f, str):
+    """delegates to the correct gff_parser based on the version"""
+    if isinstance(f, str) or isinstance(f, Path):
+        f = f if not isinstance(f, Path) else str(f)
         with open_(f) as infile:
-            yield from gff2_parser(infile)
-    elif isinstance(f, Path):
-        with open(f) as infile:
             yield from gff2_parser(infile)
     elif isinstance(f, StringIO):
         yield from gff2_parser(f)

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -21,7 +21,10 @@ from cogent3.util.misc import open_
 
 
 def gff_parser(f):
-    if isinstance(f, str) or isinstance(f, Path):
+    if isinstance(f, str):
+        with open_(f) as infile:
+            yield from gff2_parser(infile)
+    elif isinstance(f, Path):
         with open(f) as infile:
             yield from gff2_parser(infile)
     elif isinstance(f, StringIO):

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -22,8 +22,8 @@ from cogent3.util.misc import open_
 
 def gff_parser(f):
     """delegates to the correct gff_parser based on the version"""
-    if isinstance(f, str) or isinstance(f, Path):
-        f = f if not isinstance(f, Path) else str(f)
+    f = f if not isinstance(f, Path) else str(f)
+    if isinstance(f, str):
         with open_(f) as infile:
             yield from gff2_parser(infile)
     elif isinstance(f, StringIO):

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -29,6 +29,7 @@ def gff_parser(f):
     else:
         raise TypeError
 
+
 def gff2_parser(f):
     assert not isinstance(f, str)
     for line in f:

--- a/tests/data/gff2_test.gff
+++ b/tests/data/gff2_test.gff
@@ -1,3 +1,11 @@
+##gff-version 2
+##source-version <source> <version text>
+##date <date>
+##Type <type> [<seqname>]
+##DNA <seqname>
+##acggctcggattggcgctggatgatagatcagacgac
+##...
+##end-DNA
 seq1	BLASTX	similarity	101	235	87.1	+	0	Target "HBA_HUMAN" 11 55 ; E_value 0.0003
 dJ102G20	GD_mRNA	coding_exon	7105	7201	.	-	2	Sequence "dJ102G20.C1.1"
 dJ102G20	GD_mRNA	coding_exon	7105	7201	.	-	2

--- a/tests/data/gff2_test.gff
+++ b/tests/data/gff2_test.gff
@@ -1,4 +1,4 @@
 seq1	BLASTX	similarity	101	235	87.1	+	0	Target "HBA_HUMAN" 11 55 ; E_value 0.0003
 dJ102G20	GD_mRNA	coding_exon	7105	7201	.	-	2	Sequence "dJ102G20.C1.1"
 dJ102G20	GD_mRNA	coding_exon	7105	7201	.	-	2
-12345   Source with spaces	feature with spaces	-100	3600000000	1e-5	-	.	Sequence "BROADO5" ; Note "This is a \t tab containing \n multi line comment"
+12345	Source with spaces	feature with spaces	-100	3600000000	1e-5	-	.	Sequence "BROADO5" ; Note "This is a \t tab containing \n multi line comment"

--- a/tests/data/test_gff2.gff
+++ b/tests/data/test_gff2.gff
@@ -1,0 +1,4 @@
+seq1	BLASTX	similarity	101	235	87.1	+	0	Target "HBA_HUMAN" 11 55 ; E_value 0.0003
+dJ102G20	GD_mRNA	coding_exon	7105	7201	.	-	2	Sequence "dJ102G20.C1.1"
+dJ102G20	GD_mRNA	coding_exon	7105	7201	.	-	2
+12345   Source with spaces	feature with spaces	-100	3600000000	1e-5	-	.	Sequence "BROADO5" ; Note "This is a \t tab containing \n multi line comment"

--- a/tests/test_parse/test_gff.py
+++ b/tests/test_parse/test_gff.py
@@ -109,6 +109,12 @@ class GffTest(TestCase):
             ["HBA_HUMAN", "dJ102G20.C1.1", "", "BROADO5"],
         )
 
+    def test_gff2_parser_string(self):
+        """Test the gff_parser works with a string filepath"""
+        filepath = "data/gff2_test.gff"
+        for result in gff_parser(filepath):
+            # print(result)
+            pass
 
 if __name__ == "__main__":
     main()

--- a/tests/test_parse/test_gff.py
+++ b/tests/test_parse/test_gff.py
@@ -92,14 +92,14 @@ class GffTest(TestCase):
     def testGffParserData(self):
         """Test GffParser with valid data lines"""
         for (line, canned_result) in data_lines:
-            result = next(GffParser(StringIO(line)))
+            result = next(gff_parser(StringIO(line)))
             self.assertEqual(result, canned_result)
 
     def testGffParserHeaders(self):
         """Test GffParser with valid data headers"""
         data = "".join([x[0] for x in data_lines])
         for header in headers:
-            result = list(GffParser(StringIO(header + data)))
+            result = list(gff_parser(StringIO(header + data)))
             self.assertEqual(result, [x[1] for x in data_lines])
 
     def test_parse_attributes(self):

--- a/tests/test_parse/test_gff.py
+++ b/tests/test_parse/test_gff.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Unit tests for GFF and related parsers.
 """
+from pathlib import Path
 from io import StringIO
 from unittest import TestCase, main
 
@@ -112,9 +113,15 @@ class GffTest(TestCase):
     def test_gff2_parser_string(self):
         """Test the gff_parser works with a string filepath"""
         filepath = "data/gff2_test.gff"
-        for result in gff_parser(filepath):
-            # print(result)
-            pass
+        for i, result in enumerate(gff_parser(filepath)):
+            self.assertEqual(result, data_lines[i][1])
+
+    def test_gff2_parser_path(self):
+        """Test the gff_parser works with a pathlib.Path filepath"""
+        filepath = Path("data/gff2_test.gff")
+        for i, result in enumerate(gff_parser(filepath)):
+            self.assertEqual(result, data_lines[i][1])
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_parse/test_gff.py
+++ b/tests/test_parse/test_gff.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """Unit tests for GFF and related parsers.
 """
-from pathlib import Path
 from io import StringIO
+from pathlib import Path
 from unittest import TestCase, main
 
 from cogent3.parse.gff import *


### PR DESCRIPTION
Could not get cogent3.util.misc.open_(f) to work with pathlib.Path.
Allowed input as StringIO to keep old tests, and I guess backwards compatibility.
Converted the example gff2 data `data_lines` to a file to be read in so it could be checked with existing results.