### PR TITLE
available_apps are now displaying input/output/data types, #199

### DIFF
--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -22,24 +22,23 @@ def _get_app_attr(name, obj, mod, is_composable):
     _output_types = getattr(obj, "_output_types", [])
     _data_types = getattr(obj, "_data_types", [])
 
-    if type(_input_types) == str:
-        _input_types = [_input_types]
-    if type(_output_types) == str:
-        _output_types = [_output_types]
-    if type(_data_types) == str:
-        _data_types = [_data_types]
-
     if _input_types:
+        if type(_input_types) == str:
+            _input_types = [_input_types]
         in_type = [{None: ""}.get(e, e) for e in _input_types]
     else:
         in_type = []
 
     if _output_types:
+        if type(_output_types) == str:
+            _output_types = [_output_types]
         out_type = [{None: ""}.get(e, e) for e in _output_types]
     else:
         out_type = []
 
     if _data_types:
+        if type(_data_types) == str:
+            _data_types = [_data_types]
         data_type = [{None: ""}.get(e, e) for e in _data_types]
     else:
         data_type = []

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -21,9 +21,8 @@ def _get_app_attr(name, obj, mod, is_composable):
 
     _types = {"_input_types": [], "_output_types": [], "_data_types": []}
 
-    for types in _types.keys():
-        tys = types
-        types = getattr(obj, types, None) or []
+    for tys in _types.keys():
+        types = getattr(obj, tys, None) or []
         types = [types] if type(types) == str else types
         _types[tys] = [{None: ""}.get(e, e) for e in types]
 

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -25,20 +25,16 @@ def _get_app_attr(name, obj, mod, is_composable):
         tys = types
         types = getattr(obj, types, None) or []
         types = [types] if type(types) == str else types
-        _types[tys] = types
-
-    in_type = [{None: ""}.get(e, e) for e in _types["_input_types"]]
-    out_type = [{None: ""}.get(e, e) for e in _types["_output_types"]]
-    data_type = [{None: ""}.get(e, e) for e in _types["_data_types"]]
+        _types[tys] = [{None: ""}.get(e, e) for e in types]
 
     row = [
         mod.__name__,
         name,
         is_composable,
         obj.__doc__,
-        ", ".join(in_type),
-        ", ".join(out_type),
-        ", ".join(data_type),
+        ", ".join(_types["_input_types"]),
+        ", ".join(_types["_output_types"]),
+        ", ".join(_types["_data_types"]),
     ]
     return row
 

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -23,8 +23,7 @@ def _get_app_attr(name, obj, mod, is_composable):
 
     for types in _types.keys():
         tys = types
-        types = getattr(obj, types, [])
-        types = [] if types is None else types
+        types = getattr(obj, types, None) or []
         types = [types] if type(types) == str else types
         _types[tys] = types
 

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -70,5 +70,4 @@ def available_apps():
     )
     header = ["module", "name", "composable", "doc", "inputs", "outputs", "data type"]
     table = Table(header, rows)
-    table = table.get_columns(header)
     return table

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -70,7 +70,5 @@ def available_apps():
     )
     header = ["module", "name", "composable", "doc", "inputs", "outputs", "data type"]
     table = Table(header, rows)
-    # todo the inputs/outputs/data type columns no longer being populated as
-    # these attributes are instance attributes and not resolved at present
     table = table.get_columns(header)
     return table

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -18,30 +18,19 @@ __all__ = ["align", "composable", "dist", "evo", "io", "sample", "translate", "t
 
 def _get_app_attr(name, obj, mod, is_composable):
     """returns app details for display"""
-    _input_types = getattr(obj, "_input_types", [])
-    _output_types = getattr(obj, "_output_types", [])
-    _data_types = getattr(obj, "_data_types", [])
 
-    if _input_types:
-        if type(_input_types) == str:
-            _input_types = [_input_types]
-        in_type = [{None: ""}.get(e, e) for e in _input_types]
-    else:
-        in_type = []
+    _types = {"_input_types": [], "_output_types": [], "_data_types": []}
 
-    if _output_types:
-        if type(_output_types) == str:
-            _output_types = [_output_types]
-        out_type = [{None: ""}.get(e, e) for e in _output_types]
-    else:
-        out_type = []
+    for types in _types.keys():
+        tys = types
+        types = getattr(obj, types, [])
+        types = [] if types is None else types
+        types = [types] if type(types) == str else types
+        _types[tys] = types
 
-    if _data_types:
-        if type(_data_types) == str:
-            _data_types = [_data_types]
-        data_type = [{None: ""}.get(e, e) for e in _data_types]
-    else:
-        data_type = []
+    in_type = [{None: ""}.get(e, e) for e in _types["_input_types"]]
+    out_type = [{None: ""}.get(e, e) for e in _types["_output_types"]]
+    data_type = [{None: ""}.get(e, e) for e in _types["_data_types"]]
 
     row = [
         mod.__name__,

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -18,9 +18,32 @@ __all__ = ["align", "composable", "dist", "evo", "io", "sample", "translate", "t
 
 def _get_app_attr(name, obj, mod, is_composable):
     """returns app details for display"""
-    in_type = [{None: ""}.get(e, e) for e in getattr(obj, "_input_types", [])]
-    out_type = [{None: ""}.get(e, e) for e in getattr(obj, "_output_types", [])]
-    data_type = [{None: ""}.get(e, e) for e in getattr(obj, "_data_types", [])]
+    _input_types = getattr(obj, "_input_types", [])
+    _output_types = getattr(obj, "_output_types", [])
+    _data_types = getattr(obj, "_data_types", [])
+
+    if type(_input_types) == str:
+        _input_types = [_input_types]
+    if type(_output_types) == str:
+        _output_types = [_output_types]
+    if type(_data_types) == str:
+        _data_types = [_data_types]
+
+    if _input_types:
+        in_type = [{None: ""}.get(e, e) for e in _input_types]
+    else:
+        in_type = []
+
+    if _output_types:
+        out_type = [{None: ""}.get(e, e) for e in _output_types]
+    else:
+        out_type = []
+
+    if _data_types:
+        data_type = [{None: ""}.get(e, e) for e in _data_types]
+    else:
+        data_type = []
+
     row = [
         mod.__name__,
         name,
@@ -61,5 +84,5 @@ def available_apps():
     table = Table(header, rows)
     # todo the inputs/outputs/data type columns no longer being populated as
     # these attributes are instance attributes and not resolved at present
-    table = table.get_columns(["module", "name", "composable", "doc"])
+    table = table.get_columns(header)
     return table

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -53,6 +53,10 @@ class align_to_ref(ComposableSeq):
     """Aligns to a reference seq, no gaps in the reference.
     Returns an Alignment object."""
 
+    _input_types = SEQUENCE_TYPE
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = "SequenceCollection"
+
     def __init__(
         self,
         ref_seq="longest",
@@ -77,9 +81,9 @@ class align_to_ref(ComposableSeq):
             molecular type
         """
         super(align_to_ref, self).__init__(
-            input_types=SEQUENCE_TYPE,
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types="SequenceCollection",
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         assert moltype
@@ -145,6 +149,10 @@ class progressive_align(ComposableSeq):
     """Progressive multiple sequence alignment via any cogent3 model.
      Returns an Alignment object."""
 
+    _input_types = SEQUENCE_TYPE
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = "SequenceCollection"
+
     def __init__(
         self,
         model,
@@ -189,9 +197,9 @@ class progressive_align(ComposableSeq):
             sequences we recommend 'paralinear'.
         """
         super(progressive_align, self).__init__(
-            input_types=SEQUENCE_TYPE,
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types="SequenceCollection",
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
 
         self._param_vals = {

--- a/src/cogent3/app/dist.py
+++ b/src/cogent3/app/dist.py
@@ -30,11 +30,15 @@ class fast_slow_dist(ComposableDistance):
     numerically robust) approach where possible, slow (robust)
     approach when not. Returns a DistanceMatrix."""
 
+    _input_types = ALIGNED_TYPE
+    _output_types = (PAIRWISE_DISTANCE_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(self, distance=None, moltype=None, fast_calc=None, slow_calc=None):
         super(fast_slow_dist, self).__init__(
-            input_types=ALIGNED_TYPE,
-            output_types=(PAIRWISE_DISTANCE_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self._moltype = moltype if moltype is None else get_moltype(moltype)

--- a/src/cogent3/app/evo.py
+++ b/src/cogent3/app/evo.py
@@ -42,6 +42,10 @@ class model(ComposableModel):
     """Define a substitution model + tree for maximum likelihood evaluation.
     Returns model_result."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (RESULT_TYPE, MODEL_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(
         self,
         sm,
@@ -99,9 +103,9 @@ class model(ComposableModel):
         the result object has a separate entry for each.
         """
         super(model, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(RESULT_TYPE, MODEL_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._verbose = verbose
         self._formatted_params()
@@ -243,12 +247,16 @@ class hypothesis(ComposableHypothesis):
     """Specify a hypothesis through defining two models. Returns a
     hypothesis_result."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(self, null, *alternates, init_alt=None):
         # todo document! init_alt needs to be able to take null, alt and *args
         super(hypothesis, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self.null = null
@@ -303,11 +311,15 @@ class hypothesis(ComposableHypothesis):
 class bootstrap(ComposableHypothesis):
     """Parametric bootstrap for a provided hypothesis. Returns a bootstrap_result."""
 
+    _input_types = ALIGNED_TYPE
+    _output_types = (RESULT_TYPE, BOOTSTRAP_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(self, hyp, num_reps, parallel=False, verbose=False):
         super(bootstrap, self).__init__(
-            input_types=ALIGNED_TYPE,
-            output_types=(RESULT_TYPE, BOOTSTRAP_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self._hyp = hyp
@@ -352,11 +364,15 @@ class ancestral_states(ComposableTabular):
     """Computes ancestral state probabilities from a model result. Returns a dict
     with a DictArray for each node."""
 
+    _input_types = MODEL_RESULT_TYPE
+    _output_types = (RESULT_TYPE, TABULAR_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = "model_result"
+
     def __init__(self):
         super(ancestral_states, self).__init__(
-            input_types=MODEL_RESULT_TYPE,
-            output_types=(RESULT_TYPE, TABULAR_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types="model_result",
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self.func = self.recon_ancestor
@@ -379,11 +395,15 @@ class ancestral_states(ComposableTabular):
 class tabulate_stats(ComposableTabular):
     """Extracts all model statistics from model_result as Table."""
 
+    _input_types = MODEL_RESULT_TYPE
+    _output_types = (RESULT_TYPE, TABULAR_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = "model_result"
+
     def __init__(self):
         super(tabulate_stats, self).__init__(
-            input_types=MODEL_RESULT_TYPE,
-            output_types=(RESULT_TYPE, TABULAR_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types="model_result",
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self.func = self.extract_stats
@@ -411,6 +431,10 @@ class natsel_neutral(ComposableHypothesis):
     """Test of selective neutrality by assessing whether omega equals 1.
     Under the alternate, there is one omega for all branches and all sites.
     """
+
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
 
     def __init__(
         self,
@@ -454,9 +478,9 @@ class natsel_neutral(ComposableHypothesis):
             prints intermediate states to screen during fitting
         """
         super(natsel_neutral, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if not is_codon_model(sm):
@@ -515,6 +539,10 @@ class natsel_zhang(ComposableHypothesis):
     Note: Our implementation is not as parametrically succinct as that of
     Zhang et al, we have 1 additional bin probability.
     """
+
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
 
     def __init__(
         self,
@@ -583,9 +611,9 @@ class natsel_zhang(ComposableHypothesis):
         foreground edges.
         """
         super(natsel_zhang, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if not is_codon_model(sm):
@@ -718,6 +746,10 @@ class natsel_sitehet(ComposableHypothesis):
     omega < 1 and omega = 1. Under the alternate, an additional site-class of
     omega > 1 is added."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(
         self,
         sm,
@@ -763,9 +795,9 @@ class natsel_sitehet(ComposableHypothesis):
             prints intermediate states to screen during fitting
         """
         super(natsel_sitehet, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if not is_codon_model(sm):
@@ -876,6 +908,10 @@ class natsel_timehet(ComposableHypothesis):
     (or values) of omega.
     """
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(
         self,
         sm,
@@ -943,9 +979,9 @@ class natsel_timehet(ComposableHypothesis):
             prints intermediate states to screen during fitting
         """
         super(natsel_timehet, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(RESULT_TYPE, HYPOTHESIS_RESULT_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if not is_codon_model(sm):

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -150,6 +150,10 @@ class load_aligned(_seq_loader, ComposableAligned):
 
     klass = ArrayAlignment
 
+    _input_types = None
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("DataStoreMember", "str", "Path")
+
     def __init__(self, moltype=None, format="fasta"):
         """
         Parameters
@@ -160,9 +164,9 @@ class load_aligned(_seq_loader, ComposableAligned):
             sequence file format
         """
         super(ComposableAligned, self).__init__(
-            input_types=None,
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("DataStoreMember", "str", "Path"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         _seq_loader.__init__(self)
         self._formatted_params()
@@ -177,6 +181,10 @@ class load_unaligned(ComposableSeq, _seq_loader):
 
     klass = SequenceCollection
 
+    _input_types = None
+    _output_types = (SEQUENCE_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("DataStoreMember", "str", "Path")
+
     def __init__(self, moltype=None, format="fasta"):
         """
         Parameters
@@ -187,9 +195,9 @@ class load_unaligned(ComposableSeq, _seq_loader):
             sequence file format
         """
         super(ComposableSeq, self).__init__(
-            input_types=None,
-            output_types=(SEQUENCE_TYPE, SERIALISABLE_TYPE),
-            data_types=("DataStoreMember", "str", "Path"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         _seq_loader.__init__(self)
         self._formatted_params()
@@ -201,6 +209,10 @@ class load_unaligned(ComposableSeq, _seq_loader):
 
 class load_tabular(ComposableTabular):
     """Loads delimited data. Returns a Table."""
+
+    _input_types = None
+    _output_types = (TABULAR_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("DataStoreMember", "str", "Path")
 
     def __init__(
         self,
@@ -227,9 +239,9 @@ class load_tabular(ComposableTabular):
             all rows MUST have the same number of records
         """
         super(ComposableTabular, self).__init__(
-            input_types=None,
-            output_types=(TABULAR_TYPE, SERIALISABLE_TYPE),
-            data_types=("DataStoreMember", "str", "Path"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self._sep = sep
@@ -318,6 +330,10 @@ class load_tabular(ComposableTabular):
 class write_tabular(_checkpointable, ComposableTabular):
     """writes tabular data"""
 
+    _input_types = (TABULAR_RESULT_TYPE, TABULAR_TYPE)
+    _output_types = IDENTIFIER_TYPE
+    _data_types = ("Table", "DictArray", "DistanceMatrix")
+
     def __init__(
         self, data_path, format="tsv", name_callback=None, create=False, if_exists=SKIP
     ):
@@ -339,9 +355,9 @@ class write_tabular(_checkpointable, ComposableTabular):
             exception), 'overwrite'
         """
         super(write_tabular, self).__init__(
-            input_types=(TABULAR_RESULT_TYPE, TABULAR_TYPE),
-            output_types=IDENTIFIER_TYPE,
-            data_types=("Table", "DictArray", "DistanceMatrix"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
             data_path=data_path,
             name_callback=name_callback,
             create=create,
@@ -361,6 +377,10 @@ class write_tabular(_checkpointable, ComposableTabular):
 
 class write_seqs(_checkpointable):
     """Writes sequences to text files in standard format."""
+
+    _input_types = ("sequences", "aligned")
+    _output_types = ("sequences", "aligned", "identifier")
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
 
     def __init__(
         self,
@@ -391,9 +411,9 @@ class write_seqs(_checkpointable):
             exception), 'overwrite'
         """
         super(write_seqs, self).__init__(
-            input_types=("sequences", "aligned"),
-            output_types=("sequences", "aligned", "identifier"),
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
             data_path=data_path,
             name_callback=name_callback,
             create=create,
@@ -422,8 +442,13 @@ class load_json(Composable):
 
     _type = "output"
 
+    _input_types = None
+    _output_types = "serialisable"
+
     def __init__(self):
-        super(load_json, self).__init__(input_types=None, output_types="serialisable")
+        super(load_json, self).__init__(
+            input_types=self._input_types, output_types=self._output_types
+        )
         self.func = self.read
 
     def read(self, path):
@@ -451,12 +476,15 @@ class write_json(_checkpointable):
 
     _type = "output"
 
+    _input_types = "serialisable"
+    _output_types = ("identifier", "serialisable")
+
     def __init__(
         self, data_path, name_callback=None, create=False, if_exists=SKIP, suffix="json"
     ):
         super(write_json, self).__init__(
-            input_types="serialisable",
-            output_types=("identifier", "serialisable"),
+            input_types=self._input_types,
+            output_types=self._output_types,
             data_path=data_path,
             name_callback=name_callback,
             create=create,
@@ -492,8 +520,13 @@ class load_db(Composable):
 
     _type = "output"
 
+    _input_types = None
+    _output_types = "serialisable"
+
     def __init__(self):
-        super(load_db, self).__init__(input_types=None, output_types="serialisable")
+        super(load_db, self).__init__(
+            input_types=self._input_types, output_types=self._output_types
+        )
         self.func = self.read
 
     def read(self, identifier):
@@ -524,12 +557,15 @@ class write_db(_checkpointable):
 
     _type = "output"
 
+    _input_types = "serialisable"
+    _output_types = ("identifier", "serialisable")
+
     def __init__(
         self, data_path, name_callback=None, create=False, if_exists=SKIP, suffix="json"
     ):
         super(write_db, self).__init__(
-            input_types="serialisable",
-            output_types=("identifier", "serialisable"),
+            input_types=self._input_types,
+            output_types=self._output_types,
             data_path=data_path,
             name_callback=name_callback,
             create=create,

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -378,8 +378,8 @@ class write_tabular(_checkpointable, ComposableTabular):
 class write_seqs(_checkpointable):
     """Writes sequences to text files in standard format."""
 
-    _input_types = ("sequences", "aligned")
-    _output_types = ("sequences", "aligned", "identifier")
+    _input_types = (SEQUENCE_TYPE, ALIGNED_TYPE)
+    _output_types = (SEQUENCE_TYPE, ALIGNED_TYPE, IDENTIFIER_TYPE)
     _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
 
     def __init__(
@@ -443,7 +443,7 @@ class load_json(Composable):
     _type = "output"
 
     _input_types = None
-    _output_types = "serialisable"
+    _output_types = SERIALISABLE_TYPE
 
     def __init__(self):
         super(load_json, self).__init__(
@@ -476,8 +476,8 @@ class write_json(_checkpointable):
 
     _type = "output"
 
-    _input_types = "serialisable"
-    _output_types = ("identifier", "serialisable")
+    _input_types = SERIALISABLE_TYPE
+    _output_types = (IDENTIFIER_TYPE, SERIALISABLE_TYPE)
 
     def __init__(
         self, data_path, name_callback=None, create=False, if_exists=SKIP, suffix="json"
@@ -521,7 +521,7 @@ class load_db(Composable):
     _type = "output"
 
     _input_types = None
-    _output_types = "serialisable"
+    _output_types = SERIALISABLE_TYPE
 
     def __init__(self):
         super(load_db, self).__init__(
@@ -557,8 +557,8 @@ class write_db(_checkpointable):
 
     _type = "output"
 
-    _input_types = "serialisable"
-    _output_types = ("identifier", "serialisable")
+    _input_types = SERIALISABLE_TYPE
+    _output_types = (IDENTIFIER_TYPE, SERIALISABLE_TYPE)
 
     def __init__(
         self, data_path, name_callback=None, create=False, if_exists=SKIP, suffix="json"

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -99,6 +99,10 @@ class omit_degenerates(ComposableAligned):
     """Excludes alignment columns with degenerate conditions. Can accomodate
     reading frame. Returns modified Alignment."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(self, moltype=None, gap_is_degen=True, motif_length=1):
         """excludes degenerate characters from alignment
 
@@ -114,9 +118,9 @@ class omit_degenerates(ComposableAligned):
             is excluded
         """
         super(omit_degenerates, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if moltype:
@@ -148,6 +152,10 @@ class omit_gap_pos(ComposableAligned):
     """Excludes gapped alignment columns meeting a threshold. Can accomodate
     reading frame. Returns modified Alignment."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(self, allowed_frac=0.99, motif_length=1, moltype=None):
         """
         Parameters
@@ -161,9 +169,9 @@ class omit_gap_pos(ComposableAligned):
             molecular type, must be either DNA or RNA
         """
         super(omit_gap_pos, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if moltype:
@@ -194,6 +202,10 @@ class take_codon_positions(ComposableAligned):
     """Extracts the specified codon position(s) from an alignment. 
     Returns an Alignment."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(
         self,
         *positions,
@@ -217,9 +229,9 @@ class take_codon_positions(ComposableAligned):
             molecular type, must be either DNA or RNA
         """
         super(take_codon_positions, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         assert moltype is not None
@@ -287,6 +299,10 @@ class take_named_seqs(ComposableSeq):
     """Extracts (or everything but) named sequences. Returns a filtered
     sequences, alignment that satisified the condition, NotCompleted otherwise."""
 
+    _input_types = (SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
+
     def __init__(self, *names, negate=False):
         """selects named sequences from a collection
 
@@ -296,9 +312,9 @@ class take_named_seqs(ComposableSeq):
         in the collection.
         """
         super(take_named_seqs, self).__init__(
-            input_types=(SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self._names = names
@@ -319,6 +335,10 @@ class min_length(ComposableSeq):
     """Filters sequence collections / alignments by length. Returns the 
     data if it satisfies the condition, NotCompleted otherwise."""
 
+    _input_types = (SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
+
     def __init__(self, length, motif_length=1, subtract_degen=True, moltype=None):
         """
         Parameters
@@ -333,9 +353,9 @@ class min_length(ComposableSeq):
             molecular type, can be string or instance
         """
         super(min_length, self).__init__(
-            input_types=(SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if motif_length > 1:
@@ -394,6 +414,10 @@ class fixed_length(ComposableAligned):
     """Sample an alignment to a fixed length. Returns an Alignment of the 
     specified length, or NotCompleted if alignment too short."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(
         self, length, start=0, random=False, seed=None, motif_length=1, moltype=None
     ):
@@ -417,9 +441,9 @@ class fixed_length(ComposableAligned):
             molecular type, can be string or instance
         """
         super(fixed_length, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         diff = length % motif_length
@@ -490,6 +514,10 @@ class omit_bad_seqs(ComposableAligned):
     """Eliminates sequences from Alignment based on gap fraction, unique gaps.
     Returns modified alignment."""
 
+    _input_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment")
+
     def __init__(self, quantile=None, gap_fraction=1, moltype="dna"):
         """Returns an alignment without the sequences responsible for
         exceeding disallowed_frac.
@@ -508,9 +536,9 @@ class omit_bad_seqs(ComposableAligned):
             molecular type, can be string or instance
         """
         super(omit_bad_seqs, self).__init__(
-            input_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         if moltype:
@@ -538,6 +566,10 @@ class omit_duplicated(ComposableSeq):
     """Removes redundant sequences, recording dropped sequences in
     seqs.info.dropped. Returns sequence collection with only unique sequences."""
 
+    _input_types = (SEQUENCE_TYPE, SERIALISABLE_TYPE, ALIGNED_TYPE)
+    _output_types = (SEQUENCE_TYPE, SERIALISABLE_TYPE, ALIGNED_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
+
     def __init__(self, mask_degen=False, choose="longest", seed=None, moltype=None):
         """Returns unique sequences, adds 'dropped' key to seqs.info
 
@@ -555,9 +587,9 @@ class omit_duplicated(ComposableSeq):
             molecular type, can be string or instance
         """
         super(omit_duplicated, self).__init__(
-            input_types=(SEQUENCE_TYPE, SERIALISABLE_TYPE, ALIGNED_TYPE),
-            output_types=(SEQUENCE_TYPE, SERIALISABLE_TYPE, ALIGNED_TYPE),
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
 
         assert not choose or choose in "longestrandom"
@@ -617,6 +649,10 @@ class omit_duplicated(ComposableSeq):
 class trim_stop_codons(ComposableSeq):
     """Removes terminal stop codons. Returns sequences / alignment."""
 
+    _input_types = (SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _output_types = (SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
+
     def __init__(self, gc):
         """selects named sequences from a collection
 
@@ -626,9 +662,9 @@ class trim_stop_codons(ComposableSeq):
         in the collection.
         """
         super(trim_stop_codons, self).__init__(
-            input_types=(SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE),
-            output_types=(SEQUENCE_TYPE, ALIGNED_TYPE, SERIALISABLE_TYPE),
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self._gc = gc

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -157,6 +157,10 @@ class select_translatable(ComposableSeq):
     """Identifies most likely reading frame. Returns modified sequences / alignment,
     if it could be resolved, NotCompleted otherwise."""
 
+    _input_types = (SEQUENCE_TYPE, ALIGNED_TYPE)
+    _output_types = SEQUENCE_TYPE
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
+
     def __init__(
         self, moltype="dna", gc=DEFAULT, allow_rc=False, trim_terminal_stop=True
     ):
@@ -183,9 +187,9 @@ class select_translatable(ComposableSeq):
         are excluded.
         """
         super(select_translatable, self).__init__(
-            input_types=(SEQUENCE_TYPE, ALIGNED_TYPE),
-            output_types=SEQUENCE_TYPE,
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
 

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -243,6 +243,10 @@ class select_translatable(ComposableSeq):
 class translate_seqs(ComposableSeq):
     """Translates sequences, assumes in correct reading frame."""
 
+    _input_types = (SEQUENCE_TYPE, ALIGNED_TYPE)
+    _output_types = (SEQUENCE_TYPE, ALIGNED_TYPE)
+    _data_types = ("ArrayAlignment", "Alignment", "SequenceCollection")
+
     def __init__(
         self, moltype="dna", gc=DEFAULT, allow_rc=False, trim_terminal_stop=True
     ):
@@ -263,9 +267,9 @@ class translate_seqs(ComposableSeq):
         are excluded.
         """
         super(translate_seqs, self).__init__(
-            input_types=(SEQUENCE_TYPE, ALIGNED_TYPE),
-            output_types=(SEQUENCE_TYPE, ALIGNED_TYPE),
-            data_types=("ArrayAlignment", "Alignment", "SequenceCollection"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
 

--- a/src/cogent3/app/tree.py
+++ b/src/cogent3/app/tree.py
@@ -23,11 +23,15 @@ class scale_branches(ComposableTree):
     """Transforms tree branch lengths from nucleotide to codon, or the converse.
     Returns a Tree."""
 
+    _input_types = TREE_TYPE
+    _output_types = (TREE_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("PhyloNode", "TreeNode")
+
     def __init__(self, nuc_to_codon=None, codon_to_nuc=None, scalar=1, min_length=1e-6):
         super(scale_branches, self).__init__(
-            input_types=TREE_TYPE,
-            output_types=(TREE_TYPE, SERIALISABLE_TYPE),
-            data_types=("PhyloNode", "TreeNode"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         """returns a new tree with lengths divided by scalar
     
@@ -74,11 +78,15 @@ class scale_branches(ComposableTree):
 class uniformize_tree(ComposableTree):
     """Standardises the orientation of unrooted trees. Returns a Tree."""
 
+    _input_types = TREE_TYPE
+    _output_types = (TREE_TYPE, SERIALISABLE_TYPE)
+    _data_types = ("PhyloNode", "TreeNode")
+
     def __init__(self, root_at="midpoint", ordered_names=None):
         super(uniformize_tree, self).__init__(
-            input_types=TREE_TYPE,
-            output_types=(TREE_TYPE, SERIALISABLE_TYPE),
-            data_types=("PhyloNode", "TreeNode"),
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         """returns a new tree with standardised orientation
         
@@ -110,6 +118,10 @@ class uniformize_tree(ComposableTree):
 class quick_tree(ComposableTree):
     """Neighbour Joining tree based on pairwise distances."""
 
+    _input_types = PAIRWISE_DISTANCE_TYPE
+    _output_types = (TREE_TYPE, SERIALISABLE_TYPE)
+    _data_types = "DistanceMatrix"
+
     def __init__(self, drop_invalid=False):
         """computes a neighbour joining tree from an alignment
 
@@ -122,9 +134,9 @@ class quick_tree(ComposableTree):
             if False, an ArithmeticError is raised if a distance could not be computed on observed data.
         """
         super(quick_tree, self).__init__(
-            input_types=PAIRWISE_DISTANCE_TYPE,
-            output_types=(TREE_TYPE, SERIALISABLE_TYPE),
-            data_types="DistanceMatrix",
+            input_types=self._input_types,
+            output_types=self._output_types,
+            data_types=self._data_types,
         )
         self._formatted_params()
         self.func = self.quick_tree


### PR DESCRIPTION
Hi Gavin! 

I found this ticket was very related to the tasks I did before, so I implemented some codes to fix it, hope you don't mind, feel free to leave comments there, I will fix it as soon as possible! Many thanks for your teaching! 

Basically, I implemented a very simple pattern to composable apps to make available_apps be able to display input/output/data types. 

By the way, I was also thinking to put this block of codes
`
super(compassable_app_here, self).__init__(
            input_types=self._input_types,
            output_types=self._output_types,
            data_types=self._data_types,
        )
`
into its parent class, but this approach worked not very well, to avoid breaking current structure. I finally adopted the simplest modification. Hope you can have a look! 

Thanks Gavin!