### PR TITLE
BUG: setting max_workers for MPI now uses UNIVERSE_SIZE

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -688,4 +688,3 @@ class user_function(Composable):
 
     def __repr__(self):
         return str(self)
-

--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -141,8 +141,14 @@ def imap(f, s, max_workers=None, use_mpi=False, if_serial="raise", chunksize=Non
         elif COMM.Get_attr(MPI.UNIVERSE_SIZE) == 1 and if_serial == "warn":
             warnings.warn(UserWarning, msg=err_msg)
 
-        if not max_workers:
-            max_workers = COMM.Get_attr(MPI.UNIVERSE_SIZE) - 1
+        max_workers = max_workers or 0
+
+        if max_workers > COMM.Get_attr(MPI.UNIVERSE_SIZE):
+            warnings.warn(
+                UserWarning, msg="max_workers too large, reducing to UNIVERSE_SIZE-1"
+            )
+
+        max_workers = min(max_workers, COMM.Get_attr(MPI.UNIVERSE_SIZE) - 1)
 
         if not chunksize:
             chunksize = set_default_chunksize(s, max_workers)


### PR DESCRIPTION
[FIXED] some systems indicate CPUs as the number of hyperthreads,
    but mpi4py counts CPU cores. We now force max_workers to
    be the minimum of UNIVERSE_SIZE - 1, or the user specified
    value.