### PR TITLE
ENH: moltype to_regex raises exception if input seq not valid

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -744,6 +744,9 @@ class MolType(object):
 
     def to_regex(self, seq):
         """returns a regex pattern with ambiguities expanded to a character set"""
+        if not self.is_valid(seq):
+            raise ValueError(f"'{seq}' is invalid for this moltype")
+
         degen_indices = self.get_degenerate_positions(sequence=seq, include_gap=False)
         seq = list(seq)  # seq can now be modified
         for index in degen_indices:

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1070,14 +1070,21 @@ class Sequence(_Annotatable, SequenceI):
         -------
         Returns a list of Annotation instances.
         """
-        pattern = self.moltype.to_regex(seq=pattern)
+        try:
+            pattern = self.moltype.to_regex(seq=pattern)
+        except ValueError:
+            # assume already a regex
+            pass
+
         pos = [m.span() for m in re.finditer(pattern, self._seq)]
         if not pos:
             return []
 
         num_match = len(pos) if allow_multiple else 1
         annot = [
-            self.add_feature(annot_type, f"{name}:{i}", [pos[i]])
+            self.add_feature(
+                annot_type, f"{name}:{i}" if allow_multiple else name, [pos[i]]
+            )
             for i in range(num_match)
         ]
 

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -2616,6 +2616,8 @@ class AlignmentTests(AlignmentBaseTests, TestCase):
 
     def test_annotate_matches_to(self):
         """Aligned.annotate_matches_to correctly delegates to sequence"""
+        from cogent3 import get_code
+
         aln = Alignment(dict(x="TTCCACTTCCGCTT"), moltype="dna")
         seq = aln.named_seqs["x"]
         pattern = "CCRC"
@@ -2630,6 +2632,16 @@ class AlignmentTests(AlignmentBaseTests, TestCase):
         )
         got = [a.get_slice() for a in annot]
         self.assertEqual(got, matches[:1])
+
+        # handles regex from aa
+        aln = Alignment(dict(x="TTCCACTTCCGCTT"), moltype="dna")
+        gc = get_code(1)
+        aa_regex = gc.to_regex("FHF")
+        s = aln.named_seqs["x"].annotate_matches_to(
+            aa_regex, "domain", "test", allow_multiple=False
+        )
+        a = list(aln.get_annotations_from_seq("x"))[0]
+        self.assertEqual(str(aln[a].named_seqs["x"]), "TTCCACTTC")
 
     def test_deepcopy(self):
         """correctly deep copy aligned objects in an alignment"""

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -258,9 +258,13 @@ class MolTypeTests(TestCase):
     """Tests of the MolType class. Should support same API as old Alphabet."""
 
     def test_to_regex(self):
+        """returns a valid regex"""
         seq = "ACYGR"
         regular_expression = DNA.to_regex(seq=seq)
         self.assertEqual(regular_expression, "AC[CT]G[AG]")
+        # raises an exception if a string is already a regex, or invalid
+        with self.assertRaises(ValueError):
+            DNA.to_regex("(?:GAT|GAC)(?:GGT|GGC|GGA|GGG)(?:GAT|GAC)(?:CAA|CAG)")
 
     def test_pickling(self):
         pkl = pickle.dumps(DNA)


### PR DESCRIPTION
[FIXED] this allows improved handling of input that is already a regex