### PR TITLE
BUG: new Map.zeroed() method and usage, fixes #487

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1734,9 +1734,9 @@ class _SequenceCollectionBase:
 
         # Deep copying Aligned instance to ensure only region specified by Aligned.map is displayed.
         if isinstance(seq1, Aligned):
-            seq1 = seq1.deepcopy()
+            seq1 = seq1.deepcopy(sliced=True)
         if isinstance(seq2, Aligned):
-            seq2 = seq2.deepcopy()
+            seq2 = seq2.deepcopy(sliced=True)
 
         if seq1.is_annotated() or seq2.is_annotated():
             annotated = True
@@ -2056,7 +2056,11 @@ class Aligned(object):
         if sliced:
             span = self.map.get_covering_span()
             new_seq = new_seq[span.start : span.end]
-        return self.__class__(self.map, new_seq)
+            new_map = self.map.zeroed()
+        else:
+            new_map = self.map
+
+        return self.__class__(new_map, new_seq)
 
     def __repr__(self):
         return "%s of %s" % (repr(self.map), repr(self.data))

--- a/src/cogent3/core/location.py
+++ b/src/cogent3/core/location.py
@@ -804,6 +804,32 @@ class Map(object):
         data["version"] = __version__
         return data
 
+    def zeroed(self):
+        """returns a new instance with the first span starting at 0
+
+        Note
+        ----
+
+        Useful when an Annotatable object is sliced, but the connection to
+        the original parent is being deliberately broken as in the
+        Sequence.deepcopy(sliced=True) case.
+        """
+        # todo there's probably a more efficient way to do this
+        # create the new instance
+        from cogent3.util.deserialise import deserialise_map_spans
+
+        data = self.to_rich_dict()
+        zeroed = deserialise_map_spans(data)
+        zeroed.parent_length = len(self)
+        min_val = min(zeroed.start, zeroed.end)
+        for span in zeroed.spans:
+            if span.lost:
+                continue
+            span.start -= min_val
+            span.end -= min_val
+
+        return zeroed
+
 
 class SpansOnly(ConstrainedList):
     """List that converts elements to Spans on addition."""


### PR DESCRIPTION
[NEW] zeroed() method returns a new instance with the start at 0
[CHANGED] Sequence.deepcopy(sliced=True) now uses the zeroed method