### PR TITLE
Explored SyntaxWarnings associated to using py38

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -1225,7 +1225,7 @@ class TreeNode(object):
                         for (n, v) in list(self.params.items())
                         if v is not None
                         and child.params.get(n) is not None
-                        and n is not "length"
+                        and n != "length"
                     ]
                     length = self.length + child.length
                     if length:

--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -52,7 +52,7 @@ def get_rank():
         rank = COMM.Get_rank()
     else:
         process_name = multiprocessing.current_process().name
-        if process_name is not "MainProcess":
+        if process_name != "MainProcess":
             rank = int(process_name.split("-")[-1])
     return rank
 

--- a/tests/test_maths/test_stats/test_jackknife.py
+++ b/tests/test_maths/test_stats/test_jackknife.py
@@ -21,7 +21,7 @@ def pmcc(data, axis=1):
     is two dimensional: [[Y1], [Y2]] (trying to determine the correlation
     coefficient between data sets Y1 and Y2"""
 
-    if axis is 0:
+    if axis == 0:
         data = data.transpose()
         axis = 1
 
@@ -96,7 +96,7 @@ class JackknifeTests(TestCase):
         test_knife = JackknifeStats(data.shape[1], pmcc_stat)
         self.assertFloatEqual(test_knife.JackknifedStat, 1.2905845)
         self.assertFloatEqual(test_knife.Exception, 0.2884490)
-        self.assertTrue(test_knife._jackknifed_stat is not None)
+        self.assertTrue(test_knife._jackknifed_stat != None)
 
         # Vector
         mean_stat = stat_maker(mean, data, 1)


### PR DESCRIPTION
The python syntax warning
`SyntaxWarning: "is not" with a literal. Did you mean "!="?`
arises because 'is not' and 'is' are used to check whether two objects are exactly the same (their id and values are equal). The instances where these expressions are used in cogent have been replaced by '!=' and '==' to make the correct comparison.