### PR TITLE
TST: tweak the atol values for evaluating jsd/jsm cases that produce 0, #534

### DIFF
--- a/tests/test_maths/test_measure.py
+++ b/tests/test_maths/test_measure.py
@@ -1,6 +1,6 @@
 from unittest import TestCase, main
 
-from numpy import diag_indices, dot
+from numpy import diag_indices, dot, finfo, float64
 from numpy.random import random
 from numpy.testing import assert_allclose
 
@@ -111,6 +111,11 @@ class ParalinearTest(TestCase):
 
 
 class TestJensenShannon(TestCase):
+    # the following value is 4x machine precision, used to handle
+    # architectures that have lower precision and do not produce 0.0 from
+    # numerical calcs involved in jsd/jsm
+    atol = 4 * finfo(float64).eps
+
     def test_jsd_validation(self):
         """jsd fails with malformed data"""
         freqs1 = random(5)
@@ -164,7 +169,8 @@ class TestJensenShannon(TestCase):
             jsd(normalised_freqs1, freqs2, validate=True)  # invalid freqs2
 
     def test_jsd(self):
-        """case1 is testing if the jsd between two identical distributions is 0.0"""
+        """evaluate jsd between identical, and non-identical distributions"""
+        # case1 is testing if the jsd between two identical distributions is 0.0
         case1 = [
             [0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0],
@@ -176,6 +182,7 @@ class TestJensenShannon(TestCase):
                 jsd(case1[0], case1[1], validate=True),
                 0.0,
                 err_msg="Testing case1 for jsd failed",
+                atol=self.atol,
             )
             case1[0][index] = 0.0
             case1[1][index] = 0.0
@@ -185,6 +192,7 @@ class TestJensenShannon(TestCase):
             jsd(case2[0], case2[1], validate=True),
             0.7655022032053593,
             err_msg="Testing case2 for jsd failed",
+            atol=self.atol,
         )
         # case3 is testing the numerical output of jsd between two distant distributions
         case3 = [[1.0, 0.0], [1 / 2, 1 / 2]]
@@ -192,6 +200,7 @@ class TestJensenShannon(TestCase):
             jsd(case3[0], case3[1], validate=True),
             0.3112781244591328,
             err_msg="Testing case3 for jsd failed",
+            atol=self.atol,
         )
         # case4 - the jsd between two identical uniform distributions is 0.0
         case4 = [
@@ -202,10 +211,11 @@ class TestJensenShannon(TestCase):
             jsd(case4[0], case4[1], validate=True),
             0.0,
             err_msg="Testing case4 for jsd failed",
+            atol=self.atol,
         )
 
     def test_jsm(self):
-        """case1 is testing if the jsm between two identical distributions is 0.0"""
+        """evaluate jsm between identical, and non-identical distributions"""
         case1 = [
             [0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0],
@@ -217,6 +227,7 @@ class TestJensenShannon(TestCase):
                 jsm(case1[0], case1[1], validate=True),
                 0.0,
                 err_msg="Testing case1 for jsm failed",
+                atol=self.atol,
             )
             case1[0][index] = 0.0
             case1[1][index] = 0.0
@@ -226,6 +237,7 @@ class TestJensenShannon(TestCase):
             jsm(case2[0], case2[1], validate=True),
             0.8749298275892526,
             err_msg="Testing case2 for jsm failed",
+            atol=self.atol,
         )
         # case3 is testing the numerical output of jsm between two random distributions
         case3 = [[1.0, 0.0], [1 / 2, 1 / 2]]
@@ -233,6 +245,7 @@ class TestJensenShannon(TestCase):
             jsm(case3[0], case3[1], validate=True),
             0.5579230452841438,
             err_msg="Testing case3 for jsm failed",
+            atol=self.atol,
         )
         # case4 is testing if the jsm between two identical uniform distributions is 0.0
         case4 = [
@@ -243,6 +256,7 @@ class TestJensenShannon(TestCase):
             jsm(case4[0], case4[1], validate=True),
             0.0,
             err_msg="Testing case4 for jsm failed",
+            atol=self.atol,
         )
 
 


### PR DESCRIPTION
[CHANGED] the i386, armel CPUs have lower floating point precision. I've increased
    the asbolute tolerance in the testing (for these functions only) to 4x machine
    precision. This "may" fix the reported issue.