### PR TITLE
ENH: DistanceMatrix.to_table()

### DIFF
--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -739,6 +739,18 @@ class DistanceMatrix(DictArray):
     def names(self):
         return self.template.names[0]
 
+    def to_table(self):
+        """converted to a Table"""
+        from cogent3.util.table import Table
+
+        data = {"names": self.names}
+        for i, name in enumerate(self.names):
+            column = self.array[:, i]
+            data[name] = column
+        header = ["names"] + list(self.names)
+        table = Table(header=header, data=data, row_ids="names")
+        return table
+
     def to_dict(self, **kwargs):
         """Returns a flattened dict with diagonal elements removed"""
         result = super(DistanceMatrix, self).to_dict(flatten=True)

--- a/tests/test_evolve/test_distance.py
+++ b/tests/test_evolve/test_distance.py
@@ -915,6 +915,23 @@ class DistancesTests(TestCase):
         d = EstimateDistances(al, submodel=HKY85())
         self.assertEqual(d.get_pairwise_distances(), None)
 
+    def test_to_table(self):
+        """converts a distance matrix to a Table"""
+        data = {
+            ("A", "B"): 2,
+            ("A", "C"): 3,
+            ("B", "C"): 1,
+            ("B", "A"): 2,
+            ("C", "A"): 3,
+            ("C", "B"): 1,
+        }
+        darr = DistanceMatrix(data)
+        table = darr.to_table()
+        self.assertEqual(table.shape, (3, 4))
+        self.assertEqual(table.columns["names"].tolist(), list(darr.names))
+        self.assertEqual(table["A", "B"], 2)
+        self.assertEqual(table["A", "A"], 0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
[NEW] returns table with a "names" column that also acts as a row
    index. Thus you can index by named pairs, e.g. table["A", "B"]