### PR TITLE
API: significant change to identifiability checks on model_result object

### DIFF
--- a/src/cogent3/app/result.py
+++ b/src/cogent3/app/result.py
@@ -285,7 +285,7 @@ class model_result(generic_result):
                     d = v.get("DLC")
                 else:
                     d = v.all_psubs_DLC()
-                DLC.append(d)
+                DLC.append(d != False)
 
             self._DLC = all(DLC)
 
@@ -304,7 +304,7 @@ class model_result(generic_result):
                     except (NotImplementedError, KeyError):
                         # KeyError happens on discrete time model
                         u = None  # non-primary root issue
-                unique.append(u)
+                unique.append(u != False)
 
             self._unique_Q = all(unique)
 


### PR DESCRIPTION
[CHANGED] at least one of the identifiability conditions for non-stationary
    continuous-time models is numerically difficult to assess, i.e. unique_Q is
    incompletely checked. We defaulted to None in those cases. The unique_Q and DLC
    attributes of the model_result object will return True unless the checking
    algorithms successfully complete. This is a permissive setting!