### PR TITLE
API: rename Table row_ids arg to index

### DIFF
--- a/doc/examples/handling_tabular_data.rst
+++ b/doc/examples/handling_tabular_data.rst
@@ -195,7 +195,7 @@ Tables may also be created from 2-dimensional dictionaries. In this case, specia
     >>> d2D['edge.name'] = dict(zip(row_order, row_order))
     >>> t3 = Table(['edge.name', 'edge.parent', 'length', 'x', 'y', 'z'], d2D,
     ...            row_order=row_order, missing_data='*', space=8,
-    ...            max_width=50, row_ids='edge.name', title='My title',
+    ...            max_width=50, index='edge.name', title='My title',
     ...            legend='legend: this is a nonsense example.')
     >>> print(t3)
     My title
@@ -239,7 +239,7 @@ Tables may also be created from 2-dimensional dictionaries. In this case, specia
     <BLANKLINE>
     legend: this is a nonsense example.
 
-In the above we specify a maximum width of the table, and also specify row identifiers (using ``row_ids``, the name to use as row identifiers). This has the effect of forcing the table to wrap when the simple text format is used, but wrapping does not occur for any other format. The ``row_ids`` is a column containing data for slicing the table by row, and as identifiers are presented in each wrapped sub-table.
+In the above we specify a maximum width of the table, and also specify row identifiers (using ``index``, the name to use as row identifiers). This has the effect of forcing the table to wrap when the simple text format is used, but wrapping does not occur for any other format. The ``index`` is a column containing data for slicing the table by row, and as identifiers are presented in each wrapped sub-table.
 
 Wrapping generates neat looking tables whether or not you index the table rows. We demonstrate here
 
@@ -264,7 +264,7 @@ Wrapping generates neat looking tables whether or not you index the table rows. 
     ------
     <BLANKLINE>
     >>> wrap_table = make_table(header=h, data=rows, max_width=30,
-    ...  row_ids="A/C")
+    ...  index="A/C")
     >>> print(wrap_table)
     ==========================
        A/C       A/G       A/T
@@ -642,7 +642,7 @@ Test the writing of phylip distance matrix format.
     ...  0.088337278874079342, '', 0.44084000179090932], ['e',
     ...  0.44084000179091454, 0.44083999937417828, 0.44084000179090932, '']]
     >>> header = ['seq1/2', 'a', 'c', 'b', 'e']
-    >>> dist = Table(header=header, data=rows, row_ids='seq1/2')
+    >>> dist = Table(header=header, data=rows, index='seq1/2')
     >>> print(dist.to_string(format='phylip'))
        4
     a           0.0000  0.0883  0.1885  0.4408
@@ -759,7 +759,7 @@ Saving a table object to file for later reloading can be done using the standard
 
     >>> t3 = Table(['edge.name', 'edge.parent', 'length', 'x', 'y', 'z'], d2D,
     ...            row_order=row_order, missing_data='*', space=8,
-    ...            max_width=50, row_ids='edge.name', title='My title',
+    ...            max_width=50, index='edge.name', title='My title',
     ...            legend='legend: this is a nonsense example.')
     >>> t3.write("t3.pickle")
     >>> t3_loaded = load_table("t3.pickle")
@@ -1099,12 +1099,12 @@ We can likewise specify a writer, using a custom field formatter and provide thi
 Table slicing and iteration
 ---------------------------
 
-The Table class is capable of slicing by row, range of rows, column or range of columns headings or used to identify a single cell. Slicing using the method ``get_columns`` can also be used to reorder columns. In the case of columns, either the string headings or their position integers can be used. For rows, if ``row_ids`` was specified, the cell values in that column can also be used.
+The Table class is capable of slicing by row, range of rows, column or range of columns headings or used to identify a single cell. Slicing using the method ``get_columns`` can also be used to reorder columns. In the case of columns, either the string headings or their position integers can be used. For rows, if ``index`` was specified, the cell values in that column can also be used.
 
 .. doctest::
 
     >>> t4 = Table(['edge.name', 'edge.parent', 'length', 'x', 'y', 'z'], d2D,
-    ...            row_order=row_order, row_ids='edge.name', title='My title')
+    ...            row_order=row_order, index='edge.name', title='My title')
 
 We subset ``t4`` by column and reorder them.
 

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -299,7 +299,7 @@ def make_table(
     space=4,
     title="",
     max_width=1e100,
-    row_ids=None,
+    index=None,
     legend="",
     missing_data="",
     column_templates=None,
@@ -328,7 +328,7 @@ def make_table(
         as implied
     max_width
         maximum column width for printing
-    row_ids
+    index
         if True, the 0'th column is used as row identifiers and keys
         for slicing.
     legend
@@ -367,7 +367,7 @@ def make_table(
         space=space,
         missing_data=missing_data,
         max_width=max_width,
-        row_ids=row_ids,
+        index=index,
         legend=legend,
         data_frame=data_frame,
         format=format,
@@ -385,7 +385,7 @@ def load_table(
     title="",
     missing_data="",
     max_width=1e100,
-    row_ids=None,
+    index=None,
     legend="",
     column_templates=None,
     dtype=None,
@@ -429,7 +429,7 @@ def load_table(
         character assigned if a row has no entry for a column
     max_width
         maximum column width for printing
-    row_ids
+    index
         if True, the 0'th column is used as row identifiers and keys
         for slicing.
     legend
@@ -501,7 +501,7 @@ def load_table(
         space=space,
         missing_data=missing_data,
         max_width=max_width,
-        row_ids=row_ids,
+        index=index,
         legend=legend,
         format=format,
     )

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -484,7 +484,7 @@ def available_codes():
     table = Table(
         header=header,
         rows=rows,
-        row_ids="Code ID",
+        index="Code ID",
         title="Specify a genetic code using either 'Name' or "
         "Code ID (as an integer or string)",
     )

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1507,6 +1507,6 @@ def available_moltypes():
     header = ["Abbreviation", "Number of states", "Moltype"]
     title = "Specify a moltype by the string 'Abbreviation' (case insensitive)."
 
-    result = Table(header=header, data=rows, title=title, row_ids="Abbreviation")
+    result = Table(header=header, data=rows, title=title, index="Abbreviation")
     result = result.sorted(columns=["Number of states", "Abbreviation"])
     return result

--- a/src/cogent3/evolve/distance.py
+++ b/src/cogent3/evolve/distance.py
@@ -346,7 +346,7 @@ class EstimateDistances(object):
         T = table.Table(
             [r"Seq1 \ Seq2"] + self._seqnames,
             twoD,
-            row_ids=r"Seq1 \ Seq2",
+            index=r"Seq1 \ Seq2",
             missing_data="*",
         )
         return T

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -303,7 +303,7 @@ def _make_stat_table(stats, names, **kwargs):
         rows[i].insert(0, names[i])
 
     table = Table(
-        header=header, data=rows, row_ids=r"Seq1 \ Seq2", missing_data="*", **kwargs
+        header=header, data=rows, index=r"Seq1 \ Seq2", missing_data="*", **kwargs
     )
     return table
 
@@ -702,7 +702,7 @@ def available_distances():
             "Specify a pairwise genetic distance calculator "
             "using 'Abbreviation' (case insensitive)."
         ),
-        row_ids="Abbreviation",
+        index="Abbreviation",
     )
     return table
 
@@ -742,7 +742,7 @@ class DistanceMatrix(DictArray):
             column = self.array[:, i]
             data[name] = column
         header = ["names"] + list(self.names)
-        table = Table(header=header, data=data, row_ids="names")
+        table = Table(header=header, data=data, index="names")
         return table
 
     def to_dict(self, **kwargs):

--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -827,16 +827,14 @@ class LikelihoodFunction(ParameterController):
                     list_table.append(row)
             if table_dims:
                 title = ["", "%s params" % " ".join(table_dims)][with_titles]
-                # row_ids = True
             else:
-                # row_ids = False
                 title = ["", "global params"][with_titles]
             row_ids = None
             stat_table = table.Table(
                 heading_names,
                 list_table,
                 max_width=80,
-                row_ids=row_ids,
+                index=row_ids,
                 title=title,
                 **self._format,
             )

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -123,7 +123,7 @@ class _LikelihoodTreeEdge(object):
             rows = list(zip(motifs, observed, expected))
             rows.sort(key=lambda row: (-row[1], row[0]))
             table = Table(
-                header=["Pattern", "Observed", "Expected"], data=rows, row_ids="Pattern"
+                header=["Pattern", "Observed", "Expected"], data=rows, index="Pattern"
             )
             return (G, table)
         else:

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -787,7 +787,7 @@ class Parametric(_ContinuousSubstitutionModel):
             data=rows,
             max_width=max_width,
             title=title,
-            row_ids=r"From\To",
+            index=r"From\To",
         )
         result = t if return_table else t.to_string(center=True)
         return result

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -367,7 +367,7 @@ class DictArrayTemplate(object):
         else:
             return "%s dimensional %s" % (len(self.names), type(self).__name__)
 
-        t = Table(heading, data=a, digits=3, row_ids=heading[0], max_width=80)
+        t = Table(heading, data=a, digits=3, index=heading[0], max_width=80)
         return t._repr_html_(include_shape=False)
 
 

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -375,7 +375,7 @@ class TableDrawablesTest(BaseDrawablesTests):
 
     def test_to_plotly(self):
         """exercise producing a plotly table"""
-        table = make_table(header=["a", "b"], data=[[0, 1]], row_ids="a")
+        table = make_table(header=["a", "b"], data=[[0, 1]], index="a")
         drawable = table.to_plotly()
         self.assertIsInstance(drawable, Drawable)
         self._check_drawable_attrs(drawable.figure, "table")


### PR DESCRIPTION
[CHANGED] both load_table and make_table now have argument
    index=<column name>. Old arg still supported, but deprecation
    warning added.