### PR TITLE
BUG: Table operations handle cell values that are python objects

### DIFF
--- a/src/cogent3/format/table.py
+++ b/src/cogent3/format/table.py
@@ -676,13 +676,12 @@ def formatted_cells(
 
     """
     if not header:
-        num_col = max([len(row) for row in rows])
+        num_col = max(len(row) for row in rows)
         header = [""] * num_col
     else:
         num_col = len(header)
 
     col_widths = [len(col) for col in header]
-    num_row = len(rows)
     column_templates = column_templates or {}
 
     float_template = "{0:.%df}" % digits
@@ -697,7 +696,8 @@ def formatted_cells(
             except IndexError:
                 entry = "%s" % missing_data
             else:
-                if not entry:
+                not_missing = True if isinstance(entry, numpy.ndarray) else entry
+                if not not_missing:
                     try:
                         float(entry)  # could numerically be 0, so not missing
                     except (ValueError, TypeError):

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -1156,12 +1156,32 @@ class TableTests(TestCase):
 
     def test_repr_html_(self):
         """should produce html"""
-        # without an index
+        # no index
         t = Table(header=self.t8_header, data=self.t8_rows)
-        html = t._repr_html_()
-        # without an index
+        _ = t._repr_html_()
+        # with an index
         t = Table(header=self.t8_header, data=self.t8_rows, index="edge.name")
-        html = t._repr_html_()
+        _ = t._repr_html_()
+
+        # data has tuples in an array
+        data = dict(
+            key=numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
+            count=[1, 3, 2],
+        )
+        t = Table(data=data)
+        _ = t._repr_html_()
+
+    def test_array(self):
+        """should produce array"""
+        # data has tuples in an array
+        data = dict(
+            key=numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
+            count=[1, 3, 2],
+        )
+        expect = [list(v) for v in zip(data["key"][:], data["count"])]
+        t = Table(data=data)
+        arr = t.array
+        assert_equal(arr.tolist(), expect)
 
     def test_separator_format(self):
         """testing separator_format with title and legend, and contents that match the separator"""


### PR DESCRIPTION
[FIXED] table.array would fail if a column had tuples or lists as elements

[FIXED] table.format_cells now handles array elements