### PR TITLE
dendrogram.py improvements, fixes #559 and #560

### DIFF
--- a/src/cogent3/draw/dendrogram.py
+++ b/src/cogent3/draw/dendrogram.py
@@ -839,6 +839,8 @@ class Dendrogram(Drawable):
         if type(edges) == str:
             edges = [edges]
         edges = frozenset(edges)
+        if not edges.issubset(set([edge.name for edge in self.tree.preorder()])):
+            raise ValueError("edge not present in tree")
         style = UnionDict(width=self._line_width, color=self._line_color)
         style.update(line)
         self._edge_sets[edges] = UnionDict(legendgroup=legendgroup, line=style)

--- a/src/cogent3/draw/dendrogram.py
+++ b/src/cogent3/draw/dendrogram.py
@@ -671,8 +671,8 @@ class Dendrogram(Drawable):
             y = self.tree.max_y
 
         scale = 0.1 * self.tree.max_x
-        if scale < 1e-4:
-            text = "{:.2e}".format(scale)
+        if scale < 1e-2:
+            text = "{:.1e}".format(scale)
         else:
             text = "{:.2f}".format(scale)
 

--- a/tests/test_draw/test_dendrogram.py
+++ b/tests/test_draw/test_dendrogram.py
@@ -159,6 +159,14 @@ class TestDendro(TestCase):
                 style,
             )
 
+    def test_style_edges(self):
+        """test style_edges only accepts edges present in tree"""
+        tree = make_tree(treestring="(a,b,(c,(d,e)e1)e2)")
+        dnd = Dendrogram(tree=tree)
+        dnd.style_edges("a", line=dict(color="magenta"))
+        with self.assertRaises(ValueError):
+            dnd.style_edges("foo", line=dict(color="magenta"))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
style_edges check if edges are present in tree.

lowered cut-off for scale_bar to be in scientific notation.