### PR TITLE
Bug fixes and other changes

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -233,6 +233,11 @@ def load_unaligned_seqs(
     if file_format == "json":
         return load_from_json(filename, (SequenceCollection,))
 
+    format = format or file_format
+    if not format:
+        msg = "could not determined file format, set using the format argument"
+        raise ValueError(msg)
+
     parser_kw = parser_kw or {}
     for other_kw in ("constructor_kw", "kw"):
         other_kw = kw.pop(other_kw, None) or {}
@@ -283,6 +288,11 @@ def load_aligned_seqs(
     file_format, _ = get_format_suffixes(filename)
     if file_format == "json":
         return load_from_json(filename, (Alignment, ArrayAlignment))
+
+    format = format or file_format
+    if not format:
+        msg = "could not determined file format, set using the format argument"
+        raise ValueError(msg)
 
     parser_kw = parser_kw or {}
     for other_kw in ("constructor_kw", "kw"):

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -197,6 +197,7 @@ class GeneticCode:
     blocks = property(_get_blocks)
 
     def to_table(self):
+        """returns aa to codon mapping as a cogent3 Table"""
         from cogent3.core.moltype import IUPAC_PROTEIN_code_aa
 
         rows = []
@@ -205,8 +206,7 @@ class GeneticCode:
             codons = ",".join(self[code])
             row = [aa, code, codons]
             rows.append(row)
-        t = Table(header=headers, data=rows, title=self.name)
-        return t
+        return Table(header=headers, data=rows, title=self.name)
 
     def __str__(self):
         """Returns code_sequence that constructs the GeneticCode."""

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -243,15 +243,19 @@ class GeneticCode:
             raise InvalidCodonError("Codon or aa %s has wrong length" % item)
 
     def translate(self, dna, start=0):
-        """ Translates DNA to protein with current GeneticCode.
+        """Translates DNA to protein with current GeneticCode.
 
-        dna         = a string of nucleotides
-        start       = position to begin translation (used to implement frames)
+        Parameters
+        ----------
+        dna: str
+            a string of nucleotides
+        start: int
+            position to begin translation (used to implement frames)
 
-        Returns string containing amino acid sequence. Translates the entire
-        sequence: it is the caller's responsibility to find open reading frames.
-
-        NOTE: should return Protein object when we have a class for it.
+        Returns
+        -------
+        String containing amino acid sequence. Translates the entire sequence.
+        It is the caller's responsibility to find open reading frames.
         """
         if not dna:
             return ""

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -150,7 +150,13 @@ class SequenceI(object):
         return json.dumps(self.to_rich_dict())
 
     def translate(self, *args, **kwargs):
-        """translate() delegates to self._seq."""
+        """returns the result of call str.translate
+
+        Notes
+        -----
+        This is a string method, nothing to do with translating into a
+        protein sequence.
+        """
         return self._seq.translate(*args, **kwargs)
 
     def count(self, item):

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -712,7 +712,8 @@ class Sequence(_Annotatable, SequenceI):
         self.info = info
 
         if isinstance(orig_seq, _Annotatable):
-            self.copy_annotations(orig_seq)
+            for ann in orig_seq.annotations:
+                ann.copy_annotations_to(self)
 
     def to_moltype(self, moltype):
         """returns copy of self with moltype seq

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -2,7 +2,7 @@
 from cogent3.core.annotation import Feature
 from cogent3.core.genetic_code import GeneticCodes
 from cogent3.core.info import Info
-from cogent3.core.moltype import ASCII, DNA, PROTEIN
+from cogent3.core.moltype import get_moltype
 from cogent3.parse.record import FieldWrapper
 from cogent3.parse.record_finder import (
     DelimitedRecordFinder,
@@ -651,7 +651,7 @@ def RichGenbankParser(
 
     """
     info_excludes = info_excludes or []
-    moltype = moltype or ASCII
+    moltype = get_moltype(moltype or "text")
     for rec in MinimalGenbankParser(handle):
         info = Info()
         # populate the info object, excluding the sequence
@@ -660,10 +660,8 @@ def RichGenbankParser(
                 continue
             info[label] = value
 
-        if rec["mol_type"] == "protein":  # which it doesn't for genbank
-            moltype = PROTEIN
-        elif rec["mol_type"] == "DNA":
-            moltype = DNA
+        if rec["mol_type"].lower() in ("dna", "rna", "protein"):
+            moltype = get_moltype(rec["mol_type"].lower())
 
         try:
             seq = moltype.make_seq(

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -701,7 +701,7 @@ def RichGenbankParser(
             if add_annotation:
                 add_annotation(seq, feature, spans)
             else:
-                for id_field in ["gene", "note", "product", "clone"]:
+                for id_field in ["gene", "product", "clone", "note"]:
                     if id_field in feature:
                         name = feature[id_field]
                         if not isinstance(name, str):

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -200,9 +200,6 @@ class SequenceCollectionBaseTests(object):
 
     def setUp(self):
         """Define some standard SequenceCollection objects."""
-        if type(self.Class) == ArrayAlignment:
-            pass
-
         self.one_seq = self.Class({"a": "AAAAA"})
         self.ragged_padded = self.Class({"a": "AAAAAA", "b": "AAA---", "c": "AAAA--"})
         self.identical = self.Class({"a": "AAAA", "b": "AAAA"})
@@ -332,7 +329,7 @@ class SequenceCollectionBaseTests(object):
         self.assertEqual(a.names, ["seq_0", "seq_1", "seq_2"])
         self.assertEqual(list(a.seqs), ["AAAAA", "BBBBB", "CCCCC"])
 
-    def test_init_annotated_seq(self):
+    def test_init_seq_info(self):
         """SequenceCollection init from seqs w/ info should preserve data"""
         a = Sequence("AAA", name="a", info={"x": 3})
         b = Sequence("CCC", name="b", info={"x": 4})
@@ -351,6 +348,18 @@ class SequenceCollectionBaseTests(object):
         if self.Class is not ArrayAlignment:
             # ArrayAlignment is allowed to strip Info objects
             self.assertEqual([i.info.x for i in b.seqs], [5, 4, 3])
+
+    def test_init_annotated_seqs(self):
+        """correctly construct from list with annotated seq"""
+        if self.Class == ArrayAlignment:
+            # this class cannot be annotated
+            return
+        seq = make_seq("GCCAGGGGGGAAAG-GGAGAA", name="seq1")
+        _ = seq.add_feature("exon", "name", [(4, 10)])
+        coll = self.Class(data=[seq])
+        got_seq = coll.get_seq("seq1")
+        ann = got_seq.annotations[0]
+        self.assertEqual(str(got_seq[ann]), "GGGGGG")
 
     def test_init_pairs(self):
         """SequenceCollection init from list of (key,val) pairs should work correctly"""

--- a/tests/test_core/test_core_standalone.py
+++ b/tests/test_core/test_core_standalone.py
@@ -105,6 +105,11 @@ class TestConstructorFunctions(unittest.TestCase):
         self.assertTrue("Human" in got.to_dict())
         self.assertEqual(got.info["source"], path)
 
+    def test_load_unaligned_seqs_no_format(self):
+        """test loading unaligned from file"""
+        with self.assertRaises(ValueError):
+            got = load_unaligned_seqs("somepath")
+
     def test_load_aligned_seqs(self):
         """test loading aligned from file"""
         path = os.path.join(data_path, "brca1_5.paml")
@@ -117,6 +122,11 @@ class TestConstructorFunctions(unittest.TestCase):
         got = load_aligned_seqs(path, moltype="dna", array_align=False)
         self.assertEqual(got.moltype.label, "dna")
         self.assertIsInstance(got, Alignment)
+
+    def test_load_aligned_seqs_no_format(self):
+        """test loading unaligned from file"""
+        with self.assertRaises(ValueError):
+            got = load_aligned_seqs("somepath")
 
     def test_load_unaligned_seqs_from_json(self):
         """test loading an unaligned object from json file"""

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -471,6 +471,19 @@ ORIGIN
             self.assertEqual(str(got), expects[locus])
         infile.close()
 
+    def test_rich_parser_moltype(self):
+        """correctly handles moltypes"""
+        with open("data/annotated_seq.gb") as infile:
+            parser = RichGenbankParser(infile)
+            got_1 = [s for _, s in parser][0]
+
+        with open("data/annotated_seq.gb") as infile:
+            parser = RichGenbankParser(infile, moltype="dna")
+            got_2 = [s for _, s in parser][0]
+
+        self.assertEqual(len(got_1.annotations), len(got_2.annotations))
+        self.assertEqual(got_2.moltype.label, "dna")
+
 
 class LocationTests(TestCase):
     """Tests of the Location class."""

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -483,6 +483,9 @@ ORIGIN
 
         self.assertEqual(len(got_1.annotations), len(got_2.annotations))
         self.assertEqual(got_2.moltype.label, "dna")
+        # name formed from /product value
+        got = {f.name for f in got_2.get_annotations_matching("mRNA")}
+        self.assertEqual(got, {"conserved hypothetical protein", "chaperone, putative"})
 
 
 class LocationTests(TestCase):


### PR DESCRIPTION
Two bugs affecting using GenBank files have been squashed. The first arose from using the string name of a
moltype directly on RichGenbankParser. The second, when trying to use a sequence annotation when
sequence was derived from a GenBank file, but it was loaded into a sequence collection.

Have also changed the feature attributed used to name Features.