### PR TITLE
DOC: added pages under API for cogent3.__init__ functions, fixes #711

### DIFF
--- a/doc/api/__init__/cogent3.__init__.load_aligned_seqs.rst
+++ b/doc/api/__init__/cogent3.__init__.load_aligned_seqs.rst
@@ -1,0 +1,6 @@
+load_aligned_seqs
+=================
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: load_aligned_seqs

--- a/doc/api/__init__/cogent3.__init__.load_table.rst
+++ b/doc/api/__init__/cogent3.__init__.load_table.rst
@@ -1,0 +1,6 @@
+load_table
+==========
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: load_table

--- a/doc/api/__init__/cogent3.__init__.load_tree.rst
+++ b/doc/api/__init__/cogent3.__init__.load_tree.rst
@@ -1,0 +1,6 @@
+load_tree
+=========
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: load_tree

--- a/doc/api/__init__/cogent3.__init__.load_unaligned_seqs.rst
+++ b/doc/api/__init__/cogent3.__init__.load_unaligned_seqs.rst
@@ -1,0 +1,6 @@
+load_unaligned_seqs
+===================
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: load_unaligned_seqs

--- a/doc/api/__init__/cogent3.__init__.make_aligned_seqs.rst
+++ b/doc/api/__init__/cogent3.__init__.make_aligned_seqs.rst
@@ -1,0 +1,6 @@
+make_aligned_seqs
+=================
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: make_aligned_seqs

--- a/doc/api/__init__/cogent3.__init__.make_seq.rst
+++ b/doc/api/__init__/cogent3.__init__.make_seq.rst
@@ -1,0 +1,6 @@
+make_seq
+========
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: make_seq

--- a/doc/api/__init__/cogent3.__init__.make_table.rst
+++ b/doc/api/__init__/cogent3.__init__.make_table.rst
@@ -1,0 +1,6 @@
+make_table
+==========
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: make_table

--- a/doc/api/__init__/cogent3.__init__.make_tree.rst
+++ b/doc/api/__init__/cogent3.__init__.make_tree.rst
@@ -1,0 +1,6 @@
+make_tree
+=========
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: make_tree

--- a/doc/api/__init__/cogent3.__init__.make_unaligned_seqs.rst
+++ b/doc/api/__init__/cogent3.__init__.make_unaligned_seqs.rst
@@ -1,0 +1,6 @@
+make_unaligned_seqs
+===================
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: make_unaligned_seqs

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -2,6 +2,24 @@
 API
 ###
 
+***********************
+Major utility functions
+***********************
+
+.. toctree::
+    :maxdepth: 1
+
+    __init__/cogent3.__init__.make_seq
+    __init__/cogent3.__init__.make_unaligned_seqs
+    __init__/cogent3.__init__.make_aligned_seqs
+    __init__/cogent3.__init__.load_unaligned_seqs
+    __init__/cogent3.__init__.load_aligned_seqs
+    __init__/cogent3.__init__.make_table
+    __init__/cogent3.__init__.load_table
+    __init__/cogent3.__init__.make_tree
+    __init__/cogent3.__init__.load_tree
+
+
 ********************************
 Objects for the major data types
 ********************************


### PR DESCRIPTION
[CHANGED] api\index.rst now inculdes Major utility functions
from cogent3.__init__
[ADDED] rst files under api for each function in cogent3.__init__