### PR TITLE
BUG: robust table slicing when index_name defined

### DIFF
--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -311,8 +311,16 @@ class DictArrayTemplate(object):
         return DictArray(array, self)
 
     def interpret_index(self, names):
+        if isinstance(names, numpy.ndarray) and "int" in names.dtype.name:
+            # the numpy item() method casts to the nearest Python type
+            names = tuple(v.item() for v in names)
+
+        if any(isinstance(names, t_) for t_ in (list, numpy.ndarray)):
+            names = tuple(names)
+
         if not isinstance(names, tuple):
             names = (names,)
+
         index = []
         remaining = []
         for (ordinals, allnames, name) in zip(self.ordinals, self.names, names):

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -271,6 +271,25 @@ class TableTests(TestCase):
         got_np = t[indices, numpy.array([True, False, True, True])]
         assert_equal(got_np.array, got.array)
 
+    def test_slicing_with_index(self):
+        """different slice types work when index_name defined"""
+        # slicing by int works with index too
+        t = Table(header=self.t8_header, data=self.t8_rows, index="edge.name")
+        got = t[[1]]
+        self.assertEqual(got.columns["edge.name"], "NineBande")
+        self.assertEqual(got.shape, (1, t.shape[1]))
+        for v, dtype in [(1, None), (1, object), ("NineBande", "U")]:
+            got = t[numpy.array([v], dtype=dtype)]
+            self.assertEqual(got.columns["edge.name"], "NineBande")
+            self.assertEqual(got.shape, (1, t.shape[1]))
+
+        # works if, for some reason, the index column has floats
+        t = Table(header=self.t7_header, data=self.t7_rows, index="stat")
+        got = t[[1827.5580]]
+        self.assertEqual(got.shape, (1, t.shape[1]))
+        got = t[numpy.array([1827.5580])]
+        self.assertEqual(got.shape, (1, t.shape[1]))
+
     def test_specifying_space(self):
         """controls spacing in simple format"""
         space = "        "


### PR DESCRIPTION
[FIXED] Slicing Table rows using a series of int failed if index_name
    defined. This was due to DictArray not handling a list of integers,
    or a numpy array. Now it does.