### PR TITLE
BUG: formatted_array assumes series is a column

### DIFF
--- a/src/cogent3/format/table.py
+++ b/src/cogent3/format/table.py
@@ -921,7 +921,6 @@ def formatted_array(
     list of formatted series, formatted title, maximum string length
     """
     assert isinstance(series, numpy.ndarray), "must be numpy array"
-    assert series.ndim == 1, "must be a 1D numpy array"
     if pad and align.lower() not in set("lrc"):
         raise ValueError(f"alignment {align} not in 'l,c,r'")
 

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -1103,6 +1103,17 @@ class TableTests(TestCase):
         table = make_table(header=["a"])
         self.assertEqual(str(table), "=\na\n-\n-")
 
+    def test_str_object_col(self):
+        """str works when a column has complex object"""
+        # data has tuples in an array
+        data = dict(
+            key=numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
+            count=[1, 3, 2],
+        )
+        t = Table(data=data)
+        got = str(t)
+        self.assertEqual(len(got.splitlines()), 7)
+
     def test_str_md_format(self):
         """str() produces markdown table"""
         md_table = make_table(


### PR DESCRIPTION
[FIXED] was failing if numpy array had python objects, like a
    list or tuple, as elements