### PR TITLE
Refactor of Table to enable column based formatting

### DIFF
--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -508,14 +508,7 @@ class LikelihoodFunction(ParameterController):
                 "motif" in table.title and table.shape[1] == 2 and table.shape[0] >= 60
             ):  # just sort codon motif probs, then truncate
                 table = table.sorted(columns="motif")
-                data = table.tolist()
-                data = data[:5] + [["...", "..."]] + data[-5:]
-                table = table.__class__(
-                    header=table.header,
-                    data=data,
-                    digits=table._digits,
-                    title=table.title,
-                )
+                table.set_repr_policy(head=5, tail=5, show_shape=False)
                 result[i] = table
         return title, result
 

--- a/src/cogent3/format/table.py
+++ b/src/cogent3/format/table.py
@@ -40,6 +40,26 @@ known_formats = (
     "tsv",
 )
 
+css_c3table_template = "\n".join(
+    (
+        ".c3table table {margin: 10px 0;}",
+        ".c3table tr:last-child {border-bottom: 1px solid #000;} ",
+        ".c3table tr > th {text-align: left; padding: 0 5px;}",
+        ".c3table tr > td {text-align: left; padding: 5px;}",
+        ".c3table tr:nth-child(even) {background: #f7f7f7 !important;}",
+        ".c3table .ellipsis {background: rgba(0, 0, 0, .01);}",
+        ".c3table .index {background: %(colour)s; margin: 10px; font-weight: 600;}",
+        ".c3table .head_cell {background: %(head_colour)s; font-weight: bold; text-align: center;}",
+        ".c3table caption {color: rgb(250, 250, 250); background: "
+        "rgba(30, 140, 200, 1); padding: 3px; white-space: nowrap; "
+        "caption-side: top;}",
+        ".c3table .cell_title {font-weight: bold;}",
+        ".c3col_left { text-align: left !important; display: block;}",
+        ".c3col_right { text-align: right !important; display: block;}",
+        ".c3col_center { text-align: center !important; display: block;}",
+    )
+)
+
 
 def _merged_cell_text_wrap(text, max_line_length, space):
     """ left justify wraps text into multiple rows"""
@@ -998,3 +1018,36 @@ def formatted_array(
     title = format(title, format_spec)
     formatted = [format(v.strip(), format_spec) for v in formatted]
     return formatted, title, max_length
+
+
+class HtmlElement:
+    """wrapper for text to become a HTML element"""
+
+    def __init__(self, text, tag, css_classes=None, newline=False):
+        """
+        Parameters
+        ----------
+        text : str
+            cell content
+        tag : str
+            html table cell tag, e.g. 'td', 'th'
+        classes : list
+            list of custom CSS classes
+        newline : bool
+            puts the open, close tags on new lines
+        """
+        self.text = str(text)
+        self.tag = tag
+        css_classes = [css_classes] if isinstance(css_classes, str) else css_classes
+        self.css_classes = css_classes
+        self.newline = newline
+
+    def __str__(self):
+        txt = self.text
+        classes = "" if self.css_classes is None else " ".join(self.css_classes)
+        classes = f' class="{classes}"' if classes else ""
+        nl = "\n" if self.newline else ""
+        return f"{nl}<{self.tag}{classes}>{nl}{txt}{nl}</{self.tag}>"
+
+    def __repr__(self):
+        return repr(self.text)

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -349,39 +349,6 @@ class DictArrayTemplate(object):
             klass = None
         return (tuple(index), klass)
 
-    def array_repr(self, a):
-        if len(a.shape) == 1:
-            heading = [str(n) for n in self.names[0]]
-            a = a[numpy.newaxis, :]
-        elif len(a.shape) == 2:
-            heading = [""] + [str(n) for n in self.names[1]]
-            a = [[str(name)] + list(row) for (name, row) in zip(self.names[0], a)]
-        else:
-            return "%s dimensional %s" % (len(self.names), type(self).__name__)
-
-        formatted = table.formatted_cells(rows=a, header=heading)
-        return str(table.simple_format(formatted[0], formatted[1], space=4))
-
-    def _get_repr_html(self, a):
-        """returns Table._repr_html_()"""
-        from cogent3.util.table import Table
-
-        if len(a.shape) == 1:
-            heading = [str(n) for n in self.names[0]]
-            a = a[numpy.newaxis, :]
-            index = None
-        elif len(a.shape) == 2:
-            heading = [""] + [str(n) for n in self.names[1]]
-            a = [[str(name)] + list(row) for (name, row) in zip(self.names[0], a)]
-            a = {d[0]: d[1:] for d in zip(heading, *a)}
-            index = heading[0]
-        else:
-            return "%s dimensional %s" % (len(self.names), type(self).__name__)
-
-        t = Table(heading, data=a, digits=3, index=index, max_width=80)
-        t.set_repr_policy(show_shape=False)
-        return t._repr_html_()
-
 
 class DictArray(object):
     """Wraps a numpy array so that it can be indexed with strings like nested
@@ -488,7 +455,12 @@ class DictArray(object):
         return [(n, self[n]) for n in list(self.keys())]
 
     def __repr__(self):
-        return self.template.array_repr(self.array)
+        if self.array.ndim > 2:
+            return "%s dimensional %s" % (self.array.ndim, type(self).__name__)
+
+        t = self.to_table()
+        t.set_repr_policy(show_shape=False)
+        return t
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -543,7 +515,12 @@ class DictArray(object):
         return template.wrap(result)
 
     def _repr_html_(self):
-        return self.template._get_repr_html(self.array)
+        if self.array.ndim > 2:
+            return "%s dimensional %s" % (self.array.ndim, type(self).__name__)
+
+        t = self.to_table()
+        t.set_repr_policy(show_shape=False)
+        return t._repr_html_()
 
     def to_string(self, format="tsv", sep=None):
         """Return the data as a formatted string.

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -489,7 +489,7 @@ class DictArray(object):
 
         t = self.to_table()
         t.set_repr_policy(show_shape=False)
-        return t
+        return str(t)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -339,7 +339,7 @@ class DictArrayTemplate(object):
                 name = slice(start, stop, name.step)
                 remaining.append(allnames.__getitem__(name))
             elif type(name) in (list, numpy.ndarray):
-                name = [ordinals.get(n, n) for n in name]
+                name = [n if type(n) == int else ordinals[n] for n in name]
                 remaining.append([allnames[i] for i in name])
 
             index.append(name)

--- a/src/cogent3/util/modules.py
+++ b/src/cogent3/util/modules.py
@@ -19,12 +19,14 @@ class ExpectedImportError(ImportError):
     pass
 
 
-def fail(msg):
+def fail(msg):  # pragma: no cover
     print(msg, file=sys.stderr)
     raise ExpectedImportError
 
 
-def importVersionedModule(name, exec_globals, min_version, alt_desc):
+def importVersionedModule(
+    name, exec_globals, min_version, alt_desc
+):  # pragma: no cover
     if "COGENT3_PURE_PYTHON" in os.environ:
         fail('Not using compiled module "%s".  Will use %s.' % (name, alt_desc))
     try:

--- a/src/cogent3/util/table.py
+++ b/src/cogent3/util/table.py
@@ -1789,7 +1789,7 @@ class Table:
         element_formatters=None,
         merge_identical=False,
         compact=False,
-    ):
+    ):  # pragma: no cover
         """returns just the table as html.
 
         Parameters

--- a/src/cogent3/util/table.py
+++ b/src/cogent3/util/table.py
@@ -719,7 +719,7 @@ class Table:
         if not self._repr_policy["show_shape"]:
             shape_info = ""
 
-        if self.shape == (0, 0):
+        if self.shape[0] == 0:
             return shape_info
 
         title, legend = table.title, table.legend

--- a/src/cogent3/util/table.py
+++ b/src/cogent3/util/table.py
@@ -13,6 +13,7 @@ Table can read pickled and delimited formats.
 import csv
 import json
 import pickle
+import re
 
 from collections import defaultdict
 from collections.abc import Callable, MutableMapping
@@ -23,7 +24,6 @@ import numpy
 
 from cogent3.format import bedgraph
 from cogent3.format import table as table_format
-from cogent3.format.table import formatted_array
 from cogent3.util.dict_array import DictArray, DictArrayTemplate
 from cogent3.util.misc import (
     atomic_write,
@@ -94,6 +94,14 @@ def _callback(callback, row, num_columns=None):
         return callback(row)
     else:
         return eval(callback, {}, row)
+
+
+_num_type = re.compile("^(float|int|complex)").search
+
+
+def array_is_num_type(data):
+    """whether data has a dtype for int, float or complex"""
+    return _num_type(data.dtype.name) != None
 
 
 def cast_str_to_numeric(values):
@@ -252,6 +260,7 @@ class Columns(MutableMapping):
         if isinstance(key, slice):
             key, _ = self._template.interpret_index(key)
             key = self._order[key[0]]
+
         if isinstance(key, numpy.ndarray):
             key = numpy.array(self._order)[key].tolist()
 
@@ -584,6 +593,9 @@ class Table:
         index_name = attr.pop("index")
         result = self.__class__(**attr)
         for c in columns:
+            if len(self.columns[c]) == 0:
+                continue
+
             result.columns[c] = self.columns[c][rows]
 
         if index_name in result.columns:
@@ -619,6 +631,9 @@ class Table:
             return "0 rows x 0 columns"
 
         table, shape_info, unset_columns = self._get_repr_()
+        if self.shape[0] == 0:
+            return "\n".join([shape_info, unset_columns])
+
         if not self._repr_policy["show_shape"]:
             shape_info = ""
         result = (
@@ -645,7 +660,6 @@ class Table:
             self._repr_policy["tail"] = tail
 
         shape_info = ""
-        ellipsis = None
         if rn:
             indices = numpy.random.choice(self.shape[0], size=rn, replace=False)
             indices = list(sorted(indices))
@@ -654,7 +668,6 @@ class Table:
             indices = list(range(head)) + list(
                 range(self.shape[0] - tail, self.shape[0])
             )
-            ellipsis = "..."
             if head + tail < self.shape[0]:
                 shape_info = f"Top {head} and bottom {tail} rows from"
         elif head:
@@ -668,45 +681,24 @@ class Table:
         else:
             indices = list(range(self.shape[0]))
 
-        rows = {}
-        unset_columns = []
-        for c in self.header:
-            if len(self.columns[c]):
-                rows[c] = [self.columns[c][i] for i in indices]
-            else:
-                unset_columns.append(c)
-
-        if ellipsis:
-            for k, v in rows.items():
-                v.insert(head, ellipsis)
-
         shape_info += f"\n{self.shape[0]:,} rows x {self.shape[1]:,} columns"
+        unset_columns = [c for c in self.header if not len(self.columns[c])]
         unset_columns = (
-            "unset columns: %s" % ", ".join(unset_columns) if unset_columns else None
+            "unset columns: %s" % ", ".join(map(repr, unset_columns))
+            if unset_columns
+            else None
         )
+        table = self[indices] if self.shape[0] > 0 else None
 
-        kwargs = self._get_persistent_attrs()
-        header = self.header
-        if rows.keys():
-            header = tuple(rows.keys())
-        table = self.__class__(header=header, data=rows, **kwargs)
-        table._column_templates.update(self._column_templates)
         return table, shape_info, unset_columns
 
     def _repr_html_(self):
         """returns html, used by Jupyter"""
-        base_colour = "rgba(161, 195, 209, {alpha})"
-        colour = base_colour.format(alpha=0.25)
-
-        def row_cell_func(val, row, col):
-            if self.index_name is not None and col == 0:
-                klass = f' class="index"'
-            else:
-                klass = ""
-            val = f"<td{klass}>{val}</td>"
-            return val
-
         table, shape_info, unset_columns = self._get_repr_()
+        if isinstance(table, numpy.ndarray):
+            # single row / column
+            table = self
+
         shape_info = (
             f"<p>{shape_info}; unset columns={unset_columns}</p>"
             if unset_columns
@@ -718,51 +710,36 @@ class Table:
         if self.shape[0] == 0:
             return shape_info
 
-        title, legend = table.title, table.legend
-        # current rich_html does not provide a good mechanism for custom
-        # formatting of titles, legends
-        table.title, table.legend = None, None
-        head_colour = base_colour.format(alpha=0.75)
-        element_format = dict(thead=f'<thead class="head_cell">')
-        html = table.to_rich_html(
-            row_cell_func=row_cell_func, element_formatters=element_format
-        )
-        if title or legend:
-            title = title or ""
-            legend = legend or ""
-            caption = (
-                "<caption>"
-                f'<span class="cell_title">{title}</span>'
-                f'<br><span class="cell_legend">{legend}</span></caption>'
-            )
-            html = html.splitlines()
-            html.insert(1, caption)
-            html = "\n".join(html)
+        html = table.to_html()
+        # add elipsis if head + row < self.shape[0]
         html = html.splitlines()
-        html.insert(
-            0,
-            "\n".join(
-                [
-                    "<style>",
-                    ".c3table table {margin: 10px 0;}",
-                    ".c3table tr:last-child {border-bottom: 1px solid #000;} ",
-                    ".c3table tr > th {text-align: center !important; padding: 0 5px;}",
-                    ".c3table tr > td {text-align: right !important; padding: 5px;}",
-                    ".c3table tr:nth-child(even) {background: #f7f7f7;}",
-                    ".c3table .index {background: "
-                    + f"{colour}"
-                    + "; font-weight: 600;}",
-                    ".c3table .head_cell {background: "
-                    + f"{head_colour}"
-                    + "; font-weight: bold; text-align: center;}",
-                    ".c3table caption {color: rgb(250, 250, 250); background: rgba(30, 140, 200, 1); padding: 3px; white-space: nowrap; caption-side: top;}",
-                    ".c3table .cell_title {font-weight: bold;}",
-                    "</style>",
-                    '<div class="c3table">',
-                ]
-            ),
-        )
-        html = "\n".join(["\n".join(html), shape_info, "</div>"])
+        head = self._repr_policy.get("head") or self.shape[0]
+        tail = self._repr_policy.get("tail") or self.shape[0]
+        if head + tail < self.shape[0] and head and tail:
+            HE = table_format.HtmlElement
+            ellipsis = []
+            for c in table.columns:
+                if array_is_num_type(table.columns[c]):
+                    css_class = "c3col_right"
+                else:
+                    css_class = "c3col_left"
+
+                ellipsis.append(
+                    str(HE(HE("...", "span", css_classes=[css_class]), "td"))
+                )
+
+            ellipsis = str(HE("".join(ellipsis), "tr", css_classes="ellipsis"))
+            num_rows = 0
+            for idx in range(len(html)):
+                item = html[idx]
+                if "<tr>" in item:
+                    num_rows += 1
+                if num_rows == head:
+                    html.insert(idx + 1, ellipsis)
+                    break
+
+        html.insert(-1, shape_info)
+        html = "\n".join(html)
         return html
 
     def _get_persistent_attrs(self):
@@ -901,6 +878,7 @@ class Table:
     def index_name(self, name):
         self.columns.index_name = name
         self._index_name = name
+        self._persistent_attrs["index"] = name
         self._template = None if name is None else DictArrayTemplate(self.columns[name])
 
     @property
@@ -1525,14 +1503,21 @@ class Table:
             default str value for missing
         pad : bool
             if True, adds padding
+
+        Returns
+        -------
+        dict of formatted columns, list of [(name, length),..]
         """
         missing_data = missing_data or self._missing_data
         formatted = {}
-        col_widths = {}
+        col_widths = []
         for c in self.columns.order:
             data = self.columns[c]
+            if len(data) == 0:
+                continue
+
             format_spec = self._column_templates.get(c, None)
-            frmt, c, width = formatted_array(
+            frmt, c, width = table_format.formatted_array(
                 data,
                 c,
                 format_spec=format_spec,
@@ -1540,7 +1525,7 @@ class Table:
                 precision=self._digits,
                 pad=pad,
             )
-            col_widths[c] = width
+            col_widths.append((c, width))
             formatted[c] = frmt
 
         return formatted, col_widths
@@ -1750,6 +1735,15 @@ class Table:
             header = formatted_table.pop(0)
             return table_format.phylip_matrix(formatted_table, header)
 
+        # convert self to a 2D list after caching current column templates
+        col_formats = {}
+        for c in self.columns:
+            if c in self._column_templates:
+                col_formats[c] = self._column_templates[c]
+                continue
+
+            col_formats[c] = ">" if array_is_num_type(self.columns[c]) else "<"
+
         orig_formats = self._column_templates
         self._column_templates = col_formats
 
@@ -1814,6 +1808,8 @@ class Table:
             cells within a row are merged to one span.
 
         """
+        deprecated("method", "to_rich_html", "to_html", "2021.10")
+
         element_formatters = element_formatters or {}
         formatted_table = self.array.tolist()
         header, formatted_table = table_format.formatted_cells(
@@ -1869,6 +1865,121 @@ class Table:
             )
             tables.append(subtable)
         return "\n".join(tables)
+
+    def to_html(self, column_alignment=None):
+        """construct html table
+
+        Parameters
+        ----------
+        column_alignment : dict
+            {col_name: alignment character, ...} where alignment character
+            can be one of 'l', 'c', 'r'. Defaults to 'r' for numeric columns,
+            'l' for text columns.
+
+        Returns
+        -------
+        string
+
+        Notes
+        -----
+        Placed within c3table div element, embeds CSS style.
+        """
+        column_alignment = column_alignment or {}
+        for c, v in column_alignment.items():
+            v = v.lower()
+            if v not in "clr":
+                raise ValueError(f"invalid column alignment value {v} for '{c}'")
+
+            column_alignment[c] = {
+                "c": "c3col_center",
+                "l": "c3col_left",
+                "r": "c3col_right",
+            }[v]
+
+        base_colour = "rgba(161, 195, 209, {alpha})"
+        # alpha applied to the index column background
+        alpha = 0.0 if self.index_name is None else 0.25
+
+        style = table_format.css_c3table_template % dict(
+            colour='"white"' if self.index_name else base_colour.format(alpha=alpha),
+            head_colour=base_colour.format(alpha=0.75),
+        )
+
+        HtmlElement = table_format.HtmlElement
+        tables = [str(HtmlElement(style, "style", newline=True))]
+
+        cols, widths = self._formatted_by_col(pad=False)
+        headers = table_format.get_continuation_tables_headers(
+            widths,
+            index_name=self.index_name,
+            max_width=self._max_width,
+        )
+
+        for c in self.columns:
+            c = c.strip()
+            css_class = (
+                "c3col_right" if array_is_num_type(self.columns[c]) else "c3col_left"
+            )
+
+            css_class = [column_alignment.get(c, css_class)]
+            cols[c] = [
+                HtmlElement(
+                    HtmlElement(v, "span", css_classes=css_class),
+                    "td",
+                    css_classes=["index"] if c == self.index_name else None,
+                )
+                for v in cols[c]
+            ]
+
+        title = self.title if self.title else ""
+        if title:
+            title = escape(title)
+        legend = self.legend if self.legend else ""
+        if legend:
+            legend = escape(legend)
+
+        for i, header in enumerate(headers):
+            if title and i == 0:
+                st = HtmlElement(title, "span", css_classes=["cell_title"])
+            elif title:
+                st = HtmlElement("continuation", "span", css_classes=["cell_title"])
+            else:
+                st = None
+
+            if st:
+                st = str(HtmlElement(str(st), "br"))
+
+            if legend and i == 0:
+                legend = HtmlElement(legend, "span", css_classes=["cell_legend"])
+                st = f"{st} {legend}" if st else f"{legend}"
+
+            caption = str(HtmlElement(st, "caption", newline=True)) if st else ""
+            rows = []
+            for i, row in enumerate(zip(*[cols[c] for c in header])):
+                txt = HtmlElement("".join([str(e) for e in row]), "tr")
+                rows.append(str(txt))
+
+            rows = str(HtmlElement("\n".join(rows), "tbody", newline=True))
+
+            if column_alignment:
+                header = [
+                    HtmlElement(c, "span", css_classes=column_alignment.get(c, None))
+                    for c in header
+                ]
+
+            header = "".join([str(HtmlElement(c, "th")) for c in header])
+            header = str(
+                HtmlElement(header, "thead", css_classes=["head_cell"], newline=True)
+            )
+
+            subtable = HtmlElement(
+                "".join([caption, header, rows]), "table", newline=True
+            )
+            tables.append(str(subtable))
+
+        return str(
+            HtmlElement("\n".join(tables), "div", css_classes=["c3table"], newline=True)
+        )
 
     def tolist(self, columns=None):
         """Returns raw data as a list

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -396,15 +396,15 @@ number of free parameters = 0\n\
 4.0000
 ------
 =============================
-     edge    parent    length
+edge         parent    length
 -----------------------------
-    Human    edge.0    0.3000
+Human        edge.0    0.3000
 HowlerMon    edge.0    0.4000
-   edge.0    edge.1    0.7000
-    Mouse    edge.1    0.5000
-   edge.1      root    0.6000
-NineBande      root    0.2000
- DogFaced      root    0.1000
+edge.0       edge.1    0.7000
+Mouse        edge.1    0.5000
+edge.1       root      0.6000
+NineBande    root      0.2000
+DogFaced     root      0.1000
 -----------------------------
 ====================================
      A         C         G         T
@@ -420,15 +420,15 @@ NineBande      root    0.2000
 log-likelihood = -382.5399
 number of free parameters = 14
 ===============================
-     edge  parent  length  beta
+edge       parent  length  beta
 -------------------------------
-    Human  edge.0    1.00  1.00
+Human      edge.0    1.00  1.00
 HowlerMon  edge.0    1.00  1.00
-   edge.0  edge.1    1.00  1.00
-    Mouse  edge.1    1.00  1.00
-   edge.1    root    1.00  1.00
-NineBande    root    1.00  1.00
- DogFaced    root    1.00  1.00
+edge.0     edge.1    1.00  1.00
+Mouse      edge.1    1.00  1.00
+edge.1     root      1.00  1.00
+NineBande  root      1.00  1.00
+DogFaced   root      1.00  1.00
 -------------------------------
 ======================
    A     C     G     T
@@ -575,45 +575,15 @@ number of free parameters = 0
 6.0000
 ------
 =============================
-     edge    parent    length
+edge         parent    length
 -----------------------------
-    Human    edge.0    4.0000
+Human        edge.0    4.0000
 HowlerMon    edge.0    4.0000
-   edge.0    edge.1    4.0000
-    Mouse    edge.1    4.0000
-   edge.1      root    4.0000
-NineBande      root    4.0000
- DogFaced      root    4.0000
------------------------------
-====================================
-     A         C         G         T
-------------------------------------
-0.2500    0.2500    0.2500    0.2500
-------------------------------------""",
-        )
-
-        # self.submodel.setScaleRule("ts",['beta'])
-        # self.submodel.setScaleRule("tv",['beta'], exclude_pars = True)
-        self.assertEqual(
-            str(likelihood_function),
-            """Likelihood function statistics
-log-likelihood = -413.1886
-number of free parameters = 0
-======
-  beta
-------
-6.0000
-------
-=============================
-     edge    parent    length
------------------------------
-    Human    edge.0    4.0000
-HowlerMon    edge.0    4.0000
-   edge.0    edge.1    4.0000
-    Mouse    edge.1    4.0000
-   edge.1      root    4.0000
-NineBande      root    4.0000
- DogFaced      root    4.0000
+edge.0       edge.1    4.0000
+Mouse        edge.1    4.0000
+edge.1       root      4.0000
+NineBande    root      4.0000
+DogFaced     root      4.0000
 -----------------------------
 ====================================
      A         C         G         T
@@ -658,15 +628,15 @@ NineBande      root    4.0000
 log-likelihood = -382.5399
 number of free parameters = 14
 =======================================
-     edge    parent    length      beta
+edge         parent    length      beta
 ---------------------------------------
-    Human    edge.0    1.0000    1.0000
+Human        edge.0    1.0000    1.0000
 HowlerMon    edge.0    1.0000    1.0000
-   edge.0    edge.1    1.0000    1.0000
-    Mouse    edge.1    1.0000    1.0000
-   edge.1      root    1.0000    1.0000
-NineBande      root    1.0000    1.0000
- DogFaced      root    1.0000    1.0000
+edge.0       edge.1    1.0000    1.0000
+Mouse        edge.1    1.0000    1.0000
+edge.1       root      1.0000    1.0000
+NineBande    root      1.0000    1.0000
+DogFaced     root      1.0000    1.0000
 ---------------------------------------
 ====================================
      A         C         G         T

--- a/tests/test_util/test_dictarray.py
+++ b/tests/test_util/test_dictarray.py
@@ -435,6 +435,19 @@ class DictArrayTest(TestCase):
         got = darr["T":"A", [1, 2]]
         assert_allclose(got.array, numpy.array([[0.1, 0.2], [0.7, 0.1]]))
 
+        # make sure we cope with keys that are int's
+        nums = list(range(1, 5))
+        darr = DictArrayTemplate(nums, nums).wrap(
+            [
+                [0.7, 0.1, 0.2, 0.3],
+                [0.1, 0.7, 0.1, 0.3],
+                [0.3, 0.2, 0.6, 0.3],
+                [0.4, 0.1, 0.1, 0.7],
+            ]
+        )
+        got = darr[[1, 2], [1, 2]]
+        assert_allclose(got.array, numpy.array([[0.7, 0.1], [0.2, 0.6]]))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -221,7 +221,8 @@ class TableTests(TestCase):
     def test_indexing_rows(self):
         """works using names or ints"""
         t = Table(header=self.t7_header, data=self.t7_rows, index="gene")
-        self.assertEqual(t["ENSG00000019485", "chrom"], "A")
+        got = t["ENSG00000019485", "chrom"]
+        self.assertEqual(got, "A")
 
     def test_immutability_cells(self):
         """table cells are immutable"""
@@ -1509,9 +1510,14 @@ class TableTests(TestCase):
         # no index
         t = Table(header=self.t8_header, data=self.t8_rows)
         _ = t._repr_html_()
+
         # with an index
         t = Table(header=self.t8_header, data=self.t8_rows, index="edge.name")
-        _ = t._repr_html_()
+        got = t._repr_html_()
+        # and the index column should contain "index" css class
+        self.assertEqual(
+            got.count("index"), t.shape[0] + 1
+        )  # add 1 for CSS style sheet
 
         # data has tuples in an array
         data = dict(
@@ -1613,7 +1619,10 @@ class TableTests(TestCase):
         t.tail(nrows=3)
         self.assertEqual(tail.data.shape[0], 3)
         self.assertEqual(len(tail.output.splitlines()), 9)
-        self.assertEqual(tail.data.tolist(), self.t1_rows[-3:])
+        self.assertEqual(
+            [int(v) for v in tail.data[:, -1].tolist()],
+            [r[-1] for r in self.t1_rows[-3:]],
+        )
         # tests when number of rows < default
         t = make_table(data=dict(a=["a"], b=["b"]))
         t.tail()

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -1532,6 +1532,10 @@ class TableTests(TestCase):
         table.columns["a"] = ["a"]
         _ = t._repr_html_()
 
+        # single column with a single value should not fail
+        table = make_table(data={"kappa": [3.2]}, title="a title")
+        _ = table._repr_html_()
+
     def test_array(self):
         """should produce array"""
         # data has tuples in an array


### PR DESCRIPTION
Includes deprecation warning of `Table.to_rich_html()` and introduces `Table.to_html()` as its replacement.