### PR TITLE
ENH: wrap composable app string repr

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import re
+import textwrap
 import time
 import traceback
 
@@ -62,11 +63,7 @@ def _get_source(source):
 
 
 def _get_origin(origin):
-    if type(origin) == str:
-        result = origin
-    else:
-        result = origin.__class__.__name__
-    return result
+    return origin if type(origin) == str else origin.__class__.__name__
 
 
 class NotCompleted(int):
@@ -187,11 +184,7 @@ class ComposableType:
             return True
 
         name = data.__class__.__name__
-        valid = False
-        for type_ in self._data_types:
-            if type_ == name:
-                valid = True
-                break
+        valid = name in self._data_types
         if not valid:
             msg = f"invalid data type, '{name}' not in {', '.join(self._data_types)}"
             valid = NotCompleted("ERROR", self, message=msg, source=data)
@@ -214,6 +207,7 @@ class Composable(ComposableType):
         if txt:
             txt += " + "
         txt += "%s(%s)" % (self.__class__.__name__, ", ".join(self._formatted))
+        txt = textwrap.fill(txt, width=80, break_long_words=False)
         return txt
 
     def __repr__(self):

--- a/src/cogent3/maths/stats/contingency.py
+++ b/src/cogent3/maths/stats/contingency.py
@@ -18,11 +18,6 @@ __email__ = "Gavin.Huttley@anu.edu.au"
 __status__ = "Alpha"
 
 
-def _get_bin(bins, value):
-    """returns bin index corresponding to value"""
-    pass
-
-
 # todo this should probably go into different module
 def shuffled_matrix(matrix):
     """returns a randomly sampled matrix with same marginals"""

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -214,7 +214,7 @@ class TestNotCompletedResult(TestCase):
             got,
             "select_translatable(type='sequences', "
             "moltype='dna', gc=1, "
-            "allow_rc=False, trim_terminal_stop=True)",
+            "allow_rc=False,\ntrim_terminal_stop=True)",
         )
 
         func = select_translatable(allow_rc=True)
@@ -223,7 +223,7 @@ class TestNotCompletedResult(TestCase):
             got,
             "select_translatable(type='sequences', "
             "moltype='dna', gc=1, "
-            "allow_rc=True, trim_terminal_stop=True)",
+            "allow_rc=True,\ntrim_terminal_stop=True)",
         )
 
         nodegen = omit_degenerates()
@@ -231,14 +231,14 @@ class TestNotCompletedResult(TestCase):
         self.assertEqual(
             got,
             "omit_degenerates(type='aligned', moltype=None, "
-            "gap_is_degen=True, motif_length=1)",
+            "gap_is_degen=True,\nmotif_length=1)",
         )
         ml = min_length(100)
         got = str(ml)
         self.assertEqual(
             got,
             "min_length(type='sequences', length=100, "
-            "motif_length=1, subtract_degen=True, "
+            "motif_length=1, subtract_degen=True,\n"
             "moltype=None)",
         )
 

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -34,9 +34,9 @@ class TestModel(TestCase):
             got,
             (
                 "model(type='model', sm='HKY85', tree=None, "
-                "name=None, sm_args=None, lf_args=None, "
+                "name=None, sm_args=None,\nlf_args=None, "
                 "time_het='max', param_rules=None, "
-                "opt_args=None, split_codons=False, "
+                "opt_args=None,\nsplit_codons=False, "
                 "show_progress=False, verbose=False)"
             ),
         )
@@ -149,10 +149,10 @@ class TestModel(TestCase):
         got = str(hyp)
         expect = (
             "hypothesis(type='hypothesis', null='HKY85', "
-            "alternates=(model(type='model', sm='HKY85', tree=None, "
-            "name='hky85-max-het', sm_args=None, lf_args=None, "
+            "alternates=(model(type='model',\nsm='HKY85', tree=None, "
+            "name='hky85-max-het', sm_args=None, lf_args=None,\n"
             "time_het='max', param_rules=None, opt_args=None,"
-            " split_codons=False, show_progress=False, verbose=False),),"
+            " split_codons=False,\nshow_progress=False, verbose=False),),"
             " init_alt=None)"
         )
         self.assertEqual(got, expect)

--- a/tests/test_app/test_tree.py
+++ b/tests/test_app/test_tree.py
@@ -85,7 +85,9 @@ class TestTree(TestCase):
         proc = fast_slow_dist + quick
         self.assertEqual(
             str(proc),
-            "fast_slow_dist(type='distance', distance=None, moltype='dna', fast_calc='hamming', slow_calc=None) + quick_tree(type='tree', drop_invalid=False)",
+            "fast_slow_dist(type='distance', distance=None, moltype='dna',\n"
+            "fast_calc='hamming', slow_calc=None) + quick_tree(type='tree',\n"
+            "drop_invalid=False)",
         )
         self.assertIsInstance(proc, tree_app.quick_tree)
         self.assertEqual(proc._type, "tree")


### PR DESCRIPTION
[CHANGED] use texwrap to break up really long string representations
    into ~80 character long lines