### PR TITLE
ENH: MotifCounts and MotifFreqs support computing pairwise stats

### DIFF
--- a/src/cogent3/core/profile.py
+++ b/src/cogent3/core/profile.py
@@ -143,6 +143,23 @@ class _MotifNumberArray(DictArray):
 
         return self.__class__(result, motifs=motifs, row_indices=row_order)
 
+    def _pairwise_stat(self, func):
+        """returns self dict of pairwise measurements between arrays"""
+        if len(self.shape) <= 1 or self.shape[0] <= 1:
+            return None
+
+        from itertools import combinations
+
+        data = {k: v.array for k, v in self.items()}
+        keys = list(data)
+        stats = {}
+        for k1, k2 in combinations(range(len(keys)), 2):
+            name1, name2 = keys[k1], keys[k2]
+            stats[(name1, name2)] = func(data[name1], data[name2])
+            stats[(name2, name1)] = stats[(name1, name2)]
+
+        return stats
+
 
 def _get_ordered_motifs_from_tabular(data, index=1):
     """backend motif extraction function for motif_counts, motif_freqs and pssm
@@ -428,6 +445,18 @@ class MotifFreqsArray(_MotifNumberArray):
             axnum += 1
 
         return logo
+
+    def pairwise_jsm(self) -> dict:
+        """pairwise Jensen-Shannon metric"""
+        from cogent3.maths.measure import jsm
+
+        return self._pairwise_stat(jsm)
+
+    def pairwise_jsd(self) -> dict:
+        """pairwise Jensen-Shannon divergence"""
+        from cogent3.maths.measure import jsd
+
+        return self._pairwise_stat(jsd)
 
 
 class PSSM(_MotifNumberArray):

--- a/tests/test_core/test_profile.py
+++ b/tests/test_core/test_profile.py
@@ -293,8 +293,66 @@ class MotifFreqsArrayTests(TestCase):
         expected = [0.25, -1]
         assert_allclose(rel_entropy, expected)
 
+    def test_pairwise_jsd(self):
+        """correctly constructs pairwise JSD dict"""
+        from numpy.random import random
+
+        from cogent3.maths.measure import jsd
+
+        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+        expect = jsd(data[0], data[1])
+        freqs = MotifFreqsArray(array(data), "ACGT")
+        got = freqs.pairwise_jsd()
+        assert_allclose(list(got.values())[0], expect)
+
+        data = []
+        for _ in range(6):
+            freqs = random(4)
+            freqs = freqs / freqs.sum()
+            data.append(freqs)
+
+        freqs = MotifFreqsArray(array(data), "ACGT")
+        pwise = freqs.pairwise_jsd()
+        self.assertEqual(len(pwise), 6 * 6 - 6)
+
+    def test_pairwise_jsm(self):
+        """correctly constructs pairwise JS metric dict"""
+        from numpy.random import random
+
+        from cogent3.maths.measure import jsm
+
+        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+        expect = jsm(data[0], data[1])
+        freqs = MotifFreqsArray(array(data), "ACGT")
+        got = freqs.pairwise_jsm()
+        assert_allclose(list(got.values())[0], expect)
+
+        data = []
+        for _ in range(6):
+            freqs = random(4)
+            freqs = freqs / freqs.sum()
+            data.append(freqs)
+
+        freqs = MotifFreqsArray(array(data), "ACGT")
+        pwise = freqs.pairwise_jsm()
+        self.assertEqual(len(pwise), 6 * 6 - 6)
+
+    def test_pairwise_(self):
+        """returns None when single row"""
+        # ndim=1
+        data = [0.25, 0.25, 0.25, 0.25]
+        freqs = MotifFreqsArray(array(data), "ACGT")
+        got = freqs.pairwise_jsm()
+        self.assertEqual(got, None)
+
+        # ndim=2
+        data = array([[0.25, 0.25, 0.25, 0.25]])
+        freqs = MotifFreqsArray(data, "ACGT")
+        got = freqs.pairwise_jsm()
+        self.assertEqual(got, None)
+
     def test_information(self):
-        """calculates entr0pies correctly"""
+        """calculates entropies correctly"""
         data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
         got = MotifFreqsArray(array(data), "ABCD")
         entropy = got.information()
@@ -307,7 +365,7 @@ class MotifFreqsArrayTests(TestCase):
         pos1 = Counter()
         pos2 = Counter()
         num = 1000
-        for i in range(num):
+        for _ in range(num):
             seq = farr.simulate_seq()
             self.assertEqual(len(seq), 2)
             pos1[seq[0]] += 1


### PR DESCRIPTION
[NEW] added MotifFreqs.to_jsm() and MotifFreqs.to_jsd(). These return a
    dict of pairwise Jensen-Shannon metric / divergence statistics.

    Example usage: aln.counts_per_seq().to_freq_array().to_jsd()