### PR TITLE
MAINT: use one function to infer data source

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -50,15 +50,16 @@ def _make_logfile_name(process):
 
 def _get_source(source):
     if isinstance(source, str):
-        result = str(source)
-    else:
+        return str(source)
+
+    # todo maybe a dict? see about getting keys
+    try:
+        result = source.source
+    except AttributeError:
         try:
-            result = source.source
+            result = source.info.source
         except AttributeError:
-            try:
-                result = source.info.source
-            except AttributeError:
-                result = None
+            result = None
     return result
 
 

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -414,19 +414,17 @@ class WritableDataStoreBase:
 
     def make_relative_identifier(self, data):
         """returns identifier for a new member relative to source"""
+        from cogent3.app.composable import _get_source
+
         if isinstance(data, DataStoreMember):
             data = data.name
         elif type(data) != str:
-            try:
-                data = data.info.source
-            except AttributeError:
-                try:
-                    data = data.source
-                except AttributeError:
-                    raise ValueError(
-                        "objects for storage require either a "
-                        "source or info.source string attribute"
-                    )
+            data = _get_source(data)
+            if data is None:
+                raise ValueError(
+                    "objects for storage require either a "
+                    "source or info.source string attribute"
+                )
         basename = os.path.basename(data)
         suffix, comp = get_format_suffixes(basename)
         if suffix and comp:

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -4,10 +4,10 @@ import pathlib
 import shutil
 import zipfile
 
-from os.path import basename, join
+from os.path import join
 from tempfile import TemporaryDirectory
 from unittest import TestCase, main
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import numpy
 
@@ -456,30 +456,31 @@ class TestIo(TestCase):
         """correctly writes an object with info attribute from json"""
         # create a mock object that pretends like it's been derived from
         # something
-        from cogent3.util.union_dict import UnionDict
+        from cogent3.app.result import generic_result
 
         with TemporaryDirectory(dir=".") as dirname:
             outdir = join(dirname, "delme")
-            mock = Mock()
-            mock.to_rich_dict = DNA.to_rich_dict
-            mock.info = UnionDict(source=join("blah", "delme.json"))
+
+            obj = generic_result(source=join("blah", "delme.json"))
+            obj["dna"] = DNA
             writer = io_app.write_json(outdir, create=True)
-            _ = writer(mock)
+            _ = writer(obj)
             reader = io_app.load_json()
             got = reader(join(outdir, "delme.json"))
-            self.assertEqual(got, DNA)
+            got.deserialised_values()
+            self.assertEqual(got["dna"], DNA)
 
         # now with a zipped archive
         with TemporaryDirectory(dir=".") as dirname:
             outdir = join(dirname, "delme.zip")
-            mock = Mock()
-            mock.to_rich_dict = DNA.to_rich_dict
-            mock.info = UnionDict(source=join("blah", "delme.json"))
+            obj = generic_result(source=join("blah", "delme.json"))
+            obj["dna"] = DNA
             writer = io_app.write_json(outdir, create=True)
-            identifier = writer(mock)
+            identifier = writer(obj)
             reader = io_app.load_json()
             got = reader(writer.data_store[0])
-            self.assertEqual(got, DNA)
+            got.deserialised_values()
+            self.assertEqual(got["dna"], DNA)
             expect = join(outdir.replace(".zip", ""), "delme.json")
             if expect.startswith("." + os.sep):
                 expect = expect[2:]


### PR DESCRIPTION
[CHANGED] use the app.composable._get_source function consistently
[CHANGED] don't use Mock for testing in this case, too difficult to
    track API