### PR TITLE
BUG: address changes in multiprocess in python3.8+

### DIFF
--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -15,6 +15,8 @@ import numpy
 from cogent3.util.misc import extend_docstring_from
 
 
+multiprocessing.set_start_method("fork")
+
 __author__ = "Sheng Han Moses Koh"
 __copyright__ = "Copyright 2007-2020, The Cogent Project"
 __credits__ = ["Peter Maxwell", "Sheng Han Moses Koh", "Gavin Huttley"]


### PR DESCRIPTION
[FIXED] prior to python3.8, the default approach for creating a new process
    on MacOS was to use fork(). This changed with 3.8, which now defaults
    to using spawn(). According to this blog post

    https://chrissardegna.com/blog/multiprocessing-changes-python-3-8/

    an effect of the 3.8 change is code cannot dereference data. What I find
    puzzling is that this behaviour depends on whether client code invoking
    multiprocess (in cogent3's case, that's any code running in parallel other
    than via mpi) is invoked under a `if __name__ == "__main__"` condition.

    This patch does fix the known failures, so I'm pushing this even though
    it is not explicitly tested.

NOTE: I still have not yet established how to correctly test this!