### PR TITLE
BUG: mpi execution with out specifying max_workers now correct

### DIFF
--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -143,7 +143,7 @@ def imap(f, s, max_workers=None, use_mpi=False, if_serial="raise", chunksize=Non
         elif COMM.Get_attr(MPI.UNIVERSE_SIZE) == 1 and if_serial == "warn":
             warnings.warn(err_msg, UserWarning)
 
-        max_workers = max_workers or 0
+        max_workers = max_workers or 1
 
         if max_workers > COMM.Get_attr(MPI.UNIVERSE_SIZE):
             warnings.warn(
@@ -151,7 +151,6 @@ def imap(f, s, max_workers=None, use_mpi=False, if_serial="raise", chunksize=Non
             )
 
         max_workers = min(max_workers, COMM.Get_attr(MPI.UNIVERSE_SIZE) - 1)
-
         if not chunksize:
             chunksize = set_default_chunksize(s, max_workers)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py37mpi, py38, py39
+envlist = py36, py37, py37mpi, py38mpi, py39mpi, py38, py39
 
 [testenv]
 passenv = *
@@ -13,38 +13,55 @@ deps = py{36,37,38}: numba>0.48.0
        pytest
        scitrack
        pandas
-       py{36,37,38,39}: pytest-cov
+       pytest-cov
        py37mpi: mpi4py
+       py38mpi: mpi4py
+       py39mpi: mpi4py
 
 [testenv:py39]
 changedir = tests
 basepython = python3.9
 commands =
-    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_mpi.py
+    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_app_mpi.py
 
 [testenv:py38]
 changedir = tests
 basepython = python3.8
 commands =
-    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_mpi.py
+    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_app_mpi.py
 
 [testenv:py37]
 changedir = tests
 basepython = python3.7
 commands =
-    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_mpi.py
+    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_app_mpi.py
 
 [testenv:py37mpi]
 changedir = tests
 basepython = python3.7
+whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ test_mpi.py
+    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+
+[testenv:py38mpi]
+changedir = tests
+basepython = python3.8
+whitelist_externals = mpiexec
+commands =
+    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+
+[testenv:py39mpi]
+changedir = tests
+basepython = python3.9
+whitelist_externals = mpiexec
+commands =
+    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [testenv:py36]
 changedir = tests
 basepython = python3.6
 commands =
-    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_mpi.py
+    pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 ./ --ignore=test_app_mpi.py
 
 [gh-actions]
 python =


### PR DESCRIPTION
[FIXED] mpi tests now correctly specified in tox.ini
[NEW] added tox environments py38mpi and py39mpi