### PR TITLE
BUG: atomic_write now correctly handles writing to compressed formats

### DIFF
--- a/tests/test_util/test_misc.py
+++ b/tests/test_util/test_misc.py
@@ -651,6 +651,24 @@ class AtomicWriteTests(TestCase):
                     raise AssertionError
             self.assertFalse(test_filepath.exists())
 
+    def test_writes_compressed_formats(self):
+        """correctly writes / reads different compression formats"""
+        fpath = pathlib.Path("data/sample.tsv")
+        with open(fpath) as infile:
+            expect = infile.read()
+
+        with tempfile.TemporaryDirectory(".") as dirname:
+            dirname = pathlib.Path(dirname)
+            for suffix in ["gz", "bz2", "zip"]:
+                outpath = dirname / f"{fpath.name}.{suffix}"
+                with atomic_write(outpath, mode="wt") as f:
+                    f.write(expect)
+
+                with open_(outpath) as infile:
+                    got = infile.read()
+
+                self.assertEqual(got, expect, msg=f"write failed for {suffix}")
+
     def test_rename(self):
         """Renames file as expected """
         # create temp file directory


### PR DESCRIPTION
[CHANGED] internal operation now relies on creating a temporary working
    directory, if not user specified, and uses a uuid as the file name,
    adding the suffixes of the actual expected output path. This enables
    open_ to provide the correct open function.