### PR TITLE
TST: improve tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,7 @@ deps = py{36,37,38}: numba>0.48.0
        scitrack
        pandas
        pytest-cov
-       py37mpi: mpi4py
-       py38mpi: mpi4py
-       py39mpi: mpi4py
+       py{37mpi,38mpi,39mpi}: mpi4py
 
 [testenv:py39]
 changedir = tests
@@ -41,21 +39,21 @@ changedir = tests
 basepython = python3.7
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [testenv:py38mpi]
 changedir = tests
 basepython = python3.8
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [testenv:py39mpi]
 changedir = tests
 basepython = python3.9
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [testenv:py36]
 changedir = tests


### PR DESCRIPTION
[CHANGED] invoke mpi4py futures correctly. To do this required ensuring
    I correctly specify the tox venv environment python interpreter.
    Other miscellaneous cleanup.