### PR TITLE
TST: better error message on simulate_alignment method

### DIFF
--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -1032,16 +1032,19 @@ class LikelihoodFunction(ParameterController):
         root_sequence
             a sequence from which all others evolve
         """
-
+        orig_ambig = {}
         if sequence_length is None:
             lht = self.get_param_value("lht", locus=locus)
-            sequence_length = len(lht.index)
+            try:
+                sequence_length = len(lht.index)
+            except AttributeError:
+                raise ValueError(
+                    f"Must provide sequence_length since no alignment set on self"
+                )
+
             leaves = self.get_param_value("leaf_likelihoods", locus=locus)
-            orig_ambig = {}
             for (seq_name, leaf) in list(leaves.items()):
                 orig_ambig[seq_name] = leaf.get_ambiguous_positions()
-        else:
-            orig_ambig = {}
 
         if random_series is None:
             random_series = random.Random()

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -500,6 +500,20 @@ DogFaced   root      1.00  1.00
         lf.set_param_rule("beta", bin="high", value=10.0)
         simulated_alignment = lf.simulate_alignment(100)
 
+    def test_simulate_alignment1(self):
+        "Simulate alignment when no alignment set"
+        al = make_aligned_seqs(data={"a": "ggaatt", "c": "cctaat"})
+        t = make_tree("(a,c);")
+        sm = get_model("F81")
+        lf = sm.make_likelihood_function(t)
+        # no provided alignment raises an exception
+        with self.assertRaises(ValueError):
+            lf.simulate_alignment()
+
+        # unless you provide length
+        sim_aln = lf.simulate_alignment(sequence_length=10)
+        self.assertEqual(len(sim_aln), 10)
+
     def test_simulate_alignment2(self):
         "Simulate alignment with dinucleotide model"
         al = make_aligned_seqs(data={"a": "ggaatt", "c": "cctaat"})


### PR DESCRIPTION
[CHANGED] if no alignment was set on the likelihood function instance,
    it requires the user specify sequence_length. Now raises ValueError
    if not specified.