### PR TITLE
ENH: app.evo.model now supports unique trees per alignment

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -207,7 +207,9 @@ class Composable(ComposableType):
         if txt:
             txt += " + "
         txt += "%s(%s)" % (self.__class__.__name__, ", ".join(self._formatted))
-        txt = textwrap.fill(txt, width=80, break_long_words=False)
+        txt = textwrap.fill(
+            txt, width=80, break_long_words=False, break_on_hyphens=False
+        )
         return txt
 
     def __repr__(self):


### PR DESCRIPTION
[NEW] added unique_trees argument to app.model(). When True,
    a new unrooted tree is build for each alignment. This is only
    valid when the number of sequences in an alignment is 3.