### PR TITLE
DOC: added get_model() to API docs

### DIFF
--- a/doc/api/__init__/cogent3.__init__.get_model.rst
+++ b/doc/api/__init__/cogent3.__init__.get_model.rst
@@ -1,0 +1,6 @@
+get_model
+=========
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: get_model

--- a/src/cogent3/app/result.py
+++ b/src/cogent3/app/result.py
@@ -509,9 +509,13 @@ class hypothesis_result(model_collection_result):
         table = table.sorted(columns="nfp")
         table.set_repr_policy(show_shape=False)
         stats = [[self.LR, self.df, self.pvalue]]
-        col_templates = {
-            "pvalue": "%.4f" if self.pvalue > 1e-3 else "%.2e",
-        }
+        col_templates = (
+            None
+            if self.pvalue is None
+            else {
+                "pvalue": "%.4f" if self.pvalue > 1e-3 else "%.2e",
+            }
+        )
         stats = Table(
             header=["LR", "df", "pvalue"],
             data=stats,

--- a/src/cogent3/evolve/models.py
+++ b/src/cogent3/evolve/models.py
@@ -2710,6 +2710,14 @@ def get_model(name, **kw):
 
     name is case sensitive.
 
+    Parameters
+    ----------
+    optimise_motif_probs: bool
+        Treat like other free parameters.
+    recode_gaps: bool
+        Whether gaps in an alignment should be treated as an ambiguous state
+        instead.
+
     Notes
     -----
     See available_models() for the full list.

--- a/src/cogent3/evolve/ns_substitution_model.py
+++ b/src/cogent3/evolve/ns_substitution_model.py
@@ -4,6 +4,7 @@ from cogent3.core import moltype
 from cogent3.evolve.discrete_markov import PsubMatrixDefn
 from cogent3.evolve.predicate import MotifChange
 from cogent3.maths.optimisers import ParameterOutOfBoundsError
+from cogent3.util.misc import extend_docstring_from
 
 from .substitution_model import (
     Parametric,
@@ -154,27 +155,33 @@ class DiscreteSubstitutionModel(_SubstitutionModel):
 
 
 class NonReversibleNucleotide(Parametric):
-    """A nucleotide substitution model."""
+    """Base non-reversible nucleotide substitution model."""
 
+    @extend_docstring_from(Parametric.__init__)
     def __init__(self, *args, **kw):
         Parametric.__init__(self, moltype.DNA.alphabet, *args, **kw)
 
 
 class NonReversibleDinucleotide(Parametric):
-    """A dinucleotide substitution model."""
+    """Base non-reversible dinucleotide substitution model."""
 
+    @extend_docstring_from(Parametric.__init__)
     def __init__(self, *args, **kw):
         Parametric.__init__(self, moltype.DNA.alphabet, motif_length=2, *args, **kw)
 
 
 class NonReversibleTrinucleotide(Parametric):
-    """A trinucleotide substitution model."""
+    """Base non-reversible trinucleotide substitution model."""
 
+    @extend_docstring_from(Parametric.__init__)
     def __init__(self, *args, **kw):
         Parametric.__init__(self, moltype.DNA.alphabet, motif_length=3, *args, **kw)
 
 
 class NonReversibleCodon(_Codon, Parametric):
+    """Base non-reversible codon substitution model."""
+
+    @extend_docstring_from(Parametric.__init__)
     def __init__(self, alphabet=None, gc=None, **kw):
         if gc is not None:
             alphabet = moltype.CodonAlphabet(gc=gc)
@@ -192,7 +199,7 @@ class StrandSymmetric(NonReversibleNucleotide):
 
 
 class NonReversibleProtein(Parametric):
-    """base protein substitution model."""
+    """Base non-reversible protein substitution model."""
 
     def __init__(self, with_selenocysteine=False, *args, **kw):
         alph = moltype.PROTEIN.alphabet

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -144,31 +144,37 @@ class _SubstitutionModel(object):
         name="",
         motifs=None,
     ):
-        # subclasses can extend this incomplete docstring
         """
-
-        alphabet:
-         - alphabet - An Alphabet object
-         - motif_length: Use a tuple alphabet based on 'alphabet'.
-         - motifs: Use a subalphabet that only contains those motifs.
-         - model_gaps: Whether the gap motif should be included as a state.
-         - recode_gaps: Whether gaps in an alignment should be treated as an
-           ambiguous state instead.
-
-        Motif Probability:
-         - motif_probs: Dictionary of probabilities.
-         - equal_motif_probs: Flag to set alignment motif probs equal.
-         - motif_probs_alignment: An alignment from which motif probs are set.
-
-         If none of these options are set then motif probs will be derived
-         from the data: ie the particular alignment provided later.
-
-         - optimise_motif_probs: Treat like other free parameters.  Any values
-           set by the other motif_prob options will be used as initial values.
-
-         - mprob_model: 'tuple', 'conditional', 'monomer' or 'monomers' to specify how
+        Parameters
+        ----------
+        alphabet
+            An Alphabet object
+        motif_probs
+            Dictionary of probabilities.
+        optimise_motif_probs: bool
+            Treat like other free parameters.  Any values set by the other
+            motif_prob options will be used as initial values.
+        equal_motif_probs: bool
+            Flag to set alignment motif probs equal.
+        motif_probs_from_data: bool
+            Get motif probabilities from data provided to likelihood function.
+        motif_probs_alignment
+            An alignment from which motif probs are set.
+        mprob_model: str
+            'tuple', 'conditional', 'monomer' or 'monomers' to specify how
            tuple-alphabet (including codon) motif probs are used.
-
+        model_gaps: bool
+            Whether the gap motif should be included as a state.
+        recode_gaps: bool
+            Whether gaps in an alignment should be treated as an ambiguous
+            state instead.
+        motif_length: int
+            Based on 'alphabet', uses a tuple alphabet where individual words
+            have motif_length number of characters.
+        name: str
+            Name of this model
+        motifs
+            Use a subalphabet that only contains those motifs.
         """
         d = locals()
         exclude = ("self", "__class__")
@@ -461,11 +467,15 @@ class _ContinuousSubstitutionModel(_SubstitutionModel):
         **kw,
     ):
         """
-        - with_rate: Add a 'rate' parameter which varies by bin.
-        - ordered_param: name of a single parameter which distinguishes any bins.
-        - distribution: choices of 'free' or 'gamma' or an instance of some
-          distribution. Could probably just deprecate free
-        - partitioned_params: names of params to be partitioned across bins
+        with_rate: bool
+            Add a 'rate' parameter which varies by bin.
+        ordered_param: str
+            name of a single parameter which distinguishes any bins.
+        distribution: str
+            choices of 'free' or 'gamma' or an instance of some distribution
+        partitioned_params
+            names of params to be partitioned across bins
+        kw
         """
 
         _SubstitutionModel.__init__(self, alphabet, **kw)
@@ -703,8 +713,11 @@ class Parametric(_ContinuousSubstitutionModel):
     @extend_docstring_from(_ContinuousSubstitutionModel.__init__)
     def __init__(self, alphabet, predicates=None, scales=None, **kw):
         """
-        - predicates: a dict of {name:predicate}. See cogent3.evolve.predicate
-        - scales: scale rules, dict with predicates
+        predicates: dict
+            a dict of {name:predicate}. See cogent3.evolve.predicate
+        scales: dict
+            scale rules, dict with predicates
+        kw
         """
         self._canned_predicates = None
         _ContinuousSubstitutionModel.__init__(self, alphabet, **kw)
@@ -887,11 +900,14 @@ class Parametric(_ContinuousSubstitutionModel):
 
 
 class Stationary(StationaryQ, Parametric):
+    @extend_docstring_from(Parametric.__init__)
     def __init__(self, *args, **kw):
+        """"""
         Parametric.__init__(self, *args, **kw)
 
 
 class TimeReversible(Stationary):
+    @extend_docstring_from(Stationary.__init__)
     def __init__(self, *args, **kw):
         """"""
         Stationary.__init__(self, *args, **kw)
@@ -1009,6 +1025,7 @@ class _Codon:
 class TimeReversibleCodon(_Codon, _TimeReversibleNucleotide):
     """Core substitution model for codons"""
 
+    @extend_docstring_from(_TimeReversibleNucleotide.__init__)
     def __init__(self, alphabet=None, gc=None, **kw):
         if gc is not None:
             alphabet = moltype.CodonAlphabet(gc=gc)

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -31,7 +31,6 @@ class TestModel(TestCase):
         """correct str representation"""
         model = evo_app.model("HKY85", time_het="max")
         got = " ".join(str(model).splitlines())
-        print(got)
         expect = (
             "model(type='model', sm='HKY85', tree=None, unique_trees=False, "
             "name=None, sm_args=None, lf_args=None, "
@@ -79,6 +78,32 @@ class TestModel(TestCase):
         hyp = evo_app.hypothesis(model1, model2, init_alt=lambda x, y: x)
         result = hyp(aln)
         self.assertEqual(result.df, 1)
+
+    def test_hyp_init_sequential(self):
+        """uses preceding model to initialise function"""
+        opt_args = dict(max_evaluations=15, limit_action="ignore")
+        model1 = evo_app.model("F81", opt_args=opt_args)
+        model2 = evo_app.model("HKY85", opt_args=opt_args)
+        model3 = evo_app.model("GTR", opt_args=opt_args)
+        # defaults to initialise model3 from model 2 from model1
+        hyp = evo_app.hypothesis(model1, model2, model3, sequential=True)
+        _data = {
+            "Human": "ATGCGGCTCGCGGAGGCCGCGCTCGCGGAG",
+            "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
+            "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
+        }
+        aln = make_aligned_seqs(data=_data, moltype="dna")
+        result = hyp(aln)
+        self.assertTrue(
+            result["F81"].lf.lnL < result["HKY85"].lf.lnL < result["GTR"].lf.lnL
+        )
+
+        # can be set to False, in which case all models start at defaults
+        hyp = evo_app.hypothesis(model1, model2, model3, sequential=False)
+        result = hyp(aln)
+        self.assertFalse(
+            result["F81"].lf.lnL < result["HKY85"].lf.lnL < result["GTR"].lf.lnL
+        )
 
     def test_model_time_het(self):
         """support lf time-het argument edge_sets"""
@@ -177,7 +202,7 @@ class TestModel(TestCase):
             "name='hky85-max-het', sm_args=None, lf_args=None, "
             "time_het='max', param_rules=None, opt_args=None,"
             " split_codons=False, show_progress=False, verbose=False),),"
-            " init_alt=None)"
+            " sequential=True, init_alt=None)"
         )
         self.assertEqual(got, expect)
 
@@ -438,7 +463,6 @@ class TestHypothesisResult(TestCase):
         tree = "(Mouse,Human,Opossum)"
         m1 = evo_app.model("JTT92", tree=tree)
         r = m1(aln)
-        print(r)
         self.assertEqual(r.origin, "model")
 
 


### PR DESCRIPTION
[CHANGED] add key modelling args to get_model(), plus use
    numpydoc style on substitution model classes