### PR TITLE
MAINT: code tidy

### DIFF
--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -407,10 +407,6 @@ class WritableDataStoreBase:
         self._members = []
         if_exists = if_exists.lower()
         assert if_exists in (OVERWRITE, SKIP, RAISE, IGNORE)
-        if create is False and if_exists == OVERWRITE:
-            warn(f"'{OVERWRITE}' reset to '{IGNORE}' and create=True", UserWarning)
-            create = True
-
         self._source_create_delete(if_exists, create)
 
     def make_relative_identifier(self, data):

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -819,6 +819,7 @@ class TinyDBDataStoreTests(TestCase):
 
             # correctly creates tinydb when full path does not exist
             dstore = self.WriteClass(path, create=True)
+            dstore.close()
 
 
 class SingleReadStoreTests(TestCase):


### PR DESCRIPTION
[CHANGED] removed uninformative warning when configured to overwrite
    a data store but create path is False

[CHANGED] close data store before its context disappears in a test