### PR TITLE
TST: improve testing of sample.concat

### DIFF
--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -74,10 +74,25 @@ class concat:
         data
             series of alignment instances
         """
-        names = self._name_callback(list(aln.names for aln in data))
-        collated = defaultdict(list)
+        if len(data) == 0:
+            raise ValueError("no data")
+
+        names = []
         for aln in data:
-            assert isinstance(aln, ArrayAlignment) or isinstance(aln, Alignment)
+            if not (isinstance(aln, ArrayAlignment) or isinstance(aln, Alignment)):
+                raise TypeError(f"{type(aln)} invalid for concat")
+            names.append(aln.names)
+
+        names = self._name_callback(names)
+        collated = defaultdict(list)
+        if self._moltype is None:
+            self._moltype = aln.moltype
+
+        for aln in data:
+            if self._moltype and aln.moltype != self._moltype:
+                # try converting
+                aln = aln.to_moltype(self.moltype)
+
             if self._intersect:
                 seqs = aln.take_seqs(names).to_dict()
             else:

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -415,6 +415,42 @@ class TranslateTests(TestCase):
             },
         )
 
+    def test_concat_handles_moltype(self):
+        """coerces to type"""
+        alns = [
+            make_aligned_seqs(data=d, moltype=DNA)
+            for d in [
+                {"seq1": "AAA", "seq2": "AAA", "seq3": "AAA"},
+                {"seq1": "TTT", "seq2": "TTT", "seq3": "TTT", "seq4": "TTT"},
+                {"seq1": "CC", "seq2": "CC", "seq3": "CC"},
+            ]
+        ]
+        ccat = sample.concat()
+        got = ccat(alns)
+        self.assertIsInstance(got.moltype, type(DNA))
+
+    def test_concat_validates_type(self):
+        """raises TypeError if not known alignment type"""
+        data = [
+            {"seq1": "AAA", "seq2": "AAA", "seq3": "AAA"},
+            make_aligned_seqs(
+                data={"seq1": "TTT", "seq2": "TTT", "seq3": "TTT", "seq4": "TTT"},
+                moltype=DNA,
+            ),
+        ]
+        ccat = sample.concat()
+        # triggered by first record
+        with self.assertRaises(TypeError):
+            ccat(data)
+
+        # triggered by second record
+        with self.assertRaises(TypeError):
+            ccat(data[::-1])
+
+        # triggered by no data
+        with self.assertRaises(ValueError):
+            ccat([])
+
     def test_trim_stop_codons(self):
         """trims stop codons using the specified genetic code"""
         trimmer = sample.trim_stop_codons()  # defaults to standard code


### PR DESCRIPTION
[CHANGED] check there is input data, that it's of the correct type

[CHANGED] if not defined, set concat moltype attribute to be that of first
    entry

[CHANGED] coerce output alignment to correct type