### PR TITLE
ENH: app.align.align_to_ref now retains gaps in the reference

### DIFF
--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -8,6 +8,8 @@ from cogent3.align import (
 )
 from cogent3.align.progressive import TreeAlign
 from cogent3.app import dist
+from cogent3.core.alignment import Aligned, Alignment
+from cogent3.core.location import LostSpan, Map, Span
 from cogent3.core.moltype import get_moltype
 from cogent3.evolve.models import get_model
 
@@ -31,27 +33,184 @@ __email__ = "Gavin.Huttley@anu.edu.au"
 __status__ = "Alpha"
 
 
-class _GapInRef:
-    """assumes first element of series is reference, returns True if that matches
-    gap_state"""
+def _gap_insertion_data(seq: Aligned):
+    """compute gap position, length and cumulative offsets
 
-    def __init__(self, moltype, gap):
-        self.gap_state = moltype.alphabet.to_indices(gap)[0]
-        self.func = self._ref_gap if gap == "-" else self._array_ref_gap
+    Parameters
+    ----------
+    seq
+        a cogent3 annotatable sequence
 
-    def _ref_gap(self, x):
-        return x[0] != self.gap_state
+    Returns
+    -------
+    [(seq position, gap length), ...], [cum sum gap length, ...]
 
-    def _array_ref_gap(self, x):
-        return x.flatten()[0] != self.gap_state
+    Notes
+    -----
+    The sequence position is in unaligned sequence coordinates. offsets are
+    calculated as the cumulative sum of gap lengths. The offset
+    plus the sequence position gives the alignment coordinate for a gap.
+    """
+    gap_pos = []
+    offsets = []
+    offset = 0
+    for i, span in enumerate(seq.map.spans):
+        if not span.lost:
+            continue
+        pos = seq.map.spans[i - 1].end if i else 0
+        gap_pos.append((pos, len(span)))
+        offsets.append(offset)
+        offset += span.length
 
-    def __call__(self, x):
-        return self.func(x)
+    return gap_pos, offsets
+
+
+def _merged_gaps(a_gaps, b_gaps, function="max"):
+    """
+
+    Parameters
+    ----------
+    a_gaps, b_gaps
+        [(gap position, length),...]
+    function
+        When a and b contain a gap at the same position, function is applied
+        to the gap lengths. Valid values are either 'max' or 'sum'.
+
+    Returns
+    -------
+    Merged places as [(gap position, length),...]
+    """
+    if function.lower() not in "maxsum":
+        raise ValueError(f"{function} not allowed, choose either 'sum' or 'max'")
+
+    function = max if function.lower() == "max" else sum
+
+    if not a_gaps:
+        return b_gaps
+
+    if not b_gaps:
+        return a_gaps
+
+    places = sorted(a_gaps + b_gaps)
+
+    positions, lengths = [places[0][0]], [places[0][1]]
+    for i, (pos, l) in enumerate(places[1:], 1):
+        if positions[-1] == pos:
+            lengths[-1] = function([lengths[-1], l])
+            continue
+
+        positions.append(pos)
+        lengths.append(l)
+    return list(zip(positions, lengths))
+
+
+def _gap_pos_to_map(gap_pos, gap_lengths, seq_length):
+    """[(pos, gap length), ...]"""
+
+    if not gap_pos:
+        return Map([(0, seq_length)], parent_length=seq_length)
+
+    spans = []
+    last = pos = 0
+    for i, pos in enumerate(gap_pos):
+        if pos > seq_length:
+            raise ValueError(
+                f"cannot have gap at position {pos} beyond seq_length= {seq_length}"
+            )
+
+        gap = LostSpan(length=gap_lengths[i])
+        spans.extend([gap] if pos == 0 else [Span(last, pos), gap])
+        last = pos
+
+    if pos < seq_length:
+        spans.append(Span(last, seq_length))
+
+    return Map(spans=spans, parent_length=seq_length)
+
+
+def _interconvert_seq_aln_coords(gaps, offsets, pos, seq_pos=True):
+    """converts sequence position to an alignment position
+
+    Parameters
+    ----------
+    gaps
+        series of [(seq pos, length), ..]
+    offsets
+        the offset of seq pos, which is basically the sum of all lengths up
+        to the previous gap
+    p
+        the sequence coordinate to convert
+    seq_pos : bool
+        whether pos is in sequence coordinates. If False, means it is in
+        alignment coordinates.
+    Returns
+    -------
+    alignment coordinate
+    """
+    if pos < 0:
+        raise ValueError(f"negative value {pos}")
+
+    if not gaps or pos == 0:
+        return pos
+
+    offset = 0
+    for i, (p, len) in enumerate(gaps):
+        assert p >= 0 and len > 0
+        if p + offset >= pos:
+            break
+        offset += len
+    assert offset < pos, f"calculated offset {offset} greater than align pos {p}"
+    if not seq_pos:  # we subtract the gap length total to get to seq coords
+        offset = -offset
+    return pos + offset
+
+
+def _map_ref_gaps_to_seq(all_ref_seq, curr_ref, other):
+    """inject ref gaps missing from curr_ref into other map
+
+    Returns
+    -------
+    Map
+    """
+    all_gap_pos, _ = _gap_insertion_data(all_ref_seq)
+    c_gpos, c_offsets = _gap_insertion_data(curr_ref)
+    o_gpos, o_offsets = _gap_insertion_data(other)
+    unique_ref_gaps = set(all_gap_pos) - set(c_gpos)
+    if not unique_ref_gaps:  # other seq map unchanged
+        return other.map
+
+    # we add the offset from the full ref up to the new gap
+    new_gaps = []
+    for unique in unique_ref_gaps:
+        # convert ref seq coord into current alignment coord
+        aln_pos = _interconvert_seq_aln_coords(
+            c_gpos, c_offsets, unique[0], seq_pos=True
+        )
+        # convert current alignment coord into query seq coord
+        seq_pos = _interconvert_seq_aln_coords(
+            o_gpos, o_offsets, aln_pos, seq_pos=False
+        )
+        new_gaps.append((seq_pos, unique[1]))
+
+    # because we combine gap positions from two different sequences,
+    # the reference and the other, we need to merge overlapping gaps by
+    # summation, rather than max
+    o_gpos = _merged_gaps(o_gpos, new_gaps, function="sum")
+    gap_pos, gap_lengths = list(zip(*o_gpos))
+    seq = other.data
+    return _gap_pos_to_map(gap_pos, gap_lengths, len(seq))
 
 
 class align_to_ref(ComposableSeq):
-    """Aligns to a reference seq, no gaps in the reference.
-    Returns an Alignment object."""
+    """Aligns sequences to a nominated reference in the unaligned collection.
+    This is much faster, and requires much less memory, than progressive_align
+    but the quality will likely be lower. Alignment quality will be strongly
+    affected by choice of reference.
+
+    Returns
+    -------
+    ArrayAlignment.
+    """
 
     _input_types = SEQUENCE_TYPE
     _output_types = (ALIGNED_TYPE, SERIALISABLE_TYPE)
@@ -122,27 +281,33 @@ class align_to_ref(ComposableSeq):
             seqs = seqs.to_moltype(self._moltype)
 
         ref_seq = seqs.get_seq(self._ref_name)
-        aligned = None
+        ref_gaps = []
         kwargs = self._kwargs.copy()
-        no_ref_gap = None
-
-        for i in range(seqs.num_seqs):
-            seq = seqs.seqs[i]
+        pwise = []
+        for seq in seqs.seqs:
             if seq.name == self._ref_name:
                 continue
 
-            result = global_pairwise(ref_seq, seq, **kwargs)
-            if no_ref_gap is None:
-                no_ref_gap = _GapInRef(result.moltype, seqs.moltype.gap)
+            aln = global_pairwise(ref_seq, seq, **kwargs).to_type(array_align=False)
+            pwise.append(((seq.name, aln)))
+            gap_pos, _ = _gap_insertion_data(aln.named_seqs[ref_seq.name])
+            ref_gaps = _merged_gaps(ref_gaps, gap_pos, function="max")
 
-            # as we're going to be using a pairwise distance that excludes gaps
-            # eliminating positions with deletions in the reference
-            result = result.filtered(no_ref_gap)
-            aligned = result if aligned is None else aligned.add_from_ref_aln(result)
+        gap_pos, gap_lengths = list(zip(*ref_gaps)) if ref_gaps else ([], [])
+        m = _gap_pos_to_map(gap_pos, gap_lengths, len(ref_seq))
+        aligned = [Aligned(m, ref_seq)]
+        for other_name, aln in pwise:
+            curr_ref = aln.named_seqs[ref_seq.name]
+            other_seq = aln.named_seqs[other_name]
+            m = _map_ref_gaps_to_seq(aligned[0], curr_ref, other_seq)
+            aligned.append(
+                other_seq if m is other_seq.map else Aligned(m, other_seq.data)
+            )
 
         # default to ArrayAlign
-        new = aligned.to_type(array_align=True, moltype=self._moltype)
-        return new
+        return Alignment(aligned, moltype=self._moltype, info=seqs.info).to_type(
+            array_align=True, moltype=self._moltype
+        )
 
 
 class progressive_align(ComposableSeq):


### PR DESCRIPTION
[CHANGED] previously, no gaps were retained in the reference sequence.
    They are now retained. This will be modestly slower than previously, but
    avoids losing information if the choice of reference sequence is a bad one.