### PR TITLE
BUG: app.tree.quicktree now works for 2 sequences

### DIFF
--- a/src/cogent3/app/tree.py
+++ b/src/cogent3/app/tree.py
@@ -150,11 +150,11 @@ class quick_tree(ComposableTree):
             raise ValueError("invalid pairwise distances")
 
         # how many species do we have
-        species = dists.keys()
-        if len(species) == 2:
-            dist = list(dists.values())[0] / 2.0
-            treestring = "(%s:%.4f,%s:%.4f)" % (species[0], dist, species[1], dist)
-            tree = make_tree(treestring=treestring, underscore_unmunge=True)
+        if size == 2:
+            dist = dists.array[0, 1] / 2.0
+            newick = ",".join(f"{sp}:{dist:.4f}" for sp in dists.names)
+            newick = f"({newick})"
+            tree = make_tree(treestring=newick, underscore_unmunge=True)
         else:
             (result,) = gnj(dists.to_dict(), keep=1, show_progress=False)
             (score, tree) = result

--- a/tests/test_app/test_tree.py
+++ b/tests/test_app/test_tree.py
@@ -106,7 +106,6 @@ class TestTree(TestCase):
         # tests when distances contain None
         data = dict(
             seq1="AGGGGGGGGGGCCCCCCCCCCCCCCCCCGGGGGGGGGGGGGGGCGGTTTTTTTTTTTTTTTTTT",
-            seq2="TAAAAAAAAAAGGGGGGGGGGGGGGGGGGTTTTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCC",
         )
         aln2 = make_aligned_seqs(data=data, moltype=DNA)
         tree2 = proc(aln2)
@@ -129,7 +128,7 @@ class TestTree(TestCase):
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
-            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data.keys()))
+            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data))
         )
 
         data = {
@@ -159,7 +158,7 @@ class TestTree(TestCase):
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
-            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data.keys()))
+            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data))
         )
 
         data = {
@@ -181,7 +180,7 @@ class TestTree(TestCase):
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
-            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data.keys()))
+            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data))
         )
 
         data = {
@@ -234,7 +233,14 @@ class TestTree(TestCase):
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
-            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data.keys()))
+            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data))
+        )
+
+        data = {"a": {"b": 0.1, "a": 0.0}, "b": {"a": 0.1, "b": 0.0}}
+        darr = DistanceMatrix(data)
+        tree = quick_tree.quick_tree(darr)
+        self.assertEqual(
+            set(tree.get_tip_names()), set.union(*(set(tup) for tup in data))
         )
 
     def test_uniformize_tree(self):


### PR DESCRIPTION
[FIXED] now correctly use the DistanceMatrix class for the most trivial case
        fixed