### PR TITLE
BUG: refactor variable_positions() to correctly handle gaps

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -3117,19 +3117,13 @@ class AlignmentI(object):
             column are ignored.
 
         """
-        seqs = [str(self.named_seqs[n]) for n in self.names]
-        seq1 = seqs[0]
-        positions = list(zip(*seqs[1:]))
+        gaps = set(self.moltype.gaps)
         result = []
-        for (position, (motif1, column)) in enumerate(zip(seq1, positions)):
-            for motif in column:
-                if motif != motif1:
-                    if include_gap_motif:
-                        result.append(position)
-                        break
-                    elif motif != "-" and motif1 != "-":
-                        result.append(position)
-                        break
+        for position, column in enumerate(self.iter_positions()):
+            column = set(column)
+            num_states = len(column) if include_gap_motif else len(column - gaps)
+            if num_states > 1:
+                result.append(position)
 
         return result
 

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -2181,9 +2181,14 @@ class AlignmentBaseTests(SequenceCollectionBaseTests):
 
     def test_variable_positions(self):
         """correctly identify variable positions"""
-        new_seqs = {"seq1": "ACGTACGT", "seq2": "ACCGACGT", "seq3": "ACGTACGT"}
+        new_seqs = {"A": "-CG-C", "B": "ACAA?", "C": "GCGAC"}
         aln = self.Class(data=new_seqs, moltype=DNA)
-        self.assertEqual(aln.variable_positions(), [2, 3])
+        self.assertEqual(aln.variable_positions(include_gap_motif=True), [0, 2, 3, 4])
+        self.assertEqual(aln.variable_positions(include_gap_motif=False), [0, 2])
+        new_seqs = {"A": "GCGAC", "B": "GCGAC", "C": "GCGAC"}
+        aln = self.Class(data=new_seqs, moltype=DNA)
+        self.assertEqual(aln.variable_positions(include_gap_motif=True), [])
+        self.assertEqual(aln.variable_positions(include_gap_motif=False), [])
 
     def test_to_type(self):
         """correctly interconvert between alignment types"""


### PR DESCRIPTION
[FIXED] always report a position as variable if multiple non-gap characters
    are present