### PR TITLE
BUG: RichGenbankParser moltype argument now overrides file spec

### DIFF
--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -477,15 +477,25 @@ ORIGIN
             parser = RichGenbankParser(infile)
             got_1 = [s for _, s in parser][0]
 
-        with open("data/annotated_seq.gb") as infile:
-            parser = RichGenbankParser(infile, moltype="dna")
-            got_2 = [s for _, s in parser][0]
-
-        self.assertEqual(len(got_1.annotations), len(got_2.annotations))
-        self.assertEqual(got_2.moltype.label, "dna")
         # name formed from /product value
-        got = {f.name for f in got_2.get_annotations_matching("mRNA")}
+        got = {f.name for f in got_1.get_annotations_matching("mRNA")}
         self.assertEqual(got, {"conserved hypothetical protein", "chaperone, putative"})
+
+        # the file defines itself as DNA
+        self.assertEqual(got_1.moltype.label, "dna")
+
+        # but that is overridden by user setting moltype explicitly
+        for moltype in ("dna", "rna", "text"):
+            with open("data/annotated_seq.gb") as infile:
+                parser = RichGenbankParser(infile, moltype=moltype)
+                got_2 = [s for _, s in parser][0]
+
+            self.assertEqual(len(got_1.annotations), len(got_2.annotations))
+            self.assertEqual(got_2.moltype.label, moltype)
+            got = {f.name for f in got_1.get_annotations_matching("mRNA")}
+            self.assertEqual(
+                got, {"conserved hypothetical protein", "chaperone, putative"}
+            )
 
 
 class LocationTests(TestCase):


### PR DESCRIPTION
[CHANGED] if provided, this defines the moltype of the returned sequence,
    otherwise the moltype is determined from the genbank file meta-data