### PR TITLE
ENH: add optimise_motif_probs argument to app.evo.model

### DIFF
--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -150,7 +150,7 @@ class _SubstitutionModel(object):
         motif_probs
             Dictionary of probabilities.
         optimise_motif_probs: bool
-            Treat like other free parameters.  Any values set by the other
+            Treat like other free parameters. Any values set by the other
             motif_prob options will be used as initial values.
         equal_motif_probs: bool
             Flag to set alignment motif probs equal.


### PR DESCRIPTION
[NEW] This is such an important setting for modelling that
    it should be directly exposed, rather than relying on users
    to understand they should set it via sm_args.

NOTE: this setting overrides a value provided via sm_args.