### PR TITLE
API: app.result objects require source instance of str or pathlib.Path

### DIFF
--- a/src/cogent3/app/result.py
+++ b/src/cogent3/app/result.py
@@ -3,9 +3,11 @@ import json
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from functools import total_ordering
+from pathlib import Path
 
 import numpy
 
+from cogent3.app.data_store import get_data_source
 from cogent3.maths.stats import chisqprob
 from cogent3.util.misc import extend_docstring_from, get_object_provenance
 from cogent3.util.table import Table
@@ -28,6 +30,10 @@ class generic_result(MutableMapping):
     _item_types = ()
 
     def __init__(self, source):
+        source = get_data_source(source)
+        if not isinstance(source, (str, Path)):
+            raise ValueError(f"Cannot infer source from type {type(source)}")
+
         self._store = {}
         self._construction_kwargs = dict(source=source)
         self.source = source
@@ -142,12 +148,13 @@ class model_result(generic_result):
         if type(stat) == str:
             stat = eval(stat)
 
-        self._construction_kwargs = dict(
-            name=name,
-            stat=stat.__name__,
-            source=source,
-            elapsed_time=elapsed_time,
-            num_evaluations=num_evaluations,
+        self._construction_kwargs.update(
+            dict(
+                name=name,
+                stat=stat.__name__,
+                elapsed_time=elapsed_time,
+                num_evaluations=num_evaluations,
+            )
         )
         self._store = {}
         self._name = name
@@ -526,7 +533,7 @@ class hypothesis_result(model_collection_result):
             key for the null hypothesis
         """
         super(hypothesis_result, self).__init__(name=name, source=source)
-        self._construction_kwargs = dict(name_of_null=name_of_null, source=source)
+        self._construction_kwargs.update(dict(name_of_null=name_of_null))
 
         self._name_of_null = name_of_null
 
@@ -620,7 +627,6 @@ class bootstrap_result(generic_result):
 
     def __init__(self, source=None):
         super(bootstrap_result, self).__init__(source)
-        self._construction_kwargs = dict(source=source)
 
     @property
     def observed(self):

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -868,7 +868,7 @@ class TestFunctions(TestCase):
 
         for val_klass in (str, pathlib.Path):
             value = val_klass("some/path.txt")
-            obj = make_unaligned_seqs(data=dict(seq1="ACGG"), info=dict(source=value))
+            obj = make_unaligned_seqs(data=dict(seq1="ACGG"), info=dict(source=value, random_key=1234))
             got = get_data_source(obj)
             self.assertEqual(got, str(value))
 

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -868,7 +868,9 @@ class TestFunctions(TestCase):
 
         for val_klass in (str, pathlib.Path):
             value = val_klass("some/path.txt")
-            obj = make_unaligned_seqs(data=dict(seq1="ACGG"), info=dict(source=value, random_key=1234))
+            obj = make_unaligned_seqs(
+                data=dict(seq1="ACGG"), info=dict(source=value, random_key=1234)
+            )
             got = get_data_source(obj)
             self.assertEqual(got, str(value))
 

--- a/tests/test_app/test_result.py
+++ b/tests/test_app/test_result.py
@@ -87,7 +87,7 @@ class TestGenericResult(TestCase):
         # or Path
         aln.info.source = pathlib.Path(source)
         gr = generic_result(aln)
-        self.assertEqual(str(gr.source), "path/blah.fasta")
+        self.assertEqual(str(gr.source), str(pathlib.Path("path/blah.fasta")))
 
         # or DataStoreMember
         aln.info.source = DataStoreMember(source)

--- a/tests/test_util/test_deserialise.py
+++ b/tests/test_util/test_deserialise.py
@@ -233,7 +233,7 @@ class TestDeserialising(TestCase):
         edge_vals = zip(aln.names, (2, 3, 4))
         for edge, val in edge_vals:
             lf.set_param_rule("kappa", edge=edge, init=val)
-        result = model_result(name="test")
+        result = model_result(name="test", source="blah")
         result[1] = lf
         self.assertIs(result[1], lf)
         self.assertEqual(result.nfp, lf.nfp)


### PR DESCRIPTION
[CHANGED] We now apply the get_data_source() function to provided source
    value and raise a ValueError if the returned value is not a str or Path.
    (Note that the data_store.DataMember is a subclass of string.)

NOTE: this affects all result types!