### PR TITLE
API: fail if users set motif prob optimisation via sm_args

### DIFF
--- a/src/cogent3/app/evo.py
+++ b/src/cogent3/app/evo.py
@@ -127,6 +127,11 @@ class model(ComposableModel):
         ), "cannot provide a tree when unique_trees is True"
         self._unique_trees = unique_trees
         sm_args = sm_args or {}
+        if "optimise_motif_probs" in sm_args:
+            raise ValueError(
+                "'optimise_motif_probs' value in sm_args is IGNORED, use explicit argument instead",
+            )
+
         sm_args["optimise_motif_probs"] = optimise_motif_probs
         if type(sm) == str:
             sm = get_model(sm, **sm_args)

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -53,11 +53,16 @@ class TestModel(TestCase):
         """argument controls optimisability of motif prob settings"""
         for mn in ("HKY85", "GN", "CNFGTR"):
             for value in (True, False):
-                # check setting via sm_args is overriden
+                # check setting via sm_args is overridden
+                with self.assertRaises(ValueError):
+                    model = evo_app.model(
+                        mn,
+                        optimise_motif_probs=value,
+                        sm_args=dict(optimise_motif_probs=not value),
+                    )
                 model = evo_app.model(
                     mn,
                     optimise_motif_probs=value,
-                    sm_args=dict(optimise_motif_probs=not value),
                 )
                 self.assertEqual(model._sm._optimise_motif_probs, value)
                 # check picking a different value for constructor get's overriden


### PR DESCRIPTION
[NEW] value is over ridden by the explicit argument, need to block this
    as effect is major