### PR TITLE
TST: fix tox py310mpi setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,25 +42,25 @@ commands =
 basepython = python3.7
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 2 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [testenv:py38mpi]
 basepython = python3.8
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 2 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [testenv:py39mpi]
 basepython = python3.9
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 2 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
-[testenv:py10mpi]
+[testenv:py310mpi]
 basepython = python3.10
 whitelist_externals = mpiexec
 commands =
-    mpiexec -n 1 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
+    mpiexec -n 2 {envpython} -m mpi4py.futures -m pytest -x --junitxml=junit-{envname}.xml --cov-report xml --cov=cogent3 test_app/test_app_mpi.py
 
 [gh-actions]
 python =


### PR DESCRIPTION
[FIXED] Fixed typo in the Python 3.10 MPI testing environment. This was super
    irrittating and -- worse -- the "commands succeeded" message is misleading.
[CHANGED] set mpi num cpu's to 2