### PR TITLE
MAINT: changed how parallel generates child processes using multiprocess

### DIFF
--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -8,7 +8,7 @@ from cogent3.util.misc import extend_docstring_from
 
 
 multiprocessing.set_start_method(
-    "fork" if sys.platform == "darwin" else "spawn", force=True
+    "forkserver" if sys.platform == "darwin" else "spawn", force=True
 )
 
 __author__ = "Sheng Han Moses Koh"
@@ -71,7 +71,7 @@ def is_master_process():
             return False
     elif sys.version_info[1] >= 7:
         process_name = multiprocessing.current_process().name
-        if "ForkProcess" in process_name or "SpawnProcess" in process_name:
+        if "Fork" in process_name or "Spawn" in process_name:
             return False
     else:
         raise RuntimeError("is_master_process() requires Python 3.7 or greater")


### PR DESCRIPTION
[CHANGED] concurrent.futures sometimes hangs. With some searching it seems it is
    an artefact of set_start_method("fork") on macOS. According to this blog post
    http://www.bnikolic.co.uk/blog/python/parallelism/2019/11/13/python-forkserver-preload.html
    this approach can be unreliable if the parent state is complex (e.g. multi-threads).
    The forkserver approach strips down the runtime so avoids this issue. Better yet,
    it fixed the hanging parallel calculations.