### PR TITLE
BUG: improve consistency in setting motif_probs on likelihood function

### DIFF
--- a/src/cogent3/evolve/parameter_controller.py
+++ b/src/cogent3/evolve/parameter_controller.py
@@ -148,12 +148,11 @@ class _LikelihoodParameterController(_LF):
         pseudocount=None,
         **kwargs,
     ):
-
         counts = self.model.count_motifs(align, include_ambiguity=include_ambiguity)
         if is_constant is None:
             is_constant = not self.optimise_motif_probs
-        if pseudocount is None:
-            pseudocount = 0.0 if is_constant else 0.5
+
+        pseudocount = 0.0 if is_constant or (counts != 0).all() else pseudocount or 0.5
         counts += pseudocount
         mprobs = counts / (1.0 * sum(counts))
         self.set_motif_probs(

--- a/tests/test_evolve/test_parameter_controller.py
+++ b/tests/test_evolve/test_parameter_controller.py
@@ -66,6 +66,28 @@ class test_parameter_controller(TestCase):
         lf.set_param_rule(par_name="kappa", is_independent=True, edges=["b", "d"])
         self.assertEqual(null + 2, lf.get_num_free_params())
 
+    def test_set_get_motif_probs_nstat(self):
+        from cogent3 import get_model
+
+        aln = make_aligned_seqs(
+            data=dict(
+                a="AACGAAGCAGAGTCACGGCA",
+                b="ACGGAAGTTGAGTCACCCCA",
+                c="TGCATCGAAAAGTCACGCTG",
+            ),
+            moltype="dna",
+        )
+        bases = "ACGT"
+        expect = aln.get_motif_probs()
+        expect = [expect[b] for b in bases]
+        tree = make_tree("(a,b,c)")
+        gn = get_model("GN")
+        lf = gn.make_likelihood_function(tree)
+        lf.set_alignment(aln)
+        got = lf.get_motif_probs().to_dict()
+        got = [got[b] for b in bases]
+        assert_allclose(got, expect)
+
     def test_set_motif_probs(self):
         """Mprobs supplied to the parameter controller"""
 


### PR DESCRIPTION
[FIXED] only apply a pseudocount if optimising motif probs
    and at least one state has zero frequency, default pseudocount is 0.5.

Thanks to Stephen Rogers for finding this!