### PR TITLE
ENH: enhance placement of dendrogram scale bars

### DIFF
--- a/src/cogent3/draw/dendrogram.py
+++ b/src/cogent3/draw/dendrogram.py
@@ -652,8 +652,14 @@ class Dendrogram(Drawable):
         if not self.scale_bar or self.contemporaneous:
             return None, None
 
+        # place scale bar above / below dendrogram area
+        y_shift = (self.tree.max_y - self.tree.min_y) / 11
         x = self.tree.min_x if "left" in self.scale_bar else self.tree.max_x
-        y = self.tree.min_y if "bottom" in self.scale_bar else self.tree.max_y
+        y = (
+            self.tree.min_y - y_shift
+            if "bottom" in self.scale_bar
+            else self.tree.max_y + y_shift
+        )
         scale = 0.1 * self.tree.max_x
         text = f"{scale:.1e}" if scale < 1e-2 else f"{scale:.2f}"
         shape = {
@@ -663,6 +669,7 @@ class Dendrogram(Drawable):
             "x1": x + scale,
             "y1": y,
             "line": {"color": self._line_color, "width": self._line_width},
+            "name": "scale_bar",
         }
         annotation = UnionDict(
             x=x + (0.5 * scale),

--- a/tests/test_draw/test_dendrogram.py
+++ b/tests/test_draw/test_dendrogram.py
@@ -178,6 +178,28 @@ class TestDendro(TestCase):
         dnd.tip_font.color = "red"
         self.assertEqual(dnd.tip_font["color"], "red")
 
+    def test_scale_bar_place(self):
+        """outside rectangle containing dendrogram"""
+        from itertools import product
+
+        tree = make_tree(
+            "((a:0.1,b:0.25):0.1,(c:0.02,(e:0.035,f:0.04):0.15):0.3,g:0.3)"
+        )
+        styles = ["square", "circular", "angular", "radial"]
+        for style in styles:
+            dnd = tree.get_figure(style=style)
+            for vert, horizontal in product(["top", "bottom"], ["left", "right"]):
+                dnd.scale_bar = f"{vert} {horizontal}"
+                for s in dnd.figure.layout.shapes:
+                    if s.get("name") == "scale_bar":
+                        scale_y = s["y0"]
+                min_y, max_y = dnd.tree.min_y, dnd.tree.max_y
+                self.assertFalse(min_y <= scale_y <= max_y)
+
+        # if we set scale_bar None, there should be shapes
+        dnd.scale_bar = None
+        self.assertIsNone(dnd.figure.layout.get("shapes"))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
[NEW] added name="scale_bar" to shape annotation
[CHANGED] position the scale bar outside (above or below) the y-limits
    of the dendrogram