### PR TITLE
ENH: open_ now handles urls too

### DIFF
--- a/src/cogent3/parse/fasta.py
+++ b/src/cogent3/parse/fasta.py
@@ -61,16 +61,15 @@ def MinimalFastaParser(
     try:
         infile = open_(infile)
         close_at_end = True
-    except (TypeError, AttributeError):
+    except (ValueError, TypeError, AttributeError):
         close_at_end = False
 
     for rec in finder(infile):
         # first line must be a label line
-        if not rec[0][0] in label_characters:
+        if rec[0][0] not in label_characters:
             if strict:
                 raise RecordError(f"Found Fasta record without label line: {rec}")
             continue
-        # record must have at least one sequence
         if len(rec) < 2:
             if strict:
                 raise RecordError(f"Found label line without sequences: {rec}")

--- a/tests/test_util/test_io.py
+++ b/tests/test_util/test_io.py
@@ -295,22 +295,17 @@ def test_open_zip_multi(tmp_dir):
 
 
 @pytest.mark.parametrize(
-    "file_name,mode",
-    list(
-        product(
-            ("c_elegans_WS199_dna_shortened.fasta", "gff2_test.gff"),
-            ("r", "rb", "rt", None),
-        )
-    ),
+    "mode",
+    ("r", "rb", "rt", None),
 )
-def test_open_url(file_name, mode):
+def test_open_url(mode):
     # None value for open_url mode defaults to "rb"
-    local_root = pathlib.Path("data")
+    file_name = "gff2_test.gff"
     remote_root = (
         "https://raw.githubusercontent.com/cogent3/cogent3/develop/tests/data/{}"
     )
 
-    with open_(local_root / file_name, mode=mode) as infile:
+    with open_(DATADIR / file_name, mode=mode) as infile:
         local_data = infile.read()
 
     with open_url(remote_root.format(file_name), mode=mode) as infile:
@@ -320,6 +315,37 @@ def test_open_url(file_name, mode):
     # Test using a ParseResult for url
     with open_url(urlparse(remote_root.format(file_name)), mode=mode) as infile:
         remote_data = infile.read()
+    assert remote_data.splitlines() == local_data.splitlines()
+
+
+def test_open_url_local():
+    """using file:///"""
+    # None value for open_url mode defaults to "rb"
+    file_name = "gff2_test.gff"
+    with open_(DATADIR / file_name) as infile:
+        local_data = infile.read()
+
+    with open_url(f"file://{DATADIR}/{file_name}") as infile:
+        remote_data = infile.read()
+
+    assert remote_data.splitlines() == local_data.splitlines()
+
+
+def test_open_url_compressed():
+    """uses local compressed file to check"""
+    # None value for open_url mode defaults to "rb"
+    file_name = "formattest.fasta.gz"
+    remote_root = (
+        "https://raw.githubusercontent.com/cogent3/cogent3/develop/tests/data/{}"
+    )
+
+    with open_(DATADIR / file_name) as infile:
+        local_data = infile.read()
+
+    print(remote_root.format(file_name))
+    with open_url(remote_root.format(file_name)) as infile:
+        remote_data = infile.read()
+
     assert remote_data.splitlines() == local_data.splitlines()
 
 

--- a/tests/test_util/test_io.py
+++ b/tests/test_util/test_io.py
@@ -322,10 +322,13 @@ def test_open_url_local():
     """using file:///"""
     # None value for open_url mode defaults to "rb"
     file_name = "gff2_test.gff"
-    with open_(DATADIR / file_name) as infile:
+    local_path = DATADIR / file_name
+    with open_(local_path) as infile:
         local_data = infile.read()
 
-    with open_url(f"file://{DATADIR}/{file_name}") as infile:
+    # make absolute path but trim extra "/" at start
+    url = "/".join(local_path.absolute().parts)[1:]
+    with open_url(f"file://{url}") as infile:
         remote_data = infile.read()
 
     assert remote_data.splitlines() == local_data.splitlines()
@@ -342,7 +345,6 @@ def test_open_url_compressed():
     with open_(DATADIR / file_name) as infile:
         local_data = infile.read()
 
-    print(remote_root.format(file_name))
     with open_url(remote_root.format(file_name)) as infile:
         remote_data = infile.read()
 

--- a/tests/test_util/test_io.py
+++ b/tests/test_util/test_io.py
@@ -326,9 +326,8 @@ def test_open_url_local():
     with open_(local_path) as infile:
         local_data = infile.read()
 
-    # make absolute path but trim extra "/" at start
-    url = "/".join(local_path.absolute().parts)[1:]
-    with open_url(f"file://{url}") as infile:
+    # make absolute path
+    with open_url(local_path.absolute().as_uri()) as infile:
         remote_data = infile.read()
 
     assert remote_data.splitlines() == local_data.splitlines()


### PR DESCRIPTION
[NEW] this enables files to be downloaded from the web using the
    convenience functions,
    e.g. load_aligned_seqs("https://path/to/somefile.fasta")
    will now work.

[NEW] open_url() now supports "file://path/to/local/file". Mainly for
    testing purposes.

[CHANGED] tests of open_url() now only use 1 remote file to reduce
    test time.