### PR TITLE
DEP: refactor all apps to have a main() method, relates to #1071

### DIFF
--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -376,9 +376,9 @@ class align_to_ref(ComposableSeq):
             S=S, d=insertion_penalty, e=extension_penalty, return_score=False
         )
         if ref_seq.lower() == "longest":
-            self.main = self.align_to_longest
+            self._func = self.align_to_longest
         else:
-            self.main = self.align_to_named_seq
+            self._func = self.align_to_named_seq
             self._ref_name = ref_seq
 
         self._gap_state = None  # can be character or int, depends on aligner
@@ -410,6 +410,10 @@ class align_to_ref(ComposableSeq):
             pwise.append(((seq.name, aln)))
 
         return pairwise_to_multiple(pwise, ref_seq, self._moltype, info=seqs.info)
+
+    def main(self, seqs):
+        """return aligned sequences"""
+        return self._func(seqs)
 
 
 class progressive_align(ComposableSeq):
@@ -515,8 +519,6 @@ class progressive_align(ComposableSeq):
             show_progress=False,
         )
 
-        self.main = self.multiple_align
-
     def _build_guide(self, seqs):
         tree = self._make_tree(seqs)
         if self._scalar != 1:
@@ -524,7 +526,8 @@ class progressive_align(ComposableSeq):
             tree = scaler(tree)
         return tree
 
-    def multiple_align(self, seqs):
+    def main(self, seqs):
+        """returned progressively aligned sequences"""
         if self._moltype and self._moltype != seqs.moltype:
             seqs = seqs.to_moltype(self._moltype)
 
@@ -534,7 +537,7 @@ class progressive_align(ComposableSeq):
             diff = set(self._guide_tree.get_tip_names()) ^ set(seqs.names)
             if diff:
                 numtips = len(set(self._guide_tree.get_tip_names()))
-                print(f"numseqs={len(seqs.names)} not equal " f"to numtips={numtips}")
+                print(f"numseqs={len(seqs.names)} not equal to numtips={numtips}")
                 print(f"These were different: {diff}")
                 seqs = seqs.take_seqs(self._guide_tree.get_tip_names())
 

--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -172,7 +172,6 @@ class ComposableType:
 class Composable(ComposableType):
     def __init__(self, **kwargs):
         super(Composable, self).__init__(**kwargs)
-        # self.main = None  # over-ride in subclass
         self._in = None  # input rules
         self._out = None  # rules receiving output
         # rules operating on result but not part of a chain
@@ -458,7 +457,7 @@ class Composable(ComposableType):
                 # know it's NotCompleted.
                 # Note: we directly call .write() so NotCompleted's don't
                 # get blocked from being written by __call__()
-                outcome = self.write(data=result)
+                outcome = self.main(data=result)
                 if result and isinstance(outcome, DataStoreMember):
                     input_id = outcome.name
                 else:
@@ -638,7 +637,6 @@ class _checkpointable(Composable):
             data_path, suffix=suffix, create=create, if_exists=if_exists
         )
         self._callback = name_callback
-        self.main = self.write
 
         # override the following in subclasses
         self._format = None
@@ -662,7 +660,7 @@ class _checkpointable(Composable):
             exists = False
         return exists
 
-    def write(self, data) -> DataStoreMember:
+    def main(self, data) -> DataStoreMember:
         # over-ride in subclass
         raise NotImplementedError
 

--- a/src/cogent3/app/dist.py
+++ b/src/cogent3/app/dist.py
@@ -100,7 +100,6 @@ class fast_slow_dist(ComposableDistance):
         elif slow_calc:
             self._moltype = slow_calc.moltype
         self._sm = slow_calc
-        self.main = self.calc_distance
 
     def _est_dist_pair_slow(self, aln):
         """returns distance between seq pairs in aln"""
@@ -112,7 +111,7 @@ class fast_slow_dist(ComposableDistance):
         lf.optimise(max_restarts=0, show_progress=False)
         return 2 * lf.get_param_value("length", edge=aln.names[0])
 
-    def calc_distance(self, aln):
+    def main(self, aln):
         if self._moltype and self._moltype != aln.moltype:
             aln = aln.to_moltype(self._moltype)
 

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -180,10 +180,7 @@ def get_data_store(
 
 
 class _seq_loader:
-    def __init__(self):
-        self.main = self.load
-
-    def load(self, path):
+    def main(self, path):
         """returns alignment"""
         # if we get a seq object, we try getting abs_path from that now
         try:
@@ -230,7 +227,6 @@ class load_aligned(ComposableAligned, _seq_loader):
             output_types=self._output_types,
             data_types=self._data_types,
         )
-        _seq_loader.__init__(self)
         self._formatted_params()
         if moltype:
             moltype = get_moltype(moltype)
@@ -261,7 +257,6 @@ class load_unaligned(ComposableSeq, _seq_loader):
             output_types=self._output_types,
             data_types=self._data_types,
         )
-        _seq_loader.__init__(self)
         self._formatted_params()
         if moltype:
             moltype = get_moltype(moltype)
@@ -310,7 +305,6 @@ class load_tabular(ComposableTabular):
         self._with_title = with_title
         self._with_header = with_header
         self._limit = limit
-        self.main = self.load
         self.strict = strict
         self.as_type = as_type
 
@@ -360,7 +354,7 @@ class load_tabular(ComposableTabular):
         records = numpy.array(records, dtype="O").T
         return header, records, title
 
-    def load(self, path):
+    def main(self, path):
         if type(path) == str:
             # we use a data store as it's read() handles compression
             path = SingleReadDataStore(path)[0]
@@ -429,7 +423,7 @@ class write_tabular(_checkpointable, ComposableTabular):
         self._formatted_params()
         self._format = format
 
-    def write(self, data, identifier=None):
+    def main(self, data, identifier=None):
         from cogent3.app.composable import NotCompleted
 
         if isinstance(data, NotCompleted):
@@ -501,7 +495,7 @@ class write_seqs(_checkpointable):
         loader = loader(format=self._format)
         self._load_checkpoint = loader
 
-    def write(self, data, identifier=None):
+    def main(self, data, identifier=None):
         from cogent3.app.composable import NotCompleted
 
         if isinstance(data, NotCompleted):
@@ -539,9 +533,8 @@ class load_json(Composable):
         super(load_json, self).__init__(
             input_types=self._input_types, output_types=self._output_types
         )
-        self.main = self.read
 
-    def read(self, path):
+    def main(self, path):
         """returns object deserialised from json at path"""
         if type(path) == str:
             path = SingleReadDataStore(path)[0]
@@ -581,12 +574,11 @@ class write_json(_checkpointable):
             if_exists=if_exists,
             suffix=suffix,
         )
-        self.main = self.write
 
     def _set_checkpoint_loader(self):
         self._load_checkpoint = self
 
-    def write(self, data, identifier=None):
+    def main(self, data, identifier=None):
         from cogent3.app.composable import NotCompleted
 
         if isinstance(data, NotCompleted):
@@ -627,9 +619,8 @@ class load_db(Composable):
         super(load_db, self).__init__(
             input_types=self._input_types, output_types=self._output_types
         )
-        self.main = self.read
 
-    def read(self, identifier):
+    def main(self, identifier):
         """returns object deserialised from a TinyDb"""
         id_ = getattr(identifier, "id", None)
         if id_ is None:
@@ -673,12 +664,11 @@ class write_db(_checkpointable):
             suffix=suffix,
             writer_class=WritableTinyDbDataStore,
         )
-        self.main = self.write
 
     def _set_checkpoint_loader(self):
         self._load_checkpoint = self
 
-    def write(self, data, identifier=None):
+    def main(self, data, identifier=None):
         """
 
         Parameters

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -193,9 +193,8 @@ class select_translatable(ComposableSeq):
         self._gc = get_code(gc)
         self._allow_rc = allow_rc
         self._trim_terminal_stop = trim_terminal_stop
-        self.main = self.get_translatable
 
-    def get_translatable(self, seqs):
+    def main(self, seqs):
         """returns the translatable sequences from seqs.
 
         translation errors are stroed in the info object"""
@@ -272,9 +271,8 @@ class translate_seqs(ComposableSeq):
         self._moltype = moltype
         self._gc = get_code(gc)
         self._trim_terminal_stop = trim_terminal_stop
-        self.main = self.get_translated
 
-    def get_translated(self, seqs):
+    def main(self, seqs):
         """returns translated sequences"""
         if self._moltype and self._moltype != seqs.moltype:
             seqs = seqs.to_moltype(self._moltype)

--- a/src/cogent3/app/tree.py
+++ b/src/cogent3/app/tree.py
@@ -55,9 +55,8 @@ class scale_branches(ComposableTree):
 
         self._scalar = scalar
         self._min_length = min_length
-        self.main = self._scale_lengths
 
-    def _scale_lengths(self, tree):
+    def main(self, tree):
         scalar = self._scalar
         min_length = self._min_length
         tree = tree.deepcopy()
@@ -97,9 +96,8 @@ class uniformize_tree(ComposableTree):
         self._formatted_params()
         self._root_at = root_at
         self._ordered_names = ordered_names
-        self.main = self._uniformize
 
-    def _uniformize(self, tree):
+    def main(self, tree):
         if self._root_at == "midpoint":
             new = tree.root_at_midpoint()
         else:
@@ -135,10 +133,9 @@ class quick_tree(ComposableTree):
             data_types=self._data_types,
         )
         self._formatted_params()
-        self.main = self.quick_tree
         self._drop_invalid = drop_invalid
 
-    def quick_tree(self, dists):
+    def main(self, dists):
         """estimates a neighbor joining tree"""
         size = dists.shape[0]
         dists = dists.drop_invalid() if self._drop_invalid else dists

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -291,7 +291,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            got = writer.write(mca, identifier=outpath)
+            got = writer.main(mca, identifier=outpath)
             self.assertIsInstance(got, DataStoreMember)
             new = loader(outpath)
             # when written to file in tabular form
@@ -316,7 +316,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(mfa, identifier=outpath)
+            writer.main(mfa, identifier=outpath)
             new = loader(outpath)
             # when written to file in tabular form
             # the loaded table will have dim-1 dim-2 as column labels
@@ -349,7 +349,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(pssm, identifier=outpath)
+            writer.main(pssm, identifier=outpath)
             new = loader(outpath)
             expected = safe_log(data) - safe_log(numpy.array([0.25, 0.25, 0.25, 0.25]))
             for i in range(len(expected)):
@@ -366,7 +366,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(matrix, identifier=outpath)
+            writer.main(matrix, identifier=outpath)
             new = loader(outpath)
             # when written to file in tabular form
             # the loaded table will have dim-1 dim-2 as column labels
@@ -385,7 +385,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(table, identifier=outpath)
+            writer.main(table, identifier=outpath)
             new = loader(outpath)
             self.assertEqual(table.to_dict(), new.to_dict())
 
@@ -398,7 +398,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(mca, identifier=outpath)
+            writer.main(mca, identifier=outpath)
             new = loader(outpath)
             self.assertEqual(mca.to_dict(), new.to_dict())
 
@@ -411,7 +411,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(mfa, identifier=outpath)
+            writer.main(mfa, identifier=outpath)
             new = loader(outpath)
             self.assertEqual(mfa.to_dict(), new.to_dict())
 
@@ -431,7 +431,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(pssm, identifier=outpath)
+            writer.main(pssm, identifier=outpath)
             new = loader(outpath)
             assert_allclose(pssm.array, new.array, atol=0.0001)
 
@@ -443,7 +443,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(matrix, identifier=outpath)
+            writer.main(matrix, identifier=outpath)
             new = loader(outpath)
             self.assertEqual(matrix.to_dict(), new.to_dict())
 
@@ -455,7 +455,7 @@ class TestIo(TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             writer = io_app.write_tabular(data_path=dirname, format="tsv")
             outpath = join(dirname, "delme.tsv")
-            writer.write(table, identifier=outpath)
+            writer.main(table, identifier=outpath)
             new = loader(outpath)
             self.assertEqual(table.to_dict(), new.to_dict())
 

--- a/tests/test_app/test_tree.py
+++ b/tests/test_app/test_tree.py
@@ -64,7 +64,7 @@ class TestTree(TestCase):
         fast_slow_dist = dist.fast_slow_dist(fast_calc="hamming", moltype="dna")
         dist_matrix = fast_slow_dist(aln)
         quick1 = tree_app.quick_tree()
-        tree1 = quick1.quick_tree(dist_matrix)
+        tree1 = quick1(dist_matrix)
         self.assertEqual(set(tree1.get_tip_names()), set(aln.names))
 
     def test_composable_apps(self):
@@ -115,7 +115,7 @@ class TestTree(TestCase):
         }
 
         darr = DistanceMatrix(data)
-        tree = quick_tree.quick_tree(darr)
+        tree = quick_tree(darr)
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
@@ -145,7 +145,7 @@ class TestTree(TestCase):
             ("TombBat", "LittleBro"): 0.12,
         }
         darr = DistanceMatrix(data)
-        tree = quick_tree.quick_tree(darr)
+        tree = quick_tree(darr)
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
@@ -167,7 +167,7 @@ class TestTree(TestCase):
             ("BAA10469", "Avin_42730"): 1.85,
         }
         darr = DistanceMatrix(data)
-        tree = quick_tree.quick_tree(darr)
+        tree = quick_tree(darr)
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
@@ -190,12 +190,13 @@ class TestTree(TestCase):
         }
 
         darr = DistanceMatrix(data)
+        # must explicitly call main() method to avoid error trapping by Composable
         with self.assertRaises(KeyError):
-            tree = quick_tree.quick_tree(darr)
+            quick_tree.main(darr)
         # when distance_matrix is None after dropping invalid
         with self.assertRaises(ValueError):
             quick_tree = tree_app.quick_tree(drop_invalid=True)
-            tree = quick_tree.quick_tree(darr)
+            quick_tree.main(darr)
 
         data = {
             ("DogFaced", "FlyingFox"): 0.05,
@@ -220,7 +221,7 @@ class TestTree(TestCase):
             ("TombBat", "LittleBro"): 0.12,
         }
         darr = DistanceMatrix(data)
-        tree = quick_tree.quick_tree(darr)
+        tree = quick_tree(darr)
         self.assertIsInstance(tree, PhyloNode)
         self.assertIsNotNone(tree.children)
         self.assertEqual(
@@ -229,7 +230,7 @@ class TestTree(TestCase):
 
         data = {"a": {"b": 0.1, "a": 0.0}, "b": {"a": 0.1, "b": 0.0}}
         darr = DistanceMatrix(data)
-        tree = quick_tree.quick_tree(darr)
+        tree = quick_tree(darr)
         self.assertEqual(
             set(tree.get_tip_names()), set.union(*(set(tup) for tup in data))
         )


### PR DESCRIPTION
[CHANGED] no longer assign to a self.main attribute. This is required
    for us to define Composable.main as an abstract base class and method

Notes

There are two types of apps: apps for which there is only one possible
algorithm (e.g. cogent3.app.quick_tree); and, apps in which the algorithm
is selected based on args to the class constructor
(e.g. cogent3.app.sample.take_codon_positions). In the latter, I've chosen to
just create a separate self._func attribute which is called by <app>.main().