### PR TITLE
DEV remove test for _type attribute

### DIFF
--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -524,8 +524,6 @@ class load_json(Composable):
     """Loads json serialised cogent3 objects from a json file.
     Returns whatever object type was stored."""
 
-    _type = "output"
-
     _input_types = None
     _output_types = SERIALISABLE_TYPE
 
@@ -556,8 +554,6 @@ class load_json(Composable):
 
 class write_json(_checkpointable):
     """Writes json serialised objects to individual json files."""
-
-    _type = "output"
 
     _input_types = SERIALISABLE_TYPE
     _output_types = (IDENTIFIER_TYPE, SERIALISABLE_TYPE)
@@ -610,8 +606,6 @@ class load_db(Composable):
     """Loads json serialised cogent3 objects from a TinyDB file.
     Returns whatever object type was stored."""
 
-    _type = "output"
-
     _input_types = None
     _output_types = SERIALISABLE_TYPE
 
@@ -645,8 +639,6 @@ class load_db(Composable):
 
 class write_db(_checkpointable):
     """Writes json serialised objects to a TinyDB instance."""
-
-    _type = "output"
 
     _input_types = SERIALISABLE_TYPE
     _output_types = (IDENTIFIER_TYPE, SERIALISABLE_TYPE)

--- a/src/cogent3/app/result.py
+++ b/src/cogent3/app/result.py
@@ -26,7 +26,6 @@ __status__ = "Alpha"
 class generic_result(MutableMapping):
     """A dict style container for storing results."""
 
-    _type = "generic_result"
     _item_types = ()
 
     def __init__(self, source):
@@ -127,7 +126,6 @@ class generic_result(MutableMapping):
 class model_result(generic_result):
     """Storage of model results."""
 
-    _type = "model_result"
     _stat_attrs = ("lnL", "nfp", "DLC", "unique_Q")
     _item_types = ("AlignmentLikelihoodFunction",)
 
@@ -400,7 +398,6 @@ class model_result(generic_result):
 class model_collection_result(generic_result):
     """Storage of a collection of model_result."""
 
-    _type = "model_collection_result"
     _item_types = ("model_result",)
 
     def __init__(self, name=None, source=None):
@@ -523,7 +520,6 @@ class hypothesis_result(model_collection_result):
     """Storage of a collection of model_result instances that are hierarchically
     related."""
 
-    _type = "hypothesis_result"
     _item_types = ("model_result",)
 
     @extend_docstring_from(model_collection_result.__init__, pre=True)
@@ -622,7 +618,6 @@ class hypothesis_result(model_collection_result):
 
 
 class bootstrap_result(generic_result):
-    _type = "bootstrap_result"
     _item_types = ("hypothesis_result", "model_collection_result")
 
     def __init__(self, source=None):
@@ -651,7 +646,6 @@ class bootstrap_result(generic_result):
 class tabular_result(generic_result):
     """stores one or multiple cogent3 Tables, DictArray"""
 
-    _type = "tabular_result"
     _stat_attrs = ("header", "rows")
     _item_types = (
         "Table",

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -3748,7 +3748,6 @@ class ArrayAlignment(AlignmentI, _SequenceCollectionBase):
         self.array_seqs = transpose(self.array_positions)
         self.seq_data = self.array_seqs
         self.seq_len = len(self.array_positions)
-        self._type = self.moltype.get_type()
 
     def _force_same_data(self, data, names):
         """Forces array that was passed in to be used as selfarray_positions"""
@@ -4364,7 +4363,6 @@ class Alignment(_Annotatable, AlignmentI, SequenceCollection):
         names = self.names
 
         self._motif_probs = {}
-        self._type = self.moltype.get_type()
         lengths = list(map(len, self.seq_data))
         if lengths and (max(lengths) != min(lengths)):
             raise DataError(

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -64,7 +64,7 @@ class TestComposableBase(TestCase):
         aseqfunc1 = ComposableSeq(input_types="sequences", output_types="sequences")
         aseqfunc2 = ComposableSeq(input_types="sequences", output_types="sequences")
         comb = aseqfunc1 + aseqfunc2
-        expect = "ComposableSeq(type='sequences') + " "ComposableSeq(type='sequences')"
+        expect = "ComposableSeq() + " "ComposableSeq()"
         got = str(comb)
         self.assertEqual(got, expect)
 
@@ -273,7 +273,7 @@ class TestNotCompletedResult(TestCase):
         got = str(func)
         self.assertEqual(
             got,
-            "select_translatable(type='sequences', "
+            "select_translatable("
             "moltype='dna', gc=1, "
             "allow_rc=False,\ntrim_terminal_stop=True)",
         )
@@ -282,29 +282,29 @@ class TestNotCompletedResult(TestCase):
         got = str(func)
         self.assertEqual(
             got,
-            "select_translatable(type='sequences', "
+            "select_translatable("
             "moltype='dna', gc=1, "
-            "allow_rc=True,\ntrim_terminal_stop=True)",
+            "allow_rc=True, trim_terminal_stop=True)",
         )
 
         nodegen = omit_degenerates()
         got = str(nodegen)
         self.assertEqual(
             got,
-            "omit_degenerates(type='aligned', moltype=None, "
-            "gap_is_degen=True,\nmotif_length=1)",
+            "omit_degenerates(moltype=None, "
+            "gap_is_degen=True, motif_length=1)",
         )
         ml = min_length(100)
         got = str(ml)
         self.assertEqual(
             got,
-            "min_length(type='sequences', length=100, "
-            "motif_length=1, subtract_degen=True,\n"
+            "min_length(length=100, "
+            "motif_length=1, subtract_degen=True, "
             "moltype=None)",
         )
 
         qt = quick_tree()
-        self.assertEqual(str(qt), "quick_tree(type='tree', drop_invalid=False)")
+        self.assertEqual(str(qt), "quick_tree(drop_invalid=False)")
 
 
 class TestPicklable(TestCase):

--- a/tests/test_app/test_dist.py
+++ b/tests/test_app/test_dist.py
@@ -125,7 +125,6 @@ class FastSlowDistTests(TestCase):
             # Compose two composable applications, there should not be exceptions.
             got = app + fast_slow_dist
             self.assertIsInstance(got, dist_app.fast_slow_dist)
-            self.assertEqual(got._type, "distance")
             self.assertIs(got.input, app)
             self.assertIs(got.output, None)
             self.assertIsInstance(got._input_types, frozenset)

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -38,7 +38,7 @@ class TestModel(TestCase):
         model = evo_app.model("HKY85", time_het="max")
         got = " ".join(str(model).splitlines())
         expect = (
-            "model(type='model', sm='HKY85', tree=None, unique_trees=False, "
+            "model(sm='HKY85', tree=None, unique_trees=False, "
             "name=None, optimise_motif_probs=False, sm_args=None, lf_args=None, "
             "time_het='max', param_rules=None, "
             "opt_args=None, upper=50, split_codons=False, "
@@ -268,8 +268,8 @@ class TestModel(TestCase):
         hyp = evo_app.hypothesis(model1, model2)
         got = " ".join(str(hyp).splitlines())
         expect = (
-            "hypothesis(type='hypothesis', null='HKY85', "
-            "alternates=(model(type='model', sm='HKY85', tree=None, unique_trees=False, "
+            "hypothesis(null='HKY85', "
+            "alternates=(model(sm='HKY85', tree=None, unique_trees=False, "
             "name='hky85-max-het', optimise_motif_probs=False, sm_args=None, lf_args=None, "
             "time_het='max', param_rules=None, opt_args=None, upper=50,"
             " split_codons=False, show_progress=False, verbose=False),),"

--- a/tests/test_app/test_tree.py
+++ b/tests/test_app/test_tree.py
@@ -76,12 +76,11 @@ class TestTree(TestCase):
         proc = fast_slow_dist + quick
         self.assertEqual(
             str(proc),
-            "fast_slow_dist(type='distance', distance=None, moltype='dna',\n"
-            "fast_calc='hamming', slow_calc=None) + quick_tree(type='tree',\n"
+            "fast_slow_dist(distance=None, moltype='dna', "
+            "fast_calc='hamming',\nslow_calc=None) + quick_tree("
             "drop_invalid=False)",
         )
         self.assertIsInstance(proc, tree_app.quick_tree)
-        self.assertEqual(proc._type, "tree")
         self.assertIsInstance(proc.input, dist.fast_slow_dist)
         self.assertIs(proc.output, None)
         self.assertIsInstance(proc._input_types, frozenset)


### PR DESCRIPTION
@GavinHuttley 
I removed all cases of `_type` in tests. But this commit is **not** ready to merge.
Please look at this function. It cannot find `loader` when we don't have `_type` attribute. Please help me how to solve this.

```
def _set_checkpoint_loader(self):
        loader = {"sequences": load_unaligned}.get(self._out._type, load_aligned)
        loader = loader(format=self._format)
        self._load_checkpoint = loader
```