### PR TITLE
ENH: add app registry to composable decorator

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -951,6 +951,9 @@ class _connected:
         self.storage[id(instance)] = value
 
 
+__app_registry = {}
+
+
 def composable(klass=None, *, app_type: AppType = GENERIC):
     app_type = AppType(app_type)
 
@@ -1019,6 +1022,8 @@ def composable(klass=None, *, app_type: AppType = GENERIC):
         if hasattr(klass, "__slots__"):
             klass.__slots__ += tuple(slot_attrs)
 
+        # register this app
+        __app_registry[get_object_provenance(klass)] = klass.__name__
         return klass
 
     return wrapped(klass) if klass else wrapped

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -16,6 +16,7 @@ from cogent3.app.composable import (
     Composable,
     NotCompleted,
     appify,
+    composable,
     user_function,
 )
 from cogent3.app.sample import min_length, omit_degenerates
@@ -473,6 +474,19 @@ class TestUserFunction(TestCase):
             product, SERIALISABLE_TYPE, SERIALISABLE_TYPE, 2, take_log=True
         )
         self.assertEqual(ufunc(2), log(4))
+
+
+def test_app_registry():
+    """correctly registers apps"""
+
+    @composable
+    class foo:
+        def main(self, data: int) -> int:
+            return data
+
+    from cogent3.app.composable import __app_registry
+
+    assert __app_registry["test_composable.foo"] == "foo"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[NEW] module level dictionary that records apps during decoration
    by their object provenance. This means a 3rd party developer
    could develop an app with the same class name, it would be
    distinguished by it's full provenance.