### PR TITLE
TST: updated test to reflect fundamental change to str representation of apps

### DIFF
--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -263,7 +263,6 @@ class TestModel(TestCase):
         pval = str(result).splitlines()[4].split()[-1]
         self.assertTrue(re.search(r"[0-9\.]+e-\d+", pval) is not None)
 
-    @pytest.mark.xfail
     def test_hypothesis_str(self):
         """correct str representation"""
         model1 = evo_app.model("HKY85")
@@ -271,11 +270,14 @@ class TestModel(TestCase):
         hyp = evo_app.hypothesis(model1, model2)
         got = " ".join(str(hyp).splitlines())
         expect = (
-            "hypothesis(null='HKY85', "
-            "alternates=(model(sm='HKY85', tree=None, unique_trees=False, "
+            "hypothesis(null=model(sm='HKY85', tree=None, unique_trees=False, "
+            "name=None, optimise_motif_probs=False, sm_args=None, lf_args=None, "
+            "time_het=None, param_rules=None, opt_args=None, upper=50, "
+            "split_codons=False, show_progress=False, verbose=False), "
+            "alternates=model(sm='HKY85', tree=None, unique_trees=False, "
             "name='hky85-max-het', optimise_motif_probs=False, sm_args=None, lf_args=None, "
             "time_het='max', param_rules=None, opt_args=None, upper=50,"
-            " split_codons=False, show_progress=False, verbose=False),),"
+            " split_codons=False, show_progress=False, verbose=False),"
             " sequential=True, init_alt=None)"
         )
         self.assertEqual(got, expect)


### PR DESCRIPTION
[CHANGED] The interception of constructor arguments using __new__ means we no
    longer have a per class customised representation. This required some tweaking of
    test to accomodate changed behaviour of the evo.hypothesis app.