### PR TITLE
ENH: suppress numba debug logging

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -100,6 +100,14 @@ if warn_env in os.environ:
     warnings.simplefilter(os.environ[warn_env])
 
 
+import logging
+
+
+# suppress numba warnings
+__numba_logger = logging.getLogger("numba")
+__numba_logger.setLevel(logging.WARNING)
+
+
 def make_seq(seq, name=None, moltype=None):
     """
     Parameters


### PR DESCRIPTION
[CHANGED] at some point, numba debugging messages became switched on by
    default. In our case, this leads to massive log files for composable
    apps. Turning this off in cogent3.__init__ until a better solution
    arises.