### PR TITLE
ENH: support string literal type hints

### DIFF
--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -96,7 +96,6 @@ def TreeAlign(
                 1e-9, edge.length or 0
             )  # catch case where edge has no length
 
-
     LF = model.make_likelihood_function(
         tree.bifurcating(name_unnamed=True), aligned=False
     )

--- a/src/cogent3/app/typing.py
+++ b/src/cogent3/app/typing.py
@@ -19,7 +19,15 @@ __status__ = "Alpha"
 AlignedSeqsType = TypeVar("AlignedSeqsType", "Alignment", "ArrayAlignment")
 UnalignedSeqsType = TypeVar("UnalignedSeqsType", bound="SequenceCollection")
 SeqsCollectionType = Union[AlignedSeqsType, UnalignedSeqsType]
-SeqType = TypeVar("SeqType", bound="Sequence")
+SeqType = TypeVar(
+    "SeqType",
+    "Sequence",
+    "DnaSequence",
+    "RnaSequence",
+    "ByteSequence",
+    "ProteinSequence",
+    "ProteinWithStopSequence",
+)
 PairwiseDistanceType = TypeVar("PairwiseDistanceType", bound="DistanceMatrix")
 TabularType = TypeVar("TabularType", "Table", "DictArray", "DistanceMatrix")
 TreeType = TypeVar("TreeType", "TreeNode", "PhyloNode")
@@ -91,6 +99,10 @@ def get_constraint_names(*hints) -> set[str, ...]:
 
         if type(hint) == type:
             all_hints.add(hint.__name__)
+        elif type(hint) == ForwardRef:
+            all_hints.add(hint.__forward_arg__)
+        elif type(hint) == str:
+            all_hints.add(hint)
 
     all_hints = {h.__forward_arg__ if type(h) == ForwardRef else h for h in all_hints}
     return all_hints

--- a/tests/test_app/test_typing.py
+++ b/tests/test_app/test_typing.py
@@ -86,6 +86,13 @@ def test_hints_from_strings():
     assert got == [SerialisableType, AlignedSeqsType]
 
 
+def test_hints_resolved_from_str():
+    got = get_constraint_names("DnaSequence")
+    assert got == {"DnaSequence"}
+    got = get_constraint_names(Union[SerialisableType, "DnaSequence"])
+    assert got == {"SerialisableType", "DnaSequence"}
+
+
 @pytest.mark.parametrize("container", (List, Tuple))
 def test_hints_from_container_type(container):
     got = get_constraint_names(container[AlignedSeqsType])


### PR DESCRIPTION
[NEW] allows foo(name: "some_type")

[CHANGED] add constraints for SeqType