### PR TITLE
BUG: non stationary independent tuple models can now be serialised

### DIFF
--- a/src/cogent3/evolve/ns_substitution_model.py
+++ b/src/cogent3/evolve/ns_substitution_model.py
@@ -153,39 +153,47 @@ class DiscreteSubstitutionModel(_SubstitutionModel):
         )
 
 
+# todo inheritance hierarchy and constructor signatures
+# should match that of the stationary models
 class NonReversibleNucleotide(Parametric):
     """Base non-reversible nucleotide substitution model."""
 
     @extend_docstring_from(Parametric.__init__)
-    def __init__(self, *args, **kw):
-        Parametric.__init__(self, moltype.DNA.alphabet, *args, **kw)
+    def __init__(self, predicates=None, *args, **kw):
+        kw["alphabet"] = kw.get("alphabet", moltype.DNA.alphabet)
+        kw["predicates"] = predicates
+        Parametric.__init__(self, *args, **kw)
 
 
-class NonReversibleDinucleotide(Parametric):
+class NonReversibleDinucleotide(NonReversibleNucleotide):
     """Base non-reversible dinucleotide substitution model."""
 
     @extend_docstring_from(Parametric.__init__)
-    def __init__(self, *args, **kw):
-        Parametric.__init__(self, moltype.DNA.alphabet, motif_length=2, *args, **kw)
+    def __init__(self, predicates=None, *args, **kw):
+        kw["predicates"] = predicates
+        kw["motif_length"] = 2
+        NonReversibleNucleotide.__init__(self, *args, **kw)
 
 
-class NonReversibleTrinucleotide(Parametric):
+class NonReversibleTrinucleotide(NonReversibleNucleotide):
     """Base non-reversible trinucleotide substitution model."""
 
     @extend_docstring_from(Parametric.__init__)
-    def __init__(self, *args, **kw):
-        Parametric.__init__(self, moltype.DNA.alphabet, motif_length=3, *args, **kw)
+    def __init__(self, predicates=None, *args, **kw):
+        kw["predicates"] = predicates
+        kw["motif_length"] = 3
+        NonReversibleNucleotide.__init__(self, *args, **kw)
 
 
-class NonReversibleCodon(_Codon, Parametric):
+class NonReversibleCodon(_Codon, NonReversibleNucleotide):
     """Base non-reversible codon substitution model."""
 
     @extend_docstring_from(Parametric.__init__)
     def __init__(self, alphabet=None, gc=None, **kw):
         if gc is not None:
             alphabet = moltype.CodonAlphabet(gc=gc)
-        alphabet = alphabet or moltype.STANDARD_CODON
-        Parametric.__init__(self, alphabet, **kw)
+        kw["alphabet"] = alphabet or moltype.STANDARD_CODON
+        NonReversibleNucleotide.__init__(self, **kw)
 
 
 class StrandSymmetric(NonReversibleNucleotide):

--- a/src/cogent3/util/deserialise.py
+++ b/src/cogent3/util/deserialise.py
@@ -292,7 +292,8 @@ def deserialise_substitution_model(data):
     if sm is None:
         alphabet = deserialise_alphabet(data.pop("alphabet"))
         klass = _get_class(data.pop("type"))
-        sm = klass(alphabet, **data)
+        data["alphabet"] = alphabet
+        sm = klass(**data)
 
     return sm
 

--- a/tests/test_util/test_deserialise.py
+++ b/tests/test_util/test_deserialise.py
@@ -18,6 +18,11 @@ from cogent3 import (
 from cogent3.app.result import model_collection_result, model_result
 from cogent3.core import alignment, moltype
 from cogent3.evolve.models import get_model
+from cogent3.evolve.ns_substitution_model import (
+    NonReversibleDinucleotide,
+    NonReversibleTrinucleotide,
+    _sym_preds,
+)
 from cogent3.util.deserialise import (
     deserialise_likelihood_function,
     deserialise_object,
@@ -123,6 +128,18 @@ class TestDeserialising(TestCase):
         got = deserialise_object(data)
         self.assertEqual(got.to_rich_dict(), sm.to_rich_dict())
         sm = get_model("CNFGTR")
+        data = sm.to_json()
+        got = deserialise_object(data)
+        self.assertEqual(got.to_rich_dict(), sm.to_rich_dict())
+        sm = get_model("GNC")
+        data = sm.to_json()
+        got = deserialise_object(data)
+        self.assertEqual(got.to_rich_dict(), sm.to_rich_dict())
+        sm = NonReversibleDinucleotide(_sym_preds)
+        data = sm.to_json()
+        got = deserialise_object(data)
+        self.assertEqual(got.to_rich_dict(), sm.to_rich_dict())
+        sm = NonReversibleTrinucleotide(_sym_preds)
         data = sm.to_json()
         got = deserialise_object(data)
         self.assertEqual(got.to_rich_dict(), sm.to_rich_dict())


### PR DESCRIPTION
[FIXED] key-word arguments were being serialised both at
    the constructor level and within the generic ``kw`` argument
    setting. These are now purged within the `MODEL.to_rich_dict()`
    method. But that just exposed a difgerent issue -- the stationary
    and non-stationary substitution model classes are inconsistent
    in their inheritance hierarchy, and constructor signatures for
    alphabets and predicates. This will need revisiting.

[CHANGED] non-stationary nucleotide based models now inherit from
    NonReversibleNucleotide

[CHANGED] deserialise_model uses alphabet as kw, not arg

[NEW] add more tests for the non-stationary models

Thanks @StephenRogers1 for identifying this issue!