### PR TITLE
TST: test the likelihood function get_param_interval method

### DIFF
--- a/src/cogent3/recalculation/scope.py
+++ b/src/cogent3/recalculation/scope.py
@@ -729,7 +729,7 @@ class ParameterController(object):
     def get_param_interval(self, par_name, *args, **kw):
         """Confidence interval for 'par_name' found by adjusting the
         single parameter until the final result falls by 'dropoff', which
-        can be specified directly or via 'p' as chi2.isf(1, p).  Additional
+        can be specified directly or via 'p' as chi2.isf(p, 1).  Additional
         arguments are taken to specify the scope."""
         dropoff = kw.pop("dropoff", None)
         p = kw.pop("p", None)
@@ -764,7 +764,8 @@ class ParameterController(object):
         """Make a setting -> value function"""
         if p is not None:
             assert dropoff is None, (p, dropoff)
-            dropoff = chi2.isf(1, p) / 2.0
+            dropoff = chi2.isf(p, 1) / 2.0
+
         if dropoff is None:
 
             def callback(defn, posn):

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -326,6 +326,19 @@ class LikelihoodCalcs(TestCase):
         evolve_lnL = likelihood_function.get_log_likelihood()
         assert_allclose(evolve_lnL, -91.35162044257062)
 
+    def test_get_param_interval(self):
+        """get param interval succeeds"""
+        tree = load_tree("data/primate_brca1.tree")
+        aln = load_aligned_seqs("data/primate_brca1.fasta")
+        sm = get_model("HKY85")
+        lf = sm.make_likelihood_function(tree)
+        lf.set_alignment(aln)
+        lf.optimise(
+            local=True, show_progress=False, max_evaluations=10, limit_action="ignore"
+        )
+        kappa_lo, kappa_mle, kappa_hi = lf.get_param_interval("kappa")
+        assert kappa_lo < kappa_mle < kappa_hi
+
 
 class LikelihoodFunctionTests(TestCase):
     """tests for a tree analysis class. Various tests to create a tree analysis class,


### PR DESCRIPTION
[FIXED] correct argument order in using scipy.stats.distributions.chi2,
    quantile first, then df

[NEW] add explicit test