### PR TITLE
MAINT: changes to allow testing of append to data store

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -56,9 +56,8 @@ def _make_logfile_name(process):
     text = re.split(r"\s+\+\s+", text)
     parts = [part[: part.find("(")] for part in text]
     result = "-".join(parts)
-    pid = os.getpid()
-    result = f"{result}-pid{pid}.log"
-    return result
+    uid = str(uuid4())
+    return f"{result}-{uid[:8]}.log"
 
 
 def _get_origin(origin):


### PR DESCRIPTION
[CHANGED] refactor the composable._make_logfile_name function so it
    generates unique log ID's even if called on the same thread. Instead
    of using the process ID, it puts the first 8 characters of a uuid4
    string onto the end of the name.

[NEW] test that append operation creates a new logfile for directory
    and sqlite data stores