### PR TITLE
MAINT: correct log file name generating function

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -55,8 +55,8 @@ def _make_logfile_name(process):
     text = re.split(r"\s+\+\s+", str(process))
     parts = []
     for part in text:
-        if index := part.find("(") >= 0:
-            part = part[:index]
+        if part.find("(") >= 0:
+            part = part[: part.find("(")]
         parts.append(part)
     result = "-".join(parts)
     uid = str(uuid4())


### PR DESCRIPTION
[CHANGED] revert effect of previous refactor which was causing
     truncation to single characters