### PR TITLE
ENH: improved sqlitedb describe table title

### DIFF
--- a/src/cogent3/app/sqlite_data_store.py
+++ b/src/cogent3/app/sqlite_data_store.py
@@ -384,8 +384,10 @@ class DataStoreSqlite(DataStoreABC):
 
     @property
     def describe(self):
-        if self.locked:
+        if self.locked and self._lock_id != os.getpid():
             title = f"Locked db store. Locked to pid={self._lock_id}, current pid={os.getpid()}."
+        elif self.locked:
+            title = "Locked to the current process."
         else:
             title = "Unlocked db store."
         table = super().describe


### PR DESCRIPTION
[CHANGED] If a data store is locked to the current process
    then state this, the process ID is not needed.