### PR TITLE
BUG: app.get_app() works for apps with a name keyword arg

### DIFF
--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -158,12 +158,12 @@ def _get_app_matching_name(name: str):
     return getattr(mod, name)
 
 
-def get_app(name: str, *args, **kwargs):
+def get_app(_app_name: str, *args, **kwargs):
     """returns app instance, use app_help() to display arguments
 
     Parameters
     ----------
-    name
+    _app_name
         app name, e.g. 'minlength', or can include module information,
         e.g. 'cogent3.app.sample.minlength' or 'sample.minlength'. Use the
         latter (qualified class name) style when there are multiple matches
@@ -180,7 +180,7 @@ def get_app(name: str, *args, **kwargs):
     NameError when multiple apps have the same name. In that case use a
     qualified class name, as shown above.
     """
-    return _get_app_matching_name(name)(*args, **kwargs)
+    return _get_app_matching_name(_app_name)(*args, **kwargs)
 
 
 def _make_head(text: str) -> list[str]:

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -155,6 +155,12 @@ def test_get_app(name):
     assert app.__class__.__name__.endswith(name.split(".")[-1])
 
 
+def test_get_app_kwargs():
+    # when an app has a name kwarg
+    # we should still be able to use get_app!
+    _ = get_app("model", "F81", name="F81-model")
+
+
 @define_app
 def min_length(val: int) -> int:
     return val


### PR DESCRIPTION
[FIXED] renamed local variable to _app_name to minimise the chance of
    TypeError