### PR TITLE
TST: added tests of SeqView to address coverage gaps

### DIFF
--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1548,9 +1548,7 @@ class SeqView:
         else:
             start = self.start + len(self) * self.step + slice_start * self.step
 
-        if slice_stop > len(self.seq):
-            return _zero_slice
-        elif slice_stop >= 0:
+        if slice_stop >= 0:
             stop = self.start + slice_stop * self.step
         else:  # slice_stop < 0
             stop = self.start + len(self) * self.step + slice_stop * self.step


### PR DESCRIPTION
TST:
- added `test_subsequent_slice_neg_step` to ensure all conditions with negative steps are being tested
- added `test_seqview_step_0` to test that a slice with a step of 1 throws a `ValueError`
- added `test_seqview_repr` to test the representation of a SeqView object 

BUG: 
- removed untested condition that was both unnecessary and incorrect!