### PR TITLE
DEP: `cogent3.parse.genbank.Location` refactor

### DIFF
--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -427,7 +427,7 @@ class Location(object):
         except TypeError:
             return self._data[-1].stop
 
-    def first(self):
+    def first(self):  # pragma: no cover
         from cogent3.util.warning import deprecated
 
         deprecated(
@@ -440,7 +440,7 @@ class Location(object):
 
         return self.start
 
-    def last(self):
+    def last(self):  # pragma: no cover
         from cogent3.util.warning import deprecated
 
         deprecated(
@@ -456,50 +456,28 @@ class Location(object):
 class LocationList(list):
     """List of Location objects."""
 
-    BIGNUM = 1e300
-
-    def start(self):
+    def first(self):  # pragma: no cover
         """Returns first base of self."""
-        curr = self.BIGNUM
-        for i in self:
-            start = i.start
-            if curr > start:
-                curr = start
-        return curr
+        from cogent3.util.warning import discontinued
 
-    def stop(self):
-        """Returns last base of self."""
-        curr = 0
-        for i in self:
-            stop = i.stop
-            if stop > curr:
-                curr = stop
-        return curr
-
-    def first(self):
-        from cogent3.util.warning import deprecated
-
-        deprecated(
+        discontinued(
             "method",
             "LocationList.first",
-            "LocationList.start",
             "2023.06.15",
-            "Warning: '.start' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
         )
 
-        return self.start + 1
+        return min(self, key=lambda x: x.start) + 1
 
-    def last(self):
-        from cogent3.util.warning import deprecated
+    def last(self):  # pragma: no cover
+        """Returns last base of self."""
+        from cogent3.util.warning import discontinued
 
-        deprecated(
+        discontinued(
             "method",
             "LocationList.last",
-            "LocationList.stop",
             "2023.06.15",
-            "Warning: '.stop' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
         )
-        return self.stop + 1
+        return max(self, key=lambda x: x.stop) + 1
 
     @property
     def strand(self):

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -307,7 +307,7 @@ class Location(object):
     is_between should be False (the default), or True.
     is_bounds should be False(the default, indicates range), or True.
     accession should be an accession, or None (default).
-    Db should be a database identifier, or None (default).
+    db should be a database identifier, or None (default).
     Strand should be 1 (forward, default) or -1 (reverse).
 
     WARNING: This Location will allow you to do things that can't happen in
@@ -325,7 +325,7 @@ class Location(object):
         is_between=False,
         is_bounds=False,
         accession=None,
-        Db=None,
+        db=None,
         Strand=1,
         **kwargs,
     ):
@@ -340,7 +340,7 @@ class Location(object):
         self.is_between = is_between
         self.is_bounds = is_bounds
         self.accession = accession
-        self.Db = Db
+        self.db = db
         self.Strand = Strand
 
         dep_arg_map = {
@@ -348,7 +348,8 @@ class Location(object):
             "IsBetween": "is_between",
             "IsBounds": "is_bounds",
             "Accession": "accession",
-        }  # map between deprecated argument name and current argument name
+            "Db": "db",
+        }  # map between deprecated argument name and PEP8 compliant argument name
         for dep_arg, arg in dep_arg_map.items():
             if dep_arg in kwargs:
                 setattr(self, arg, kwargs.pop(dep_arg))
@@ -395,9 +396,9 @@ class Location(object):
         # check if we need to add on the accession and database
         if self.accession:
             curr = self.accession + ":" + curr
-            # we're only going to add the Db if we got an accession
-            if self.Db:
-                curr = self.Db + "::" + curr
+            # we're only going to add the db if we got an accession
+            if self.db:
+                curr = self.db + "::" + curr
         # check if it's complemented
         if self.Strand == -1:
             curr = f"complement({curr})"

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -411,19 +411,21 @@ class Location(object):
             curr = f"complement({curr})"
         return curr
 
+    @property
     def start(self):
         """Returns first base self could be."""
         try:
             return int(self._data) - 1
         except TypeError:
-            return self._data[0].start()
+            return self._data[0].start
 
+    @property
     def stop(self):
         """Returns last base self could be."""
         try:
             return int(self._data) - 1
         except TypeError:
-            return self._data[-1].stop()
+            return self._data[-1].stop
 
     def first(self):
         from cogent3.util.warning import deprecated
@@ -433,10 +435,10 @@ class Location(object):
             "Location.first",
             "Location.start",
             "2023.06.15",
-            "Warning: '.start()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+            "Warning: '.start' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
         )
 
-        return self.start()
+        return self.start
 
     def last(self):
         from cogent3.util.warning import deprecated
@@ -446,9 +448,9 @@ class Location(object):
             "Location.last",
             "Location.stop",
             "2023.06.15",
-            "Warning: '.stop()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+            "Warning: '.stop' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
         )
-        return self.stop()
+        return self.stop
 
 
 class LocationList(list):
@@ -460,7 +462,7 @@ class LocationList(list):
         """Returns first base of self."""
         curr = self.BIGNUM
         for i in self:
-            start = i.start()
+            start = i.start
             if curr > start:
                 curr = start
         return curr
@@ -469,7 +471,7 @@ class LocationList(list):
         """Returns last base of self."""
         curr = 0
         for i in self:
-            stop = i.stop()
+            stop = i.stop
             if stop > curr:
                 curr = stop
         return curr
@@ -482,10 +484,10 @@ class LocationList(list):
             "LocationList.first",
             "LocationList.start",
             "2023.06.15",
-            "Warning: '.start()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+            "Warning: '.start' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
         )
 
-        return self.start() + 1
+        return self.start + 1
 
     def last(self):
         from cogent3.util.warning import deprecated
@@ -495,10 +497,11 @@ class LocationList(list):
             "LocationList.last",
             "LocationList.stop",
             "2023.06.15",
-            "Warning: '.stop()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+            "Warning: '.stop' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
         )
-        return self.stop() + 1
+        return self.stop + 1
 
+    @property
     def strand(self):
         """Returns strand of components: 1=forward, -1=reverse, 0=both"""
         curr = {}
@@ -522,7 +525,7 @@ class LocationList(list):
         """Extracts pieces of self from sequence."""
         result = []
         for i in self:
-            start, stop = i.start(), i.stop() + 1  # inclusive, not exclusive
+            start, stop = i.start, i.stop + 1  # inclusive, not exclusive
             # translate to 0-based indices and check if it wraps around
             if start < stop:
                 curr = sequence[start:stop]
@@ -753,7 +756,7 @@ def RichGenbankParser(
             if feature["location"] is None or feature["type"] in ["source", "organism"]:
                 continue
             for location in feature["location"]:
-                (lo, hi) = (location.start(), location.stop() + 1)
+                (lo, hi) = (location.start, location.stop + 1)
                 if location.strand == -1:
                     (lo, hi) = (hi, lo)
                     assert reversed is not False

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -358,7 +358,7 @@ class Location(object):
                 from cogent3.util.warning import deprecated
 
                 deprecated(
-                    "Argument",
+                    "argument",
                     dep_arg,
                     arg,
                     "2023.06.15",
@@ -405,19 +405,44 @@ class Location(object):
             curr = f"complement({curr})"
         return curr
 
-    def first(self):
+    def start(self):
         """Returns first base self could be."""
         try:
-            return int(self._data)
+            return int(self._data) - 1
         except TypeError:
-            return self._data[0].first()
+            return self._data[0].start()
 
-    def last(self):
+    def stop(self):
         """Returns last base self could be."""
         try:
-            return int(self._data)
+            return int(self._data) - 1
         except TypeError:
-            return self._data[-1].last()
+            return self._data[-1].stop()
+
+    def first(self):
+        from cogent3.util.warning import deprecated
+
+        deprecated(
+            "method",
+            "Location.first",
+            "Location.start",
+            "2023.06.15",
+            "Warning: '.start()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+        )
+
+        return self.start()
+
+    def last(self):
+        from cogent3.util.warning import deprecated
+
+        deprecated(
+            "method",
+            "Location.last",
+            "Location.stop",
+            "2023.06.15",
+            "Warning: '.stop()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+        )
+        return self.stop()
 
 
 class LocationList(list):
@@ -428,23 +453,48 @@ class LocationList(list):
 
     BIGNUM = 1e300
 
-    def first(self):
+    def start(self):
         """Returns first base of self."""
         curr = self.BIGNUM
         for i in self:
-            first = i.first()
-            if curr > first:
-                curr = first
+            start = i.start()
+            if curr > start:
+                curr = start
         return curr
 
-    def last(self):
+    def stop(self):
         """Returns last base of self."""
         curr = 0
         for i in self:
-            last = i.last()
-            if last > curr:
-                curr = last
+            stop = i.stop()
+            if stop > curr:
+                curr = stop
         return curr
+
+    def first(self):
+        from cogent3.util.warning import deprecated
+
+        deprecated(
+            "method",
+            "LocationList.first",
+            "LocationList.start",
+            "2023.06.15",
+            "Warning: '.start()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+        )
+
+        return self.start() + 1
+
+    def last(self):
+        from cogent3.util.warning import deprecated
+
+        deprecated(
+            "method",
+            "LocationList.last",
+            "LocationList.stop",
+            "2023.06.15",
+            "Warning: '.stop()' is changed to reflect 0-based coordinated, previous implementation reflected 1-based coordinates",
+        )
+        return self.stop() + 1
 
     def strand(self):
         """Returns strand of components: 1=forward, -1=reverse, 0=both"""
@@ -469,12 +519,12 @@ class LocationList(list):
         """Extracts pieces of self from sequence."""
         result = []
         for i in self:
-            first, last = i.first() - 1, i.last()  # inclusive, not exclusive
+            start, stop = i.start(), i.stop() + 1  # inclusive, not exclusive
             # translate to 0-based indices and check if it wraps around
-            if first < last:
-                curr = sequence[first:last]
+            if start < stop:
+                curr = sequence[start:stop]
             else:
-                curr = sequence[first:] + sequence[:last]
+                curr = sequence[start:] + sequence[:stop]
             # reverse-complement if necessary
             if i.strand == -1:
                 curr = curr.translate(trans_table)[::-1]
@@ -700,7 +750,7 @@ def RichGenbankParser(
             if feature["location"] is None or feature["type"] in ["source", "organism"]:
                 continue
             for location in feature["location"]:
-                (lo, hi) = (location.first() - 1, location.last())
+                (lo, hi) = (location.start(), location.stop() + 1)
                 if location.strand == -1:
                     (lo, hi) = (hi, lo)
                     assert reversed is not False

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -305,7 +305,7 @@ class Location(object):
         sequence of two BasePosition objects. It can _not_ be two numbers.
     ambiguity should be None (the default), '>', or '<'.
     is_between should be False (the default), or True.
-    IsBounds should be False(the default, indicates range), or True.
+    is_bounds should be False(the default, indicates range), or True.
     Accession should be an accession, or None (default).
     Db should be a database identifier, or None (default).
     Strand should be 1 (forward, default) or -1 (reverse).
@@ -323,7 +323,7 @@ class Location(object):
         data,
         ambiguity=None,
         is_between=False,
-        IsBounds=False,
+        is_bounds=False,
         Accession=None,
         Db=None,
         Strand=1,
@@ -338,7 +338,7 @@ class Location(object):
         self._data = data
         self.ambiguity = ambiguity
         self.is_between = is_between
-        self.IsBounds = IsBounds
+        self.is_bounds = is_bounds
         self.Accession = Accession
         self.Db = Db
         self.Strand = Strand
@@ -346,6 +346,7 @@ class Location(object):
         dep_arg_map = {
             "Ambiguity": "ambiguity",
             "IsBetween": "is_between",
+            "IsBounds": "is_bounds"
         }  # map between deprecated argument name and current argument name
         for dep_arg, arg in dep_arg_map.items():
             if dep_arg in kwargs:
@@ -386,7 +387,7 @@ class Location(object):
                 # if long conversion failed, should have two LocalLocation
                 # objects
                 first, last = self._data
-                if self.IsBounds:
+                if self.is_bounds:
                     curr = f"({first}{'.'}{last})"
                 else:
                     curr = f"{first}{'..'}{last}"

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -4,10 +4,7 @@ from cogent3.core.genetic_code import GeneticCodes
 from cogent3.core.info import Info
 from cogent3.core.moltype import get_moltype
 from cogent3.parse.record import FieldWrapper
-from cogent3.parse.record_finder import (
-    DelimitedRecordFinder,
-    LabeledRecordFinder,
-)
+from cogent3.parse.record_finder import DelimitedRecordFinder, LabeledRecordFinder
 
 
 __author__ = "Rob Knight"
@@ -301,21 +298,30 @@ def parse_location_line(tokens, parser=parse_simple_location_segment):
 class Location(object):
     """GenBank location object. Integer, or low, high, or 2-base bound.
 
-    data must either be a long, an object that can be coerced to a long, or a
+    Parameters
+    ----------
+    data : Numeric type
+        either a long, an object that can be coerced to a long, or a
         sequence of two BasePosition objects. It can _not_ be two numbers.
-    ambiguity should be None (the default), '>', or '<'.
-    is_between should be False (the default), or True.
-    is_bounds should be False(the default, indicates range), or True.
-    accession should be an accession, or None (default).
-    db should be a database identifier, or None (default).
-    Strand should be 1 (forward, default) or -1 (reverse).
+    ambiguity : str
+        ambiguity can be '>', or '<', or default = None
+    is_between : bool
+        default = False
+    is_bounds : bool
+       default = False, which indicates range
+    accession : str
+        the accession number
+    db : str
+        database identifier
+    strand : int
+        strand should be 1 (forward, default) or -1 (reverse).
 
     WARNING: This Location will allow you to do things that can't happen in
     GenBank, such as having a start and stop that aren't from the same
     accession. No validation is performed to prevent this. All reasonable
     cases should work.
 
-    WARNING: Coordinates are based on 1, not 0, as in GenBank format.
+    WARNING: Coordinates are 0-based, not 1-based, thus no longer as in Genbank Format.
     """
 
     def __init__(
@@ -446,10 +452,7 @@ class Location(object):
 
 
 class LocationList(list):
-    """List of Location objects.
-
-    WARNING: Coordinates are based on 1, not 0, to match GenBank format.
-    """
+    """List of Location objects."""
 
     BIGNUM = 1e300
 

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -304,7 +304,7 @@ class Location(object):
     data must either be a long, an object that can be coerced to a long, or a
         sequence of two BasePosition objects. It can _not_ be two numbers.
     ambiguity should be None (the default), '>', or '<'.
-    IsBetween should be False (the default), or True.
+    is_between should be False (the default), or True.
     IsBounds should be False(the default, indicates range), or True.
     Accession should be an accession, or None (default).
     Db should be a database identifier, or None (default).
@@ -322,7 +322,7 @@ class Location(object):
         self,
         data,
         ambiguity=None,
-        IsBetween=False,
+        is_between=False,
         IsBounds=False,
         Accession=None,
         Db=None,
@@ -337,14 +337,15 @@ class Location(object):
             pass  # assume was two Location objects.
         self._data = data
         self.ambiguity = ambiguity
-        self.IsBetween = IsBetween
+        self.is_between = is_between
         self.IsBounds = IsBounds
         self.Accession = Accession
         self.Db = Db
         self.Strand = Strand
 
         dep_arg_map = {
-            "Ambiguity": "ambiguity"
+            "Ambiguity": "ambiguity",
+            "IsBetween": "is_between",
         }  # map between deprecated argument name and current argument name
         for dep_arg, arg in dep_arg_map.items():
             if dep_arg in kwargs:
@@ -367,13 +368,13 @@ class Location(object):
         you abuse this object, you'll get results that aren't valid GenBank
         locations.
         """
-        if self.IsBetween:  # between two bases
+        if self.is_between:  # between two bases
             try:
                 first, last = self._data
                 curr = f"{first}^{last}"
             except TypeError:  # only one base? must be this or the next
                 curr = f"{first}^{first + 1}"
-        else:  # not self.IsBetween
+        else:  # not self.is_between
             try:
                 data = int(self._data)
                 # if the above line succeeds, we've got a single item
@@ -600,7 +601,7 @@ def parse_location_segment(location_segment):
     # check if it's between two adjacent bases
     elif "^" in s:
         first, second = s.split("^")
-        return Location([lsp(first), lsp(second)], IsBetween=True)
+        return Location([lsp(first), lsp(second)], is_between=True)
     # check if it's a single base reference -- but don't be fooled by
     # accessions!
     elif "." in s and s.startswith("(") and s.endswith(")"):

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -466,7 +466,7 @@ class LocationList(list):
             "2023.06.15",
         )
 
-        return min(self, key=lambda x: x.start) + 1
+        return min(self, key=lambda x: x.start).start + 1
 
     def last(self):  # pragma: no cover
         """Returns last base of self."""
@@ -477,7 +477,7 @@ class LocationList(list):
             "LocationList.last",
             "2023.06.15",
         )
-        return max(self, key=lambda x: x.stop) + 1
+        return max(self, key=lambda x: x.stop).stop + 1
 
     @property
     def strand(self):

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -288,7 +288,7 @@ def parse_location_line(tokens, parser=parse_simple_location_segment):
             if type_ == "complement(":
                 children.reverse()
                 for c in children:
-                    c.Strand *= -1
+                    c.strand *= -1
             curr_index = parent.index(curr)
             del parent[curr_index]
             parent[curr_index:curr_index] = children[:]
@@ -326,7 +326,7 @@ class Location(object):
         is_bounds=False,
         accession=None,
         db=None,
-        Strand=1,
+        strand=1,
         **kwargs,
     ):
         """Returns new LocalLocation object."""
@@ -341,7 +341,7 @@ class Location(object):
         self.is_bounds = is_bounds
         self.accession = accession
         self.db = db
-        self.Strand = Strand
+        self.strand = strand
 
         dep_arg_map = {
             "Ambiguity": "ambiguity",
@@ -349,6 +349,7 @@ class Location(object):
             "IsBounds": "is_bounds",
             "Accession": "accession",
             "Db": "db",
+            "Strand": "strand",
         }  # map between deprecated argument name and PEP8 compliant argument name
         for dep_arg, arg in dep_arg_map.items():
             if dep_arg in kwargs:
@@ -400,7 +401,7 @@ class Location(object):
             if self.db:
                 curr = self.db + "::" + curr
         # check if it's complemented
-        if self.Strand == -1:
+        if self.strand == -1:
             curr = f"complement({curr})"
         return curr
 
@@ -449,7 +450,7 @@ class LocationList(list):
         """Returns strand of components: 1=forward, -1=reverse, 0=both"""
         curr = {}
         for i in self:
-            curr[i.Strand] = 1
+            curr[i.strand] = 1
         if len(curr) >= 2:  # found stuff on both strands
             return 0
         else:
@@ -475,7 +476,7 @@ class LocationList(list):
             else:
                 curr = sequence[first:] + sequence[:last]
             # reverse-complement if necessary
-            if i.Strand == -1:
+            if i.strand == -1:
                 curr = curr.translate(trans_table)[::-1]
             result.append(curr)
         return "".join(result)
@@ -700,7 +701,7 @@ def RichGenbankParser(
                 continue
             for location in feature["location"]:
                 (lo, hi) = (location.first() - 1, location.last())
-                if location.Strand == -1:
+                if location.strand == -1:
                     (lo, hi) = (hi, lo)
                     assert reversed is not False
                     reversed = True

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -306,7 +306,7 @@ class Location(object):
     ambiguity should be None (the default), '>', or '<'.
     is_between should be False (the default), or True.
     is_bounds should be False(the default, indicates range), or True.
-    Accession should be an accession, or None (default).
+    accession should be an accession, or None (default).
     Db should be a database identifier, or None (default).
     Strand should be 1 (forward, default) or -1 (reverse).
 
@@ -324,7 +324,7 @@ class Location(object):
         ambiguity=None,
         is_between=False,
         is_bounds=False,
-        Accession=None,
+        accession=None,
         Db=None,
         Strand=1,
         **kwargs,
@@ -339,14 +339,15 @@ class Location(object):
         self.ambiguity = ambiguity
         self.is_between = is_between
         self.is_bounds = is_bounds
-        self.Accession = Accession
+        self.accession = accession
         self.Db = Db
         self.Strand = Strand
 
         dep_arg_map = {
             "Ambiguity": "ambiguity",
             "IsBetween": "is_between",
-            "IsBounds": "is_bounds"
+            "IsBounds": "is_bounds",
+            "Accession": "accession",
         }  # map between deprecated argument name and current argument name
         for dep_arg, arg in dep_arg_map.items():
             if dep_arg in kwargs:
@@ -392,8 +393,8 @@ class Location(object):
                 else:
                     curr = f"{first}{'..'}{last}"
         # check if we need to add on the accession and database
-        if self.Accession:
-            curr = self.Accession + ":" + curr
+        if self.accession:
+            curr = self.accession + ":" + curr
             # we're only going to add the Db if we got an accession
             if self.Db:
                 curr = self.Db + "::" + curr

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -329,13 +329,13 @@ ORIGIN
         l = lsp("37")
         self.assertEqual(l._data, 37)
         self.assertEqual(str(l), "37")
-        self.assertEqual(l.Strand, 1)
+        self.assertEqual(l.strand, 1)
         l = lsp("40..50")
         first, second = l._data
         self.assertEqual(first._data, 40)
         self.assertEqual(second._data, 50)
         self.assertEqual(str(l), "40..50")
-        self.assertEqual(l.Strand, 1)
+        self.assertEqual(l.strand, 1)
         # should handle ambiguous starts and ends
         l = lsp(">37")
         self.assertEqual(l._data, 37)
@@ -524,7 +524,7 @@ class LocationTests(TestCase):
         self.assertEqual(str(l4), "37^42")
         l5 = Location([l4, l3])
         self.assertEqual(str(l5), "37^42..(37.42)")
-        l5 = Location([l4, l3], Strand=-1)
+        l5 = Location([l4, l3], strand=-1)
         self.assertEqual(str(l5), "complement(37^42..(37.42))")
 
 
@@ -536,7 +536,7 @@ class LocationListTests(TestCase):
         l = Location(3)
         l2_a = Location(5)
         l2_b = Location(7)
-        l2 = Location([l2_a, l2_b], Strand=-1)
+        l2 = Location([l2_a, l2_b], strand=-1)
         l3_a = Location(10)
         l3_b = Location(12)
         l3 = Location([l3_a, l3_b])

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -505,9 +505,9 @@ class LocationTests(TestCase):
         """Location should init with 1 or 2 values, plus params."""
         l = Location(37)
         self.assertEqual(str(l), "37")
-        l = Location(37, Ambiguity=">")
+        l = Location(37, ambiguity=">")
         self.assertEqual(str(l), ">37")
-        l = Location(37, Ambiguity="<")
+        l = Location(37, ambiguity="<")
         self.assertEqual(str(l), "<37")
         l = Location(37, Accession="AB123")
         self.assertEqual(str(l), "AB123:37")

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -518,7 +518,7 @@ class LocationTests(TestCase):
         l2 = Location(42)
         l = Location([l1, l2])
         self.assertEqual(str(l), "37..42")
-        l3 = Location([l1, l2], IsBounds=True)
+        l3 = Location([l1, l2], is_bounds=True)
         self.assertEqual(str(l3), "(37.42)")
         l4 = Location([l1, l2], is_between=True)
         self.assertEqual(str(l4), "37^42")

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -532,8 +532,8 @@ def test_Location_start():
     """the start and stop should reflect 0-based indexing (python style), not 1-based indexing (genbank style).
     This means they should be 1 less than the data given"""
     l = Location(37)
-    assert str(l.start()) == "36"
-    assert str(l.stop()) == "36"
+    assert l.start == 36
+    assert l.stop == 36
 
 
 class LocationListTests(TestCase):

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -520,7 +520,7 @@ class LocationTests(TestCase):
         self.assertEqual(str(l), "37..42")
         l3 = Location([l1, l2], IsBounds=True)
         self.assertEqual(str(l3), "(37.42)")
-        l4 = Location([l1, l2], IsBetween=True)
+        l4 = Location([l1, l2], is_between=True)
         self.assertEqual(str(l4), "37^42")
         l5 = Location([l4, l3])
         self.assertEqual(str(l5), "37^42..(37.42)")

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -511,7 +511,7 @@ class LocationTests(TestCase):
         self.assertEqual(str(l), "<37")
         l = Location(37, accession="AB123")
         self.assertEqual(str(l), "AB123:37")
-        l = Location(37, accession="AB123", Db="Kegg")
+        l = Location(37, accession="AB123", db="Kegg")
         self.assertEqual(str(l), "Kegg::AB123:37")
 
         l1 = Location(37)

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -528,6 +528,14 @@ class LocationTests(TestCase):
         self.assertEqual(str(l5), "complement(37^42..(37.42))")
 
 
+def test_Location_start():
+    """the start and stop should reflect 0-based indexing (python style), not 1-based indexing (genbank style).
+    This means they should be 1 less than the data given"""
+    l = Location(37)
+    assert str(l.start()) == "36"
+    assert str(l.stop()) == "36"
+
+
 class LocationListTests(TestCase):
     """Tests of the LocationList class."""
 

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -509,9 +509,9 @@ class LocationTests(TestCase):
         self.assertEqual(str(l), ">37")
         l = Location(37, ambiguity="<")
         self.assertEqual(str(l), "<37")
-        l = Location(37, Accession="AB123")
+        l = Location(37, accession="AB123")
         self.assertEqual(str(l), "AB123:37")
-        l = Location(37, Accession="AB123", Db="Kegg")
+        l = Location(37, accession="AB123", Db="Kegg")
         self.assertEqual(str(l), "Kegg::AB123:37")
 
         l1 = Location(37)


### PR DESCRIPTION
DEP: deprecating arguments on `cogent3.parse.genbank.Location` to be PEP8 compliant, fixes #1193.
DEP: deprecating coordinate handling methods on `cogent3.parse.genbank.Location`, `first` and `last` are replaced with `start` and `stop`, the former is 1-based and the latter is 0-based, fixes #1301.
