### PR TITLE
Removed whitespace from scriv templates

### DIFF
--- a/changelog.d/20230303_121357_richard_issue1304.md
+++ b/changelog.d/20230303_121357_richard_issue1304.md
@@ -6,9 +6,9 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Contributers
 
--   khiron
+- khiron
 
 ### ENH
 
--   Added automated changelog management to the project
+- Added automated changelog management to the project
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -15,19 +15,19 @@ Uncomment the category of change you are making and add a short description of t
 change as a markdown bullet point.  For example:
 
 Contributors
-*   khiron
+* khiron
 
 ENH
-*   Added a new feature that allows users to do Y
+* Added a new feature that allows users to do Y
 
 DEP
-*   Removed deprecated feature Z
+* Removed deprecated feature Z
 
 BUG
-*   Fixed a bug that caused the project to crash when a user did X by doing Y instead
+* Fixed a bug that caused the project to crash when a user did X by doing Y instead
 
 DOC
-*   Documented feature Z
+* Documented feature Z
 
 Check the file in with your changes.  
 

--- a/changelog.d/templates/new.md.j2
+++ b/changelog.d/templates/new.md.j2
@@ -8,7 +8,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 <!--
 ### {{ cat }}
 
--   A bullet item for the {{ cat }} category.
+- A bullet item for the {{ cat }} category.
 
 -->
 {% endfor -%}


### PR DESCRIPTION
Changed the whitespace after bullets in scriv templates from 3 to 1 space.

Changed the documentation and outstanding scrivlets