### PR TITLE
DEV: add support for python 3.11

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v2"
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@master

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ import pathlib
 import nox
 
 
-_py_versions = range(8, 11)
+_py_versions = range(8, 12)
 
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,13 @@ authors = [
 keywords = ["biology", "genomics", "statistics", "phylogeny", "evolution", "bioinformatics"]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8,<3.12"
 dependencies = ["chardet",
         "numpy",
-        "numba>0.48.0;python_version<'3.9'",
+        "numba==0.57.0rc1; python_version=='3.11'",
+        "numba>0.48.0; python_version<'3.9'",
         "numba>0.53; python_version>='3.9'",
-        "numba>0.54; python_version>='3.10'",
+        "numba>0.54; python_version=='3.10'",
         "scipy",
         "scitrack",
         "tqdm",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 chardet==5.1.0
-pillow==9.5.0
+pillow==9.4.0
 psutil==5.9.4
-numpy==1.24.2
+numpy==1.23.5
+numba==0.57.0rc1; python_version=='3.11'
 numba>0.48.0;python_version<'3.9'
 numba>0.53; python_version>='3.9'
-numba>0.54; python_version>='3.10'
+numba>0.54; python_version=='3.10'
 scipy==1.10.1
 nox==2022.11.21
-plotly==5.14.0
+plotly==5.13.1
 typing_extensions>=3.7
 .[dev]


### PR DESCRIPTION
[CHANGED] numba 0.57. Orc1 is 3.11 compatible, and on my machine
	all tests pass when  using it. So added as explicit version for
	python 3.11 in toml and requirements.
[CHANGED] Added 3.11 to supported versions in toml and noxfile
[CHANGED] Added 3.11 to GitHub action test matrix