### PR TITLE
API: separation of concerns changes to tree classes

### DIFF
--- a/changelog.d/20230410_151103_Gavin.Huttley.md
+++ b/changelog.d/20230410_151103_Gavin.Huttley.md
@@ -1,0 +1,54 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Contributers
+
+- A bullet item for the Contributers category.
+
+-->
+<!--
+### ENH
+
+- A bullet item for the ENH category.
+
+-->
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+
+### Discontinued
+
+- Removed methods on TreeNode that are a recursion variant of an
+  existing methods. TreeNode.copy_recursive(), TreeNode.traverse_recursive()
+  TreeNode.get_newick_recursive() all have standard implementations that can
+  be used instead.
+- PhyloNode inherits from TreeNode and is distinguished from it only by
+  have a length attribute on nodes. All methods that rely on length
+  have now been moved to PhyloNode. These methods are PhyloNode.get_distances(),
+  PhyloNode.set_max_tip_tip_distance(), PhyloNode.get_max_tip_tip_distance(),
+  PhyloNode.max_tip_tip_distance(), PhyloNode.compare_by_tip_distances().
+  One exception is TreeNode.get_newick(). When `with_distance=True`, this
+  method grabs the "length" attribute from nodes.
+- All methods that do not depend on the length attribute are moved to TreeNode.
+  These methods are TreeNode.balanced(), TreeNode.same_topology(),
+  TreeNode.unrooted_deepcopy(), TreeNode.unrooted(), TreeNode.rooted_at(),
+  TreeNode.rooted_with_tip().

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -560,33 +560,6 @@ class TreeNodeTests(TestCase):
         r = self.TreeRoot
         self.assertEqual(len(r), 2)
 
-    def test_copy_recursive(self):
-        """TreeNode.copy_recursive() should produce deep copy"""
-        t = TreeNode(["t"])
-        u = TreeNode(["u"])
-        t.append(u)
-
-        c = u.copy()
-        assert c is not u
-        assert c.name == u.name
-        assert c.name is not u.name
-        # note: name _is_ same object if it's immutable, e.g. a string.
-        # deepcopy doesn't copy data for immutable objects.
-
-        # need to check that we also copy arbitrary attributes
-        t.XYZ = [3]
-        c = t.copy()
-        assert c is not t
-        assert c[0] is not u
-        assert c[0].name is not u.name
-        assert c[0].name == u.name
-        assert c.XYZ == t.XYZ
-        assert c.XYZ is not t.XYZ
-
-        t = self.TreeRoot
-        c = t.copy()
-        self.assertEqual(str(c), str(t))
-
     def test_copy(self):
         """TreeNode.copy() should work on deep trees"""
         t = comb_tree(1024)  # should break recursion limit on regular copy
@@ -845,8 +818,6 @@ class TreeNodeTests(TestCase):
                 continue
             tree = make_tree(treestring=treestring)
             nwk = tree.get_newick(with_node_names=True, with_distances=True)
-            self.assertEqual(nwk, expect[i])
-            nwk = tree.get_newick_recursive(with_node_names=True, with_distances=True)
             self.assertEqual(nwk, expect[i])
 
     def test_root(self):
@@ -1841,37 +1812,6 @@ class TreeInterfaceForLikelihoodFunction(TestCase):
         names = [e.name for e in tree.get_edge_vector(include_root=False)]
         self.assertEqual(names, ["A", "B", "ab", "C", "D", "cd", "E", "cde"])
 
-    def test_get_newick_recursive(self):
-        orig = "((A:1.0,B:2.0)ab:3.0,((C:4.0,D:5.0)cd:6.0,E:7.0)cde:8.0)all;"
-        unlen = "((A,B)ab,((C,D)cd,E)cde)all;"
-        tree = self._maketree(orig)
-        self.assertEqual(tree.get_newick_recursive(with_distances=1), orig)
-        self.assertEqual(tree.get_newick_recursive(), unlen)
-
-        tree.name = "a'l"
-        ugly_name = "((A,B)ab,((C,D)cd,E)cde)a'l;"
-        ugly_name_esc = "((A,B)ab,((C,D)cd,E)cde)'a''l';"
-        self.assertEqual(tree.get_newick_recursive(escape_name=True), ugly_name_esc)
-        self.assertEqual(tree.get_newick_recursive(escape_name=False), ugly_name)
-
-        tree.name = "a_l"
-        ugly_name = "((A,B)ab,((C,D)cd,E)cde)a_l;"
-        ugly_name_esc = "((A,B)ab,((C,D)cd,E)cde)'a_l';"
-        self.assertEqual(tree.get_newick_recursive(escape_name=True), ugly_name_esc)
-        self.assertEqual(tree.get_newick_recursive(escape_name=False), ugly_name)
-
-        tree.name = "a l"
-        ugly_name = "((A,B)ab,((C,D)cd,E)cde)a l;"
-        ugly_name_esc = "((A,B)ab,((C,D)cd,E)cde)a_l;"
-        self.assertEqual(tree.get_newick_recursive(escape_name=True), ugly_name_esc)
-        self.assertEqual(tree.get_newick_recursive(escape_name=False), ugly_name)
-
-        tree.name = "'a l'"
-        quoted_name = "((A,B)ab,((C,D)cd,E)cde)'a l';"
-        quoted_name_esc = "((A,B)ab,((C,D)cd,E)cde)'a l';"
-        self.assertEqual(tree.get_newick_recursive(escape_name=True), quoted_name_esc)
-        self.assertEqual(tree.get_newick_recursive(escape_name=False), quoted_name)
-
     def test_get_newick(self):
         orig = "((A:1.0,B:2.0)ab:3.0,((C:4.0,D:5.0)cd:6.0,E:7.0)cde:8.0)all;"
         unlen = "((A,B)ab,((C,D)cd,E)cde)all;"
@@ -1884,18 +1824,6 @@ class TreeInterfaceForLikelihoodFunction(TestCase):
         ugly_name_esc = "((A,B)ab,((C,D)cd,E)cde)'a''l';"
         self.assertEqual(tree.get_newick(escape_name=True), ugly_name_esc)
         self.assertEqual(tree.get_newick(escape_name=False), ugly_name)
-
-        tree.name = "a_l"
-        ugly_name = "((A,B)ab,((C,D)cd,E)cde)a_l;"
-        ugly_name_esc = "((A,B)ab,((C,D)cd,E)cde)'a_l';"
-        self.assertEqual(tree.get_newick_recursive(escape_name=True), ugly_name_esc)
-        self.assertEqual(tree.get_newick_recursive(escape_name=False), ugly_name)
-
-        tree.name = "a l"
-        ugly_name = "((A,B)ab,((C,D)cd,E)cde)a l;"
-        ugly_name_esc = "((A,B)ab,((C,D)cd,E)cde)a_l;"
-        self.assertEqual(tree.get_newick_recursive(escape_name=True), ugly_name_esc)
-        self.assertEqual(tree.get_newick_recursive(escape_name=False), ugly_name)
 
         tree.name = "'a l'"
         quoted_name = "((A,B)ab,((C,D)cd,E)cde)'a l';"


### PR DESCRIPTION
`TreeNode` is the parent of `PhyloNode`. The latter is distinct in having a `length` attribute,
corresponding to a branch length. Duplicate methods accumulated on these classes during
the PyCogent era that blurred the boundaries between them. This patch addresses that blurring,
clarifying that any method which does not involve distances belongs on the `TreeNode` class,
distance related methods only on the `PhyloNode` class.
