### PR TITLE
ENH: updated relative and absolute position functions

### DIFF
--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2002,71 +2002,97 @@ def test_annotation_from_slice_with_stride():
     )
 
 
-def test_absolute_index_base_cases(one_seq):
+def test_absolute_position_base_cases(one_seq):
     """with no offset or view, the absolute index should remain unchanged"""
-    got = one_seq._seq.absolute_index(5)
+    got = one_seq._seq.absolute_position(5)
     assert got == 5
 
     # an index outside the range of the sequence should raise an IndexError
     with pytest.raises(IndexError):
-        one_seq._seq.absolute_index(20)
+        one_seq._seq.absolute_position(20)
 
     with pytest.raises(IndexError):
-        one_seq._seq.absolute_index(-20)
+        one_seq._seq.absolute_position(-20)
 
 
-def test_absolute_index_positive(one_seq):
+def test_absolute_position_positive(one_seq):
     # with an offset, the abs index should be offset + index
     one_seq.annotation_offset = 2
-    got = one_seq._seq.absolute_index(2)
+    got = one_seq._seq.absolute_position(2)
     assert got == 2 + 2
 
     # with an offset and start, the abs index should be offset + start + index
     view = one_seq[2::]
     view.annotation_offset = 2  # todo: do we want the annotation_offset to be preserved when slicing? I think yes
-    got = view._seq.absolute_index(2)
+    got = view._seq.absolute_position(2)
     assert got == 2 + 2 + 2
 
     # with an offset, start and step, the abs index should be offset + start + index * step
     view = one_seq[2::2]
     view.annotation_offset = 2
-    got = view._seq.absolute_index(2)
+    got = view._seq.absolute_position(2)
     assert got == 2 + 2 + 2 * 2
 
 
-def test_absolute_index_negative(one_seq):
-    # with an offset, the abs index should be offset + length -index
-    one_seq.annotation_offset = 2
-    got = one_seq._seq.absolute_index(-2)
-    assert got == 2 + len(one_seq) - 2
-
-    # with an offset and negative index, the abs index should be offset + abs(index)
-    view = one_seq[::-1]
-    view.annotation_offset = 2
-    got = view._seq.absolute_index(-2)
-    assert got == 3  # note an index of 3 is the 4th position
-
-    # a start position should not change the above example because -ve indexing is relative to the end
-    view = one_seq[-2::-1]
-    view.annotation_offset = 2
-    got = view._seq.absolute_index(-2)
-    assert got == 3  # note an index of 3 is the 4th position
-
-    # a stop position
-    view = one_seq[:1:-1]
-    view.annotation_offset = 2
-    got = view._seq.absolute_index(-2)
-    assert got == 5  # note an index of 5 is the 6th position
-
-
-def test_relative_index_base_cases(one_seq):
+def test_relative_position_base_cases(one_seq):
     """with no offset or view, the absolute index should remain unchanged"""
-    got = one_seq._seq.relative_index(5)
+    got = one_seq._seq.relative_position(5)
     assert got == 5
 
     # a -ve index  should raise an IndexError
     with pytest.raises(IndexError):
-        one_seq._seq.relative_index(-5)
+        one_seq._seq.relative_position(-5)
+
+
+@pytest.fixture(scope="function")
+def integer_seq():
+    return SeqView("0123456789")
+
+
+def test_relative_position(integer_seq):
+    """This test checks if the method returns the correct relative positions when
+    the given index precedes or exceeds the range of the SeqView."""
+
+    view = integer_seq[1:9:]
+    # view = "12345678"
+    got = view.relative_position(0)
+    # precedes the view, so should return -1
+    assert got == -1
+    # exceeds the view, but still returns a value
+    got = view.relative_position(10)
+    assert got == 9
+
+
+def test_relative_position_step_GT_one(integer_seq):
+    """This test checks if the method returns the correct relative positions when
+    the given index precedes or exceeds the range of the SeqView with a step greater than one."""
+
+    # precedes the view, with step > 1
+    view = integer_seq[2:7:2]
+    # view = "246", precedes the view by 1 step
+    got = view.relative_position(0)
+    assert got == -1
+    # precedes the view by 0.5 step, default behaviour is to round up to 0
+    got = view.relative_position(1)
+    assert got == 0
+    # exceeds the view by two steps, len(view) + 2 = 4
+    got = view.relative_position(10)
+    assert got == 4
+
+
+def test_relative_position_with_remainder(integer_seq):
+    """tests relative_position when the index given is excluded from the view as it falls on
+    a position that is 'stepped over'"""
+    view = integer_seq[1:9:2]
+    # view = "1357"
+    got = view.relative_position(2)
+    # 2 is stepped over in the view, so we return the index of 3 (which is 1)
+    assert got == 1
+
+    # setting the arg stop=True will adjust to the largest number, smaller than the given abs value, that is in the view
+    got = view.relative_position(8, stop=True)
+    # 8 is excluded from the view, so we return the index of 7 (which is 3)
+    assert got == 3
 
 
 @pytest.mark.parametrize("value", (0, 3))
@@ -2078,38 +2104,15 @@ def test_absolute_relative_roundtrip(one_seq, value, offset, start, stop, step):
     # a round trip from relative to absolute then from absolute to relative, should return the same value we began with
     view = one_seq[start:stop:step]
     view.annotation_offset = offset
-    abs_val = view._seq.absolute_index(value)
-    rel_val = view._seq.relative_index(abs_val)
+    abs_val = view._seq.absolute_position(value)
+    rel_val = view._seq.relative_position(abs_val)
     assert rel_val == value
 
 
-@pytest.mark.parametrize("value", (0, 2, 3))
-@pytest.mark.parametrize("offset", (None, 1, 2))
-@pytest.mark.parametrize("start", (0, 1, 2))
-@pytest.mark.parametrize("stop", (9, 10, 11))
-@pytest.mark.parametrize("step", (1, 2))
-def test_relative_absolute_roundtrip(one_seq, value, offset, start, stop, step):
-    # a round trip from relative to absolute then from absolute to relative, should return the same value we began with
-    view = one_seq[start:stop:step]
-    view.annotation_offset = offset
-    with contextlib.suppress(IndexError):
-        rel_val = view._seq.relative_index(value)
-        abs_val = view._seq.absolute_index(rel_val)
-        assert abs_val == value
-
-
-@pytest.fixture(scope="session")
-def integer_seq():
-    return SeqView("0123456789")
-
-
-@pytest.mark.parametrize("value", (0, 2, -2))
+@pytest.mark.parametrize("value", (0, 2))
 @pytest.mark.parametrize("offset", (None, 1, 2))
 @pytest.mark.parametrize("start", (None, -1, -2))
-@pytest.mark.parametrize(
-    "stop",
-    (None, -10),
-)
+@pytest.mark.parametrize("stop", (None, -10))
 @pytest.mark.parametrize("step", (-1, -2))
 def test_absolute_relative_roundtrip_reverse(
     integer_seq, value, offset, start, stop, step
@@ -2117,25 +2120,7 @@ def test_absolute_relative_roundtrip_reverse(
     # a round trip from relative to absolute then from absolute to relative, should return the same value we began with
     view = integer_seq[start:stop:step]
     view.offset = offset
-    abs_val = view.absolute_index(value)
-    with contextlib.suppress(IndexError):
-        rel_val = view.relative_index(abs_val)
-        assert view.offset == offset
-        assert (view[rel_val]).value == view[value].value
-
-
-@pytest.mark.parametrize("value", (0, 2, 3))
-@pytest.mark.parametrize("offset", (None, 1, 2))
-@pytest.mark.parametrize("start", (None, -1, -2))
-@pytest.mark.parametrize("stop", (None, -10, -11))
-@pytest.mark.parametrize("step", (-1, 2))
-def test_relative_absolute_roundtrip_reverse(
-    integer_seq, value, offset, start, stop, step
-):
-    # a round trip from relative to absolute then from absolute to relative, should return the same value we began with
-    view = integer_seq[start:stop:step]
-    view.offset = offset
-    with contextlib.suppress(IndexError):
-        rel_val = view.relative_index(value)
-        abs_val = view.absolute_index(rel_val)
-        assert abs_val == value
+    abs_val = view.absolute_position(value)
+    rel_val = view.relative_position(abs_val)
+    assert view.offset == offset
+    assert (view[rel_val]).value == view[value].value


### PR DESCRIPTION
[CHANGED] absolute_index now called absolute_position, behaviour is pretty much maintained

[CHANGED] relative_index now called relative_position. No longer accepts negative indexing. No longer throws indexError for index corresponding to "stepped over" element. No longer returns a value that supports python index, as negative return value refers to positions prior to the start of the view.