### PR TITLE
MAINT: remove new method

### DIFF
--- a/src/cogent3/core/location.py
+++ b/src/cogent3/core/location.py
@@ -886,20 +886,6 @@ class Map(object):
             raise ValueError(f"must positive, not {abs_pos=}")
         return abs_pos - self.start
 
-    def convert_position_for_reversed(self, rel_pos: T) -> T:
-        """adjusts a relative position for changed orientation
-
-        Raises
-        ------
-        raises ValueError if rel_pos < 0 or rel_pos > len(self)
-        """
-        check = array([rel_pos], dtype=int) if isinstance(rel_pos, int) else rel_pos
-        if check.min() < 0 or check.max() > len(self):
-            raise ValueError(
-                f"must be a relative position within [0,{len(self)}], not {rel_pos=}"
-            )
-        return len(self) - rel_pos - 1
-
 
 class SpansOnly(ConstrainedList):
     """List that converts elements to Spans on addition."""

--- a/tests/test_core/test_location.py
+++ b/tests/test_core/test_location.py
@@ -593,5 +593,3 @@ def test_map_plus_position():
     rc = orig.nucleic_reversed()
     rcsubseq = rc[2:7]
     abs_coord = rcsubseq.absolute_position(0)
-    abs_rc_coord = orig.convert_position_for_reversed(abs_coord)
-    assert abs_rc_coord == 6, (abs_coord, abs_rc_coord)


### PR DESCRIPTION
[CHANGED] recently added and, turns out, not required