### PR TITLE
DEV: Removed file headers as now relying on GitHub for authorship, fixes #1341

### DIFF
--- a/doc/doctest_rsts.py
+++ b/doc/doctest_rsts.py
@@ -16,16 +16,6 @@ from cogent3.app.composable import define_app
 from cogent3.util.io import atomic_write
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2020.2.7a"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 DATA_DIR = pathlib.Path(__file__).parent / "data"
 
 

--- a/doc/rst2script.py
+++ b/doc/rst2script.py
@@ -8,15 +8,6 @@ import re
 import click
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = ["Gavin Huttley", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2020.2.7a"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 not_wsp = re.compile(r"^\S+")
 code_eval = re.compile(r"(?<=\s{4})([>]{3}|[.]{3})\s")
 code_block = re.compile(r".. (jupyter-execute|doctest)::")

--- a/doc/set_working_directory.py
+++ b/doc/set_working_directory.py
@@ -5,16 +5,6 @@ import os
 import pathlib
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2020.2.7a"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def get_data_dir():
     """returns path to cogent3 doc data directory"""
     current = pathlib.Path(".").absolute().parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "cogent3"
 description = """COmparative GENomics Toolkit 3: genomic sequence analysis within notebooks or on compute systems with 1000s of CPUs."""
-dynamic = ["version"]
+# remember to update cogent3/_version.py too!
+version = "2023.2.12a1"
 authors = [
     { name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au"},
 ]

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -10,6 +10,7 @@ import warnings
 
 from typing import Callable, Optional, Union
 
+from cogent3._version import __version__
 from cogent3.app import app_help, available_apps, get_app, open_data_store
 from cogent3.core.alignment import (
     Alignment,
@@ -19,7 +20,6 @@ from cogent3.core.alignment import (
 )
 from cogent3.core.annotation_db import load_annotations
 from cogent3.core.genetic_code import available_codes, get_code
-
 # note that moltype has to be imported last, because it sets the moltype in
 # the objects created by the other modules.
 from cogent3.core.moltype import (
@@ -46,35 +46,9 @@ from cogent3.util.table import Table as _Table
 from cogent3.util.table import cast_str_to_array
 
 
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Rob Knight",
-    "Peter Maxwell",
-    "Jeremy Widmann",
-    "Catherine Lozupone",
-    "Matthew Wakefield",
-    "Edward Lang",
-    "Greg Caporaso",
-    "Mike Robeson",
-    "Micah Hamady",
-    "Sandra Smit",
-    "Zongzhi Liu",
-    "Andrew Butterfield",
-    "Amanda Birmingham",
-    "Brett Easton",
-    "Hua Ying",
-    "Jason Carnes",
-    "Raymond Sammut",
-    "Helen Lindsay",
-    "Daniel McDonald",
-]
+__copyright__ = "Copyright 2007-2023, The Cogent Project"
+__credits__ = "https://github.com/cogent3/cogent3/graphs/contributors"
 __license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 _min_version = (3, 8)

--- a/src/cogent3/_version.py
+++ b/src/cogent3/_version.py
@@ -1,0 +1,2 @@
+# remember to update version in pyproject.toml too!
+__version__ = "2023.2.12a1"

--- a/src/cogent3/align/__init__.py
+++ b/src/cogent3/align/__init__.py
@@ -20,12 +20,3 @@ __all__ = [
     "pycompare",
     "traceback",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Jeremy Widmann", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/align/align.py
+++ b/src/cogent3/align/align.py
@@ -10,16 +10,6 @@ from cogent3.util.warning import discontinued
 Float = numpy.core.numerictypes.sctype2char(float)
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def dotplot(seq1, seq2, window, threshold, **kw):
     discontinued(
         "function",

--- a/src/cogent3/align/compare_numba.py
+++ b/src/cogent3/align/compare_numba.py
@@ -1,16 +1,6 @@
 import numpy as np
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def segments_from_diagonal(
     seq1, seq2, window, threshold, min_gap_length, diagonal
 ):  # pragma: no cover

--- a/src/cogent3/align/dp_calculation.py
+++ b/src/cogent3/align/dp_calculation.py
@@ -9,16 +9,6 @@ from cogent3.recalculation.definition import (
 )
 
 
-__author__ = "Gavin Huttley and Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttleuy"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class IndelParameterDefn(ProbabilityParamDefn):
     # locus means allowed to vary by loci
     valid_dimensions = ("edge", "bin", "locus")

--- a/src/cogent3/align/indel_model.py
+++ b/src/cogent3/align/indel_model.py
@@ -6,16 +6,6 @@ import numpy
 from cogent3.maths.markov import TransitionMatrix
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def pair_transition_matrix(order, a):
     """A matrix for Pair HMMs with gap states X and Y, match state M,
     and optionally a silent wait state W"""

--- a/src/cogent3/align/indel_positions.py
+++ b/src/cogent3/align/indel_positions.py
@@ -1,13 +1,3 @@
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def pog_traceback(pogs, aligned_positions):
     upto = [0, 0]
     align_builder = POGBuilder(pogs)

--- a/src/cogent3/align/pairwise.py
+++ b/src/cogent3/align/pairwise.py
@@ -28,16 +28,6 @@ def _as_combined_arrays(preds):
     return i_sources, i_sources_offsets, j_sources, j_sources_offsets
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class PointerEncoding(object):
     """Pack very small ints into a byte.  The last field, state, is assigned
     whatever bits are left over after the x and y pointers have claimed what

--- a/src/cogent3/align/pairwise_pogs_numba.py
+++ b/src/cogent3/align/pairwise_pogs_numba.py
@@ -4,15 +4,6 @@ from numba import boolean, float64, int64, njit, optional, uint8
 from numba.core.types.containers import Tuple
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # turn off code coverage as njit-ted code not accessible to coverage
 
 

--- a/src/cogent3/align/pairwise_seqs_numba.py
+++ b/src/cogent3/align/pairwise_seqs_numba.py
@@ -4,15 +4,6 @@ from numba import boolean, float64, int64, njit, optional, uint8
 from numba.core.types.containers import Tuple
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # turn off code coverage as njit-ted code not accessible to coverage
 
 

--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -4,16 +4,6 @@ from cogent3.phylo import nj as NJ
 from cogent3.util import progress_display as UI
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 @UI.display_wrap
 def tree_align(
     model,

--- a/src/cogent3/align/pycompare.py
+++ b/src/cogent3/align/pycompare.py
@@ -10,16 +10,6 @@ import cogent3.util.progress_display as UI
 from cogent3.core.sequence import Sequence
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 # deprecated code block
 @UI.display_wrap
 def dotplot(

--- a/src/cogent3/align/traceback.py
+++ b/src/cogent3/align/traceback.py
@@ -6,16 +6,6 @@ from cogent3.core.alignment import Aligned, Alignment
 from cogent3.core.annotation import Map
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Rob Knight", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def seq_traceback(s1, s2, aligned_positions, gap_value):
     """gapped sequences from state matrix and ending point
     gaps are signified by 'gap_value' inserted in the sequences.

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -9,15 +9,6 @@ import textwrap
 from .io_new import open_data_store
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 __all__ = [
     "align",
     "composable",

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -21,16 +21,6 @@ from .tree import quick_tree, scale_branches
 from .typing import AlignedSeqsType, SerialisableType, UnalignedSeqsType
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class _GapOffset:
     """computes sum of gap lengths preceding a position. Acts like a dict
     for getting the offset for an integer key with the __getitem__ returning

--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -14,22 +14,13 @@ from uuid import uuid4
 
 from scitrack import CachingLogger
 
+from cogent3._version import __version__
 from cogent3.app.typing import get_constraint_names, type_tree
 from cogent3.util import parallel as PAR
 from cogent3.util import progress_display as UI
 from cogent3.util.misc import docstring_to_summary_rest, get_object_provenance
 
 from .data_store_new import DataMember, get_data_source, get_unique_id
-
-
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
 
 
 _builtin_seqs = list, set, tuple

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -33,16 +33,6 @@ from cogent3.util.table import Table
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 # handling archive, member existence
 SKIP = "skip"
 OVERWRITE = "overwrite"

--- a/src/cogent3/app/data_store_new.py
+++ b/src/cogent3/app/data_store_new.py
@@ -27,15 +27,6 @@ from cogent3.util.parallel import is_master_process
 from cogent3.util.table import Table
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 _NOT_COMPLETED_TABLE = "not_completed"
 _LOG_TABLE = "logs"
 _MD5_TABLE = "md5"

--- a/src/cogent3/app/dist.py
+++ b/src/cogent3/app/dist.py
@@ -13,16 +13,6 @@ from .composable import define_app
 from .typing import AlignedSeqsType, PairwiseDistanceType, SerialisableType
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 @define_app
 class fast_slow_dist:
     """Pairwise distance calculation for aligned sequences.

--- a/src/cogent3/app/evo.py
+++ b/src/cogent3/app/evo.py
@@ -27,16 +27,6 @@ from .typing import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 @define_app
 class model:
     """Define a substitution model + tree for maximum likelihood evaluation."""

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -46,16 +46,6 @@ from .typing import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def findall(base_path, suffix="fa", limit=None, verbose=False):
     """returns glob match to suffix, path is relative to base_path
 

--- a/src/cogent3/app/io_new.py
+++ b/src/cogent3/app/io_new.py
@@ -47,16 +47,6 @@ from .typing import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 _datastore_reader_map = {}
 
 

--- a/src/cogent3/app/result.py
+++ b/src/cogent3/app/result.py
@@ -9,19 +9,10 @@ import numpy
 
 from scipy.stats.distributions import chi2
 
+from cogent3._version import __version__
 from cogent3.app.data_store import get_data_source
 from cogent3.util.misc import extend_docstring_from, get_object_provenance
 from cogent3.util.table import Table
-
-
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
 
 
 class generic_result(MutableMapping):

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -13,16 +13,6 @@ from .translate import get_fourfold_degenerate_sets
 from .typing import AlignedSeqsType, SeqsCollectionType, SerialisableType
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 # TODO need a function to filter sequences based on divergence, ala divergent
 # set.
 

--- a/src/cogent3/app/sqlite_data_store.py
+++ b/src/cogent3/app/sqlite_data_store.py
@@ -25,15 +25,6 @@ from cogent3.app.data_store_new import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 _RESULT_TABLE = "results"
 _MEMORY = ":memory:"
 _mem_pattern = re.compile(r"^\s*[:]{0,1}memory[:]{0,1}\s*$")

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -9,16 +9,6 @@ from .composable import NotCompleted, define_app
 from .typing import SeqsCollectionType, SerialisableType
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def best_frame(seq, gc=1, allow_rc=False, require_stop=False):
     """returns reading frame start that has either no stops or a single
     terminal stop codon

--- a/src/cogent3/app/tree.py
+++ b/src/cogent3/app/tree.py
@@ -7,16 +7,6 @@ from .composable import define_app
 from .typing import PairwiseDistanceType, SerialisableType, TreeType
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 @define_app
 class scale_branches:
     """Transforms tree branch lengths from nucleotide to codon, or the

--- a/src/cogent3/app/typing.py
+++ b/src/cogent3/app/typing.py
@@ -9,15 +9,6 @@ from typing import ForwardRef, Iterable, TypeVar, Union
 from typing_extensions import get_args, get_origin
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 AlignedSeqsType = TypeVar("AlignedSeqsType", "Alignment", "ArrayAlignment")
 UnalignedSeqsType = TypeVar("UnalignedSeqsType", bound="SequenceCollection")
 SeqsCollectionType = Union[AlignedSeqsType, UnalignedSeqsType]

--- a/src/cogent3/cluster/UPGMA.py
+++ b/src/cogent3/cluster/UPGMA.py
@@ -18,16 +18,6 @@ from cogent3.core.tree import PhyloNode
 from cogent3.util.dict_array import DictArray
 
 
-__author__ = "Catherine Lozupone"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Catherine Lozuopone", "Rob Knight", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Catherine Lozupone"
-__email__ = "lozupone@colorado.edu"
-__status__ = "Production"
-
-
 numerictypes = numpy.core.numerictypes.sctype2char
 Float = numerictypes(float)
 BIG_NUM = 1e305

--- a/src/cogent3/cluster/__init__.py
+++ b/src/cogent3/cluster/__init__.py
@@ -3,12 +3,3 @@
 """
 
 __all__ = ["UPGMA"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Catherine Lozuopone", "Rob Knight", "Peter Maxwell", "Justin Kuczynski"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Catherine Lozupone"
-__email__ = "lozupone@colorado.edu"
-__status__ = "Production"

--- a/src/cogent3/core/__init__.py
+++ b/src/cogent3/core/__init__.py
@@ -12,20 +12,3 @@ __all__ = [
     "sequence",
     "tree",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Jeremy Widmann",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Sandra Smit",
-    "Peter Maxwell",
-    "Matthew Wakefield",
-    "Greg Caporaso",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -55,6 +55,7 @@ from numpy.random import choice, permutation, randint
 
 import cogent3  # will use to get at cogent3.parse.fasta.MinimalFastaParser,
 
+from cogent3._version import __version__
 from cogent3.core.annotation import Feature, Map
 from cogent3.core.annotation_db import (
     FeatureDataType,
@@ -67,7 +68,6 @@ from cogent3.core.genetic_code import get_code
 from cogent3.core.info import Info as InfoClass
 from cogent3.core.profile import PSSM, MotifCountsArray
 from cogent3.core.sequence import ArraySequence, Sequence, frac_same
-
 # which is a circular import otherwise.
 from cogent3.format.alignment import save_to_filename
 from cogent3.format.fasta import alignment_to_fasta
@@ -87,26 +87,6 @@ from cogent3.util.misc import (
     get_setting_from_environ,
 )
 from cogent3.util.union_dict import UnionDict
-
-
-__author__ = "Peter Maxwell and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Rob Knight",
-    "Gavin Huttley",
-    "Jeremy Widmann",
-    "Catherine Lozupone",
-    "Matthew Wakefield",
-    "Micah Hamady",
-    "Daniel McDonald",
-    "Jan Kosinski",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 
 DEFAULT_ANNOTATION_DB = GffAnnotationDb

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -34,18 +34,9 @@ from numpy import (
 )
 from numpy.testing import assert_allclose
 
+from cogent3._version import __version__
 from cogent3.util import warning as c3warns
 from cogent3.util.misc import get_object_provenance
-
-
-__author__ = "Peter Maxwell, Gavin Huttley and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rob Knight", "Andrew Butterfield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 class AlphabetError(Exception):

--- a/src/cogent3/core/annotation.py
+++ b/src/cogent3/core/annotation.py
@@ -7,20 +7,11 @@ from typing import Optional
 
 import numpy
 
+from cogent3._version import __version__
 from cogent3.util import warning as c3warn
 from cogent3.util.misc import get_object_provenance
 
 from .location import Map, as_map
-
-
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Katherine Caley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 class _AnnotationMixin:  # pragma: no cover

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -12,19 +12,10 @@ import typing
 
 import numpy
 
+from cogent3._version import __version__
 from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.misc import get_object_provenance
 from cogent3.util.table import Table
-
-
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 OptionalInt = typing.Optional[int]

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -12,15 +12,6 @@ from itertools import product
 from cogent3.util.table import Table
 
 
-__author__ = "Greg Caporaso and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Greg Caporaso", "Rob Knight", "Peter Maxwell", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Greg Caporaso"
-__email__ = "caporaso@colorado.edu"
-__status__ = "Production"
-
 maketrans = str.maketrans
 
 

--- a/src/cogent3/core/info.py
+++ b/src/cogent3/core/info.py
@@ -9,16 +9,6 @@ from cogent3.parse.record import MappedRecord
 from cogent3.util.misc import ConstrainedDict, Delegator, FunctionWrapper
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Prototype"
-
-
 class DbRef(object):
     """Holds a database accession, and optionally other data.
 

--- a/src/cogent3/core/location.py
+++ b/src/cogent3/core/location.py
@@ -45,6 +45,7 @@ from typing import Union
 
 from numpy import array, ndarray
 
+from cogent3._version import __version__
 from cogent3.util.misc import (
     ClassChecker,
     ConstrainedList,
@@ -53,15 +54,6 @@ from cogent3.util.misc import (
     iterable,
 )
 
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Matthew Wakefield", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Prototype"
 
 strip = str.strip
 

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -11,16 +11,6 @@ the MolType. It is thus essential that the connection between these other
 types and the MolType can be made after the objects are created.
 """
 
-__author__ = "Peter Maxwell, Gavin Huttley and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rob Knight", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 import json
 import re
 
@@ -29,6 +19,7 @@ from copy import deepcopy
 from random import choice
 from string import ascii_letters as letters
 
+from cogent3._version import __version__
 from cogent3.core.alignment import (
     Alignment,
     ArrayAlignment,

--- a/src/cogent3/core/profile.py
+++ b/src/cogent3/core/profile.py
@@ -8,16 +8,6 @@ from cogent3.util.dict_array import DictArray, DictArrayTemplate
 from cogent3.util.misc import extend_docstring_from
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class _MotifNumberArray(DictArray):
     def __init__(self, data, motifs, row_indices=None, dtype=None):
         """

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -37,6 +37,7 @@ from numpy import (
 )
 from numpy.random import permutation
 
+from cogent3._version import __version__
 from cogent3.core.alphabet import AlphabetError
 from cogent3.core.annotation import Feature
 from cogent3.core.annotation_db import (
@@ -65,23 +66,6 @@ from cogent3.util.warning import (
     deprecated_args,
     deprecated_callable,
 )
-
-
-__author__ = "Rob Knight, Gavin Huttley, and Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Matthew Wakefield",
-    "Daniel McDonald",
-    "Katherine Caley",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 
 ARRAY_TYPE = type(array(1))

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -36,30 +36,10 @@ from random import choice, shuffle
 
 from numpy import argsort, ceil, log, zeros
 
+from cogent3._version import __version__
 from cogent3.maths.stats.test import correlation
 from cogent3.util.io import atomic_write, get_format_suffixes
 from cogent3.util.misc import get_object_provenance
-
-
-__author__ = "Gavin Huttley, Peter Maxwell and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Peter Maxwell",
-    "Rob Knight",
-    "Andrew Butterfield",
-    "Catherine Lozupone",
-    "Micah Hamady",
-    "Jeremy Widmann",
-    "Zongzhi Liu",
-    "Daniel McDonald",
-    "Justin Kuczynski",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 def distance_from_r_squared(m1, m2):

--- a/src/cogent3/data/__init__.py
+++ b/src/cogent3/data/__init__.py
@@ -1,12 +1,3 @@
 #!/usr/bin/env python
 
 __all__ = ["energy_params", "molecular_weight"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Amanda Birmingham"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/data/energy_params.py
+++ b/src/cogent3/data/energy_params.py
@@ -14,15 +14,6 @@ The SYM term is added into the entropy or enthalpy calculation IFF the
 sequence is self-complementary (seq = Reverse Comp of seq)
 """
 
-__author__ = "Amanda Birmingham"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Amanda Birmingham", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Amanda Birmingham"
-__email__ = "amanda.birmingham@thermofisher.com"
-__status__ = "Production"
-
 
 class EnergyParams(object):
     """A data structure to hold parameters used in energy calculations"""

--- a/src/cogent3/data/molecular_weight.py
+++ b/src/cogent3/data/molecular_weight.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env Python
 """Data for molecular weight calculations on proteins and nucleotides."""
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 ProteinWeights = {
     "A": 71.09,

--- a/src/cogent3/draw/__init__.py
+++ b/src/cogent3/draw/__init__.py
@@ -1,18 +1,3 @@
 #!/usr/bin/env python
 
 __all__ = ["dendrogram", "dotplot", "drawable", "letter", "logo"]
-
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = [
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Zongzhi Liu",
-    "Matthew Wakefield",
-    "Stephanie Wilson",
-    "Rahul Ghangas",
-    "Sheng Han Moses Koh",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__status__ = "Production"

--- a/src/cogent3/draw/dendrogram.py
+++ b/src/cogent3/draw/dendrogram.py
@@ -9,16 +9,6 @@ from cogent3.util.misc import extend_docstring_from
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Rahul Ghangas, Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rahul Ghangas"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TreeGeometryBase(PhyloNode):
     """base class that computes geometric coordinates for display"""
 

--- a/src/cogent3/draw/dotplot.py
+++ b/src/cogent3/draw/dotplot.py
@@ -9,16 +9,6 @@ from cogent3.draw.drawable import Drawable
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Rahul Ghangas, Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Peter Maxwell", "Rahul Ghangas"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def suitable_threshold(window, desired_probability):
     """Use cumulative binomial distribution to find the number of identical
     bases which we expect a nucleotide window-mer to have with the desired

--- a/src/cogent3/draw/drawable.py
+++ b/src/cogent3/draw/drawable.py
@@ -7,15 +7,6 @@ from cogent3.util.misc import extend_docstring_from
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Rahul Ghangas and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rahul Ghangas", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
 # user specified environment variable for plotly renderer
 PLOTLY_RENDERER = os.environ.get("PLOTLY_RENDERER", None)
 

--- a/src/cogent3/draw/letter.py
+++ b/src/cogent3/draw/letter.py
@@ -20,15 +20,6 @@ import numpy
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Sheng Han Moses Koh"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sheng Han Moses Koh", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
 _svg_paths = {
     "A": [
         ["M", 4.2679468235157464e-05, 0.0],

--- a/src/cogent3/draw/logo.py
+++ b/src/cogent3/draw/logo.py
@@ -4,16 +4,6 @@ from cogent3.util.dict_array import DictArray
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def get_mi_char_heights(fa):
     """computes character heights from MI terms
     Parameters

--- a/src/cogent3/evolve/__init__.py
+++ b/src/cogent3/evolve/__init__.py
@@ -15,21 +15,3 @@ __all__ = [
     "substitution_model",
     "coevolution",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Peter Maxwell",
-    "Andrew Butterfield",
-    "Rob Knight",
-    "Matthrew Wakefield",
-    "Brett Easton",
-    "Edward Lang",
-    "Greg Caporaso",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/evolve/best_likelihood.py
+++ b/src/cogent3/evolve/best_likelihood.py
@@ -12,15 +12,7 @@ from numpy import log
 from cogent3 import make_aligned_seqs
 
 
-__author__ = "Helen Lindsay, Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Helen Lindsay", "Gavin Huttley", "Daniel McDonald"]
 cite = "Goldman, N. (1993).  Statistical tests of models of DNA substitution.  J Mol Evol, 36: 182-98"
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 def _transpose(array):

--- a/src/cogent3/evolve/bootstrap.py
+++ b/src/cogent3/evolve/bootstrap.py
@@ -27,22 +27,6 @@ import random
 from cogent3.util import progress_display as UI
 
 
-__author__ = "Gavin Huttley, Andrew Butterfield and Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Andrew Butterfield",
-    "Matthew Wakefield",
-    "Edward Lang",
-    "Peter Maxwell",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class ParametricBootstrapCore(object):
     """Core parametric bootstrap services."""
 

--- a/src/cogent3/evolve/coevolution.py
+++ b/src/cogent3/evolve/coevolution.py
@@ -76,21 +76,6 @@ from cogent3.maths.stats.number import CategoryCounter, CategoryFreqs
 from cogent3.maths.stats.special import ROUND_ERROR
 
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Greg Caporaso",
-    "Gavin Huttley",
-    "Brett Easton",
-    "Sandra Smit",
-    "Rob Knight",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
-__status__ = "Beta"
-
 DEFAULT_EXCLUDES = "".join([IUPAC_gap, IUPAC_missing])
 DEFAULT_NULL_VALUE = nan
 

--- a/src/cogent3/evolve/discrete_markov.py
+++ b/src/cogent3/evolve/discrete_markov.py
@@ -8,16 +8,6 @@ from cogent3.recalculation.definition import (
 )
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def _make_array(*x):
     return numpy.array(x)
 

--- a/src/cogent3/evolve/distance.py
+++ b/src/cogent3/evolve/distance.py
@@ -11,16 +11,6 @@ from cogent3.util import progress_display as UI
 from cogent3.util import table
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Peter Maxwell", "Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def get_name_combinations(names, group_size):
     """returns combinations of names"""
     combined = list(tuple(sorted(p)) for p in combinations(names, group_size))

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -6,6 +6,7 @@ import numpy
 from numpy import array, diag, dot, eye, float64, int32, log, sqrt, zeros
 from numpy.linalg import det, inv
 
+from cogent3._version import __version__
 from cogent3.core.moltype import DNA, RNA, get_moltype
 from cogent3.util.dict_array import DictArray
 from cogent3.util.misc import get_object_provenance
@@ -14,14 +15,7 @@ from cogent3.util.progress_display import display_wrap
 from .pairwise_distance_numba import fill_diversity_matrix
 
 
-__author__ = "Gavin Huttley, Yicheng Zhu and Ben Kaehler"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Yicheng Zhu", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"  # pending addition of protein distance metrics
+# pending addition of protein distance metrics
 
 
 def _same_moltype(ref, query):

--- a/src/cogent3/evolve/likelihood_calculation.py
+++ b/src/cogent3/evolve/likelihood_calculation.py
@@ -26,16 +26,6 @@ from cogent3.recalculation.definition import (
 Float = numpy.core.numerictypes.sctype2char(float)
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class _PartialLikelihoodDefn(CalculationDefn):
     def setup(self, edge_name):
         self.edge_name = edge_name

--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 import numpy
 
+from cogent3._version import __version__
 from cogent3.core.alignment import ArrayAlignment
 from cogent3.evolve import substitution_model
 from cogent3.evolve.simulate import AlignmentEvolver, random_sequence
@@ -19,25 +20,6 @@ from cogent3.recalculation.definition import ParameterController
 from cogent3.util import table
 from cogent3.util.dict_array import DictArrayTemplate
 from cogent3.util.misc import adjusted_gt_minprob, get_object_provenance
-
-
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Andrew Butterfield",
-    "Peter Maxwell",
-    "Matthew Wakefield",
-    "Rob Knight",
-    "Brett Easton",
-    "Ben Kaehler",
-    "Ananias Iliadis",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 # cogent3.evolve.parameter_controller.LikelihoodParameterController tells the

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -12,15 +12,6 @@ numpy.seterr(all="ignore")
 
 numerictypes = numpy.core.numerictypes.sctype2char
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
 
 class _LikelihoodTreeEdge(object):
     def __init__(self, children, edge_name, alignment=None):

--- a/src/cogent3/evolve/likelihood_tree_numba.py
+++ b/src/cogent3/evolve/likelihood_tree_numba.py
@@ -3,15 +3,6 @@ import numpy
 from numba import njit
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2019, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Rob Knight", "Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # turn off code coverage as njit-ted code not accessible to coverage
 
 

--- a/src/cogent3/evolve/models.py
+++ b/src/cogent3/evolve/models.py
@@ -21,16 +21,6 @@ from cogent3.evolve.substitution_model import _SubstitutionModel
 from cogent3.util.table import Table
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield", "Peter Maxwell", "Gavin Huttley", "James Kondilios"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
-
 nucleotide_models = []
 codon_models = []
 protein_models = []

--- a/src/cogent3/evolve/motif_prob_model.py
+++ b/src/cogent3/evolve/motif_prob_model.py
@@ -9,16 +9,6 @@ from cogent3.evolve.likelihood_tree import make_likelihood_tree_leaf
 from cogent3.recalculation.definition import CalcDefn, PartitionDefn
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def make_model(mprob_model, tuple_alphabet, mask):
     if mprob_model == "monomers":
         return PosnSpecificMonomerProbModel(tuple_alphabet, mask)

--- a/src/cogent3/evolve/ns_substitution_model.py
+++ b/src/cogent3/evolve/ns_substitution_model.py
@@ -14,16 +14,6 @@ from .substitution_model import (
 )
 
 
-__author__ = "Peter Maxwell, Gavin Huttley and Andrew Butterfield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = ["Gavin Huttley", "Peter Maxwell", "Ben Kaeheler", "Ananias Iliadis"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _gen_sym_preds():
     pair = {"A": "T", "T": "A", "G": "C", "C": "G"}
     sym_preds = []

--- a/src/cogent3/evolve/pairwise_distance_numba.py
+++ b/src/cogent3/evolve/pairwise_distance_numba.py
@@ -1,15 +1,6 @@
 from numba import njit
 
 
-__author__ = "Gavin Huttley, Yicheng Zhu and Ben Kaehler"
-__copyright__ = "Copyright 2007-2019, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Yicheng Zhu", "Ben Kaehler", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
 # turn off code coverage as njit-ted code not accessible to coverage
 
 # fills in a diversity matrix from sequences of integers

--- a/src/cogent3/evolve/parameter_controller.py
+++ b/src/cogent3/evolve/parameter_controller.py
@@ -19,16 +19,6 @@ from cogent3.recalculation.scope import _indexed
 from cogent3.util.misc import adjusted_gt_minprob
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Andrew Butterfield", "Peter Maxwell", "Gavin Huttley", "Helen Lindsay"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.ed.au"
-__status__ = "Production"
-
-
 def _category_names(dimension, specified):
     if type(specified) is int:
         cats = [f"{dimension}{i}" for i in range(specified)]

--- a/src/cogent3/evolve/predicate.py
+++ b/src/cogent3/evolve/predicate.py
@@ -14,16 +14,6 @@ import warnings
 import numpy
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class _CallablePredicate(object):
     # A predicate in the context of a particular model
 

--- a/src/cogent3/evolve/simulate.py
+++ b/src/cogent3/evolve/simulate.py
@@ -6,16 +6,6 @@ import bisect
 import numpy
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def argpicks(freqs, random_series):
     partition = numpy.add.accumulate(freqs)
     assert abs(partition[-1] - 1.0) < 1e-6, (freqs, partition)

--- a/src/cogent3/evolve/solved_models.py
+++ b/src/cogent3/evolve/solved_models.py
@@ -15,16 +15,6 @@ from cogent3.maths.matrix_exponentiation import FastExponentiator
 from . import solved_models_numba as _solved_models
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class PredefinedNucleotide(TimeReversibleNucleotide):
     _default_expm_setting = None
 

--- a/src/cogent3/evolve/solved_models_numba.py
+++ b/src/cogent3/evolve/solved_models_numba.py
@@ -5,15 +5,6 @@ import numpy as np
 from numba import njit
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2019, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # turn off code coverage as njit-ted code not accessible to coverage
 
 

--- a/src/cogent3/evolve/substitution_calculation.py
+++ b/src/cogent3/evolve/substitution_calculation.py
@@ -15,15 +15,6 @@ from cogent3.recalculation.definition import (
 )
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
 # Custom subclasses of Defn (see cogent3.recalulation) for use by
 # substitution models.
 

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -39,6 +39,7 @@ import numpy
 
 from numpy.linalg import svd
 
+from cogent3._version import __version__
 from cogent3.core import genetic_code, moltype
 from cogent3.evolve import motif_prob_model, parameter_controller, predicate
 from cogent3.evolve.likelihood_tree import make_likelihood_tree_leaf
@@ -63,24 +64,6 @@ from cogent3.recalculation.definition import (
     WeightedPartitionDefn,
 )
 from cogent3.util.misc import extend_docstring_from, get_object_provenance
-
-
-__author__ = "Peter Maxwell, Gavin Huttley and Andrew Butterfield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = [
-    "Gavin Huttley",
-    "Andrew Butterfield",
-    "Peter Maxwell",
-    "Matthew Wakefield",
-    "Brett Easton",
-    "Rob Knight",
-    "Von Bing Yap",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 
 def predicate2matrix(alphabet, pred, mask=None):

--- a/src/cogent3/format/__init__.py
+++ b/src/cogent3/format/__init__.py
@@ -16,20 +16,3 @@ __all__ = [
     "phylip",
     "table",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Jeremy Widmann",
-    "Gavin Huttley",
-    "Matthew Wakefield",
-    "Rob Knight",
-    "Sandra Smit",
-    "Peter Maxwell",
-    "Marcin Cieslik",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/format/alignment.py
+++ b/src/cogent3/format/alignment.py
@@ -10,15 +10,6 @@ from cogent3.parse.record import FileFormatError
 from cogent3.util.io import atomic_write
 
 
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 # todo convert formatters so str(formatter) returns correctly formatted
 # string, and rename method names, rename base class name (sequences, not
 # alignment)

--- a/src/cogent3/format/bedgraph.py
+++ b/src/cogent3/format/bedgraph.py
@@ -1,15 +1,6 @@
 from cogent3.util.misc import get_merged_by_value_coords
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "alpha"
-
 # following from https://cgwb.nci.nih.gov/goldenPath/help/bedgraph.html
 # track type=bedGraph name=track_label description=center_label
 #        visibility=display_mode color=r,g,b altColor=r,g,b

--- a/src/cogent3/format/clustal.py
+++ b/src/cogent3/format/clustal.py
@@ -7,16 +7,6 @@ from copy import copy
 from cogent3.core.alignment import SequenceCollection
 
 
-__author__ = "Jeremy Widmann"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Jeremy Widmann"
-__email__ = "jeremy.widmann@colorado.edu"
-__status__ = "Development"
-
-
 def clustal_from_alignment(aln, wrap=None):
     """
     Parameters

--- a/src/cogent3/format/fasta.py
+++ b/src/cogent3/format/fasta.py
@@ -5,16 +5,6 @@
 from cogent3.format.util import _AlignmentFormatter
 
 
-__author__ = "Jeremy Widmann"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Rob Knight", "Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Jeremy Widmann"
-__email__ = "jeremy.widmann@colorado.edu"
-__status__ = "Production"
-
-
 def alignment_to_fasta(alignment_dict, block_size=60, order=None):
     """Returns a Fasta string given an alignment."""
     order = order or []

--- a/src/cogent3/format/gde.py
+++ b/src/cogent3/format/gde.py
@@ -5,14 +5,6 @@
 from cogent3.format.util import _AlignmentFormatter
 
 
-__author__ = "Thomas La"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Rob Knight", "Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Thomas La"
-
-
 def alignment_to_gde(alignment_dict, block_size=60, order=None):
     """Returns a Gde string given an alignment."""
     return GDEFormatter().format(

--- a/src/cogent3/format/nexus.py
+++ b/src/cogent3/format/nexus.py
@@ -1,13 +1,3 @@
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def nexus_from_alignment(aln, seq_type, wrap=50):
     """returns a nexus formatted string
 

--- a/src/cogent3/format/paml.py
+++ b/src/cogent3/format/paml.py
@@ -5,14 +5,6 @@
 from cogent3.format.util import _AlignmentFormatter
 
 
-__author__ = "Thomas La"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Rob Knight", "Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Thomas La"
-
-
 def alignment_to_paml(alignment_dict, block_size=60, order=None):
     """Returns a Paml string given an alignment."""
     return PamlFormatter().format(

--- a/src/cogent3/format/phylip.py
+++ b/src/cogent3/format/phylip.py
@@ -5,16 +5,6 @@
 from cogent3.format.util import _AlignmentFormatter
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def alignment_to_phylip(alignment_dict, block_size=60, order=None):
     """Returns a Phylip string given an alignment."""
     return PhylipFormatter().format(

--- a/src/cogent3/format/table.py
+++ b/src/cogent3/format/table.py
@@ -14,15 +14,6 @@ from xml.sax.saxutils import escape
 import numpy
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Peter Maxwell", "Matthew Wakefield", "Jeremy Widmann"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 known_formats = (
     "bedgraph",
     "phylip",

--- a/src/cogent3/format/util.py
+++ b/src/cogent3/format/util.py
@@ -2,15 +2,6 @@
 """Alignment formatter template class
 """
 
-__author__ = "Thomas La"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Rob Knight", "Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 
 class _AlignmentFormatter:
     """A virtual class for formatting alignments."""

--- a/src/cogent3/maths/__init__.py
+++ b/src/cogent3/maths/__init__.py
@@ -14,22 +14,3 @@ __all__ = [
     "solve",
     "util",
 ]
-
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Peter Maxwell",
-    "Matthew Wakefield",
-    "Rob Knight",
-    "Edward Lang",
-    "Sandra Smit",
-    "Antonio Gonzalez Pena",
-    "Ben Kaehler",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/maths/distance_transform.py
+++ b/src/cogent3/maths/distance_transform.py
@@ -88,24 +88,6 @@ from numpy import (
 from numpy.linalg import norm
 
 
-__author__ = "Justin Kuczynski"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Micah Hamady",
-    "Justin Kuczynski",
-    "Zongzhi Liu",
-    "Catherine Lozupone",
-    "Antonio Gonzalez Pena",
-    "Greg Caporaso",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Justin Kuczynski"
-__email__ = "justinak@gmail.com"
-__status__ = "Prototype"
-
-
 def _rankdata(a):
     """Ranks the data in a, dealing with ties appropritely.  First ravels
     a.  Adapted from Gary Perlman's |Stat ranksort.

--- a/src/cogent3/maths/geometry.py
+++ b/src/cogent3/maths/geometry.py
@@ -23,23 +23,6 @@ from numpy import (
 )
 
 
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Sandra Smit",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Daniel McDonald",
-    "Marcin Cieslik",
-    "Helmut Simon",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Production"
-
-
 def center_of_mass(coordinates, weights=-1):
     """Calculates the center of mass for a dataset.
 

--- a/src/cogent3/maths/markov.py
+++ b/src/cogent3/maths/markov.py
@@ -7,15 +7,6 @@ import numpy
 
 Float = numpy.core.numerictypes.sctype2char(float)
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
 
 class TransitionMatrix(object):
     """The transition matrix for a Markov process.  Just a square

--- a/src/cogent3/maths/matrix_exponential_integration.py
+++ b/src/cogent3/maths/matrix_exponential_integration.py
@@ -15,16 +15,6 @@ from numpy.linalg import LinAlgError, eig, inv
 import cogent3.maths.matrix_exponentiation as cme
 
 
-__author__ = "Ben Kaehler"
-__copyright__ = "Copyright 2007-2014, The Cogent Project"
-__credits__ = ["Ben Kaehler", "Von Bing Yap", "Gavin Huttley", "Ananias Iliadis"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Ben Kaehler"
-__email__ = "benjamin.kaehler@anu.edu.au"
-__status__ = "Production"
-
-
 class _Exponentiator(object):
     def __init__(self, Q):
         self.Q = Q

--- a/src/cogent3/maths/matrix_exponentiation.py
+++ b/src/cogent3/maths/matrix_exponentiation.py
@@ -16,16 +16,6 @@ import numpy
 from numpy.linalg import eig, inv, solve
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Zongzhi Liu"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class _Exponentiator:
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.Q)})"

--- a/src/cogent3/maths/matrix_logarithm.py
+++ b/src/cogent3/maths/matrix_logarithm.py
@@ -14,16 +14,6 @@ from numpy.linalg import inv as inverse
 from numpy.linalg import norm
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2014, The Cogent Project"
-__credits__ = ["Rob Knight", "Gavin Huttley", "Von Bing Yap", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _is_Q_ok(Q):
     """Tests whether a square matrix is a valid transition rate matrix"""
     n = Q.shape[0]

--- a/src/cogent3/maths/measure.py
+++ b/src/cogent3/maths/measure.py
@@ -9,16 +9,6 @@ import cogent3.util.misc
 from cogent3.maths.util import safe_p_log_p, validate_freqs_array
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def paralinear_discrete_time(P, pi, validate=False):
     """
     Parameters

--- a/src/cogent3/maths/optimisers.py
+++ b/src/cogent3/maths/optimisers.py
@@ -14,15 +14,6 @@ from .simannealingoptimiser import SimulatedAnnealing
 GlobalOptimiser = SimulatedAnnealing
 LocalOptimiser = Powell
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Andrew Butterfield", "Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 
 def unsteadyProgressIndicator(display_progress, label="", start=0.0, end=1.0):
     template = "f = % #10.6g  ±  % 9.3e   evals = %6i "

--- a/src/cogent3/maths/period.py
+++ b/src/cogent3/maths/period.py
@@ -15,16 +15,6 @@ from numpy import (
 from .period_numba import autocorr_inner, goertzel_inner, ipdft_inner
 
 
-__author__ = "Hua Ying, Julien Epps and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Julien Epps", "Hua Ying", "Gavin Huttley", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _goertzel_inner(x, N, period):
     coeff = 2.0 * cos(2 * pi / period)
     s_prev = 0.0

--- a/src/cogent3/maths/period_numba.py
+++ b/src/cogent3/maths/period_numba.py
@@ -4,15 +4,6 @@ import numpy
 from numba import njit
 
 
-__author__ = "Hua Ying, Julien Epps and Gavin Huttley"
-__copyright__ = "Copyright 2007-2019, The Cogent Project"
-__credits__ = ["Julien Epps", "Hua Ying", "Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # turn off code coverage as njit-ted code not accessible to coverage
 
 

--- a/src/cogent3/maths/scipy_optimisers.py
+++ b/src/cogent3/maths/scipy_optimisers.py
@@ -6,16 +6,6 @@ import numpy
 from cogent3.maths.scipy_optimize import brent, fmin_powell
 
 
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def bound_brent(func, brack=None, **kw):
     """Given a function and an initial point, find another
     point within the bounds, then use the two points to

--- a/src/cogent3/maths/scipy_optimize.py
+++ b/src/cogent3/maths/scipy_optimize.py
@@ -50,14 +50,9 @@ abs = absolute
 
 pymin = builtins.min
 pymax = builtins.max
-__version__ = "2023.2.12a1"
 
 
 _epsilon = sqrt(numpy.finfo(float).eps)
-
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
 
 
 def wrap_function(function, args):

--- a/src/cogent3/maths/simannealingoptimiser.py
+++ b/src/cogent3/maths/simannealingoptimiser.py
@@ -18,16 +18,6 @@ import numpy
 from cogent3.util import checkpointing
 
 
-__author__ = "Andrew Butterfield and Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Andrew Butterfield", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class AnnealingSchedule(object):
     """Responsible for the shape of the simulated annealing temperature profile"""
 

--- a/src/cogent3/maths/solve.py
+++ b/src/cogent3/maths/solve.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
 
 EPS = 1e-15
 

--- a/src/cogent3/maths/stats/__init__.py
+++ b/src/cogent3/maths/stats/__init__.py
@@ -15,19 +15,3 @@ __all__ = [
     "special",
     "test",
 ]
-
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Rob Knight",
-    "Sandra Smit",
-    "Catherine Lozupone",
-    "Micah Hamady",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/maths/stats/contingency.py
+++ b/src/cogent3/maths/stats/contingency.py
@@ -7,16 +7,6 @@ from cogent3.maths.stats.test import G_fit
 from cogent3.util.dict_array import DictArray
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 # todo this should probably go into different module
 def shuffled_matrix(matrix):
     """returns a randomly sampled matrix with same marginals"""

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -31,15 +31,6 @@ from cogent3.maths.stats.special import (
 # ndtri import b/c it should be available via this module
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Sandra Smit", "Gavin Huttley", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 incbet = betai  # shouldn't have renamed it...
 
 # Probability integrals: low gives left-hand tail, high gives right-hand tail.

--- a/src/cogent3/maths/stats/information_criteria.py
+++ b/src/cogent3/maths/stats/information_criteria.py
@@ -1,16 +1,6 @@
 import numpy
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def aic(lnL, nfp, sample_size=None):
     """returns Aikake Information Criterion
 

--- a/src/cogent3/maths/stats/jackknife.py
+++ b/src/cogent3/maths/stats/jackknife.py
@@ -3,16 +3,6 @@ import numpy as np
 from cogent3.util.table import Table
 
 
-__author__ = "Anuj Pahwa, Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Anuj Pahwa", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def index_gen(length):
     """returns a callable
 

--- a/src/cogent3/maths/stats/kendall.py
+++ b/src/cogent3/maths/stats/kendall.py
@@ -12,16 +12,6 @@ from cogent3.maths.stats.distribution import zprob
 from cogent3.maths.stats.number import CategoryCounter
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def as_paired_ranks(x, y):
     """return as matrix of paired ranks"""
     n = len(x)

--- a/src/cogent3/maths/stats/ks.py
+++ b/src/cogent3/maths/stats/ks.py
@@ -23,15 +23,6 @@ from numpy import (
 from scipy.special import binom
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 PIO4 = pi / 4
 PIO2 = pi / 2
 INVSQRT2PI = 1 / sqrt(2 * pi)

--- a/src/cogent3/maths/stats/number.py
+++ b/src/cogent3/maths/stats/number.py
@@ -6,16 +6,6 @@ import numpy
 from numpy.testing import assert_allclose
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class SummaryStatBase:
     @property
     def mean(self):

--- a/src/cogent3/maths/stats/period.py
+++ b/src/cogent3/maths/stats/period.py
@@ -13,16 +13,6 @@ except ImportError:  # python version < 2.6
     factorial = lambda x: Gamma(x + 1)
 
 
-__author__ = "Hua Ying, Julien Epps and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Julien Epps", "Hua Ying", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def chi_square(x, p, df=1):
     """returns the chisquare statistic and it's probability"""
     N = len(x)

--- a/src/cogent3/maths/stats/special.py
+++ b/src/cogent3/maths/stats/special.py
@@ -5,15 +5,6 @@
 from numpy import exp, floor, log, sin, sqrt
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Rob Knight", "Sandra Smit", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 log_epsilon = 1e-6  # for threshold in log/exp close to 1
 # For IEEE arithmetic (IBMPC):
 MACHEP = 1.11022302462515654042e-16  # 2**-53

--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -43,26 +43,6 @@ from cogent3.maths.stats.special import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Rob Knight",
-    "Catherine Lozupone",
-    "Sandra Smit",
-    "Micah Hamady",
-    "Daniel McDonald",
-    "Greg Caporaso",
-    "Jai Ram Rideout",
-    "Michael Dwan",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 # defining globals for the alternate hypotheses
 ALT_TWO_SIDED = "2"
 ALT_LOW = "low"

--- a/src/cogent3/maths/util.py
+++ b/src/cogent3/maths/util.py
@@ -10,15 +10,6 @@ Float = numerictypes(float)
 Int = numerictypes(int)
 err = numpy.seterr(divide="raise")
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Sandra Smit", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
 
 def safe_p_log_p(data):
     """Returns -(p*log2(p)) for every non-negative, nonzero p in a.

--- a/src/cogent3/parse/__init__.py
+++ b/src/cogent3/parse/__init__.py
@@ -27,28 +27,3 @@ __all__ = [
     "tree_xml",
     "unigene",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Peter Maxwell",
-    "Rob Knight",
-    "Catherine Lozupone",
-    "Jeremy Widmann",
-    "Matthew Wakefield",
-    "Sandra Smit",
-    "Greg Caporaso",
-    "Zongzhi Liu",
-    "Micah Hamady",
-    "Jason Carnes",
-    "Raymond Sammut",
-    "Hua Ying",
-    "Andrew Butterfield",
-    "Marcin Cieslik",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/parse/blast.py
+++ b/src/cogent3/parse/blast.py
@@ -7,15 +7,6 @@ from cogent3.parse.record_finder import (
 )
 
 
-__author__ = "Micah Hamady"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Micah Hamady", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Micah Hamady"
-__email__ = "hamady@colorado.edu"
-__status__ = "Prototype"
-
 strip = str.strip
 upper = str.upper
 

--- a/src/cogent3/parse/blast_xml.py
+++ b/src/cogent3/parse/blast_xml.py
@@ -1,16 +1,6 @@
 """Parsers for XML output of blast, psi-blast and blat.
 """
 
-__author__ = "Kristian Rother"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = ["Micah Hamady"]
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Kristian Rother"
-__email__ = "krother@rubor.de"
-__status__ = "Prototype"
-
 import xml.dom.minidom
 
 from operator import gt as _gt

--- a/src/cogent3/parse/cigar.py
+++ b/src/cogent3/parse/cigar.py
@@ -21,15 +21,6 @@ from cogent3 import DNA, make_aligned_seqs
 from cogent3.core.location import LostSpan, Map, Span
 
 
-__author__ = "Hua Ying"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Hua Ying"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Hua Ying"
-__email__ = "hua.ying@anu.edu.au"
-__status__ = "Production"
-
 _pattern = re.compile("([0-9]*)([DM])")
 
 

--- a/src/cogent3/parse/cisbp.py
+++ b/src/cogent3/parse/cisbp.py
@@ -4,16 +4,6 @@ from cogent3.core.moltype import get_moltype
 from cogent3.core.profile import MotifFreqsArray
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def read(filepath):
     """returns MotifFreqsArray matrix"""
     try:

--- a/src/cogent3/parse/clustal.py
+++ b/src/cogent3/parse/clustal.py
@@ -21,15 +21,6 @@ the number of chars in the sequence printed so far.
 from cogent3.parse.record import DelimitedSplitter, RecordError
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Sandra Smit", "Gavin Huttley", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
 strip = str.strip
 
 

--- a/src/cogent3/parse/cogent3_json.py
+++ b/src/cogent3/parse/cogent3_json.py
@@ -8,16 +8,6 @@ from cogent3.util.io import open_
 from cogent3.util.misc import get_object_provenance
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Stephen Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Development"
-
-
 def load_from_json(filename, classes):
     """Loads objects from json files.
 

--- a/src/cogent3/parse/dialign.py
+++ b/src/cogent3/parse/dialign.py
@@ -5,15 +5,6 @@ import re
 from cogent3 import ASCII
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 _header = re.compile(r"^\s+[=]+")
 _quality_scores = re.compile(r"^ +\d+[\s\d]*$")
 

--- a/src/cogent3/parse/ebi.py
+++ b/src/cogent3/parse/ebi.py
@@ -15,21 +15,6 @@ from cogent3.parse.record_finder import (
 from cogent3.util.misc import NestedSplitter, curry, list_flatten
 
 
-__author__ = "Zongzhi Liu and Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Zongzhi Liu",
-    "Sandra Smit",
-    "Rob Knight",
-    "Gavin Huttley",
-    "Daniel McDonald",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Zongzhi Liu"
-__email__ = "zongzhi.liu@gmail.com"
-__status__ = "Development"
-
 maketrans = str.maketrans
 
 

--- a/src/cogent3/parse/fasta.py
+++ b/src/cogent3/parse/fasta.py
@@ -13,16 +13,6 @@ from cogent3.parse.record_finder import LabeledRecordFinder
 from cogent3.util.io import open_
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
-
 strip = str.strip
 
 Sequence = BYTES.make_seq

--- a/src/cogent3/parse/gbseq.py
+++ b/src/cogent3/parse/gbseq.py
@@ -8,15 +8,6 @@ import xml.dom.minidom
 from cogent3.core import annotation, moltype
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield", "Peter Maxwell", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 """
 CAUTION:
 This XML PARSER uses minidom. This means a bad performance for

--- a/src/cogent3/parse/gcg.py
+++ b/src/cogent3/parse/gcg.py
@@ -1,12 +1,3 @@
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield", "Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 import warnings
 
 

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -12,15 +12,6 @@ from cogent3.parse.record_finder import (
 from cogent3.util import warning as c3warn
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Matthew Wakefield", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 maketrans = str.maketrans
 strip = str.strip
 rstrip = str.rstrip

--- a/src/cogent3/parse/gff.py
+++ b/src/cogent3/parse/gff.py
@@ -6,20 +6,6 @@ import typing
 from cogent3.util.io import open_
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Matthew Wakefield",
-    "Gavin Huttley",
-    "Christopher Bradley",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
 OptionalCallable = typing.Optional[typing.Callable]
 OptionalStrContainer = typing.Optional[typing.Union[str, typing.Sequence]]
 

--- a/src/cogent3/parse/greengenes.py
+++ b/src/cogent3/parse/greengenes.py
@@ -10,16 +10,6 @@ from cogent3.parse.record import DelimitedSplitter, GenericRecord
 from cogent3.parse.record_finder import DelimitedRecordFinder
 
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Daniel McDonald"
-__email__ = "daniel.mcdonald@colorado.edu"
-__status__ = "Prototype"
-
-
 def make_ignore_f(start_line):
     """Make an ignore function that ignores bad gg lines"""
 

--- a/src/cogent3/parse/jaspar.py
+++ b/src/cogent3/parse/jaspar.py
@@ -6,16 +6,6 @@ from cogent3.core.moltype import get_moltype
 from cogent3.core.profile import MotifCountsArray
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 _brackets = re.compile(r"\[|\]")
 
 

--- a/src/cogent3/parse/locuslink.py
+++ b/src/cogent3/parse/locuslink.py
@@ -51,15 +51,6 @@ from cogent3.parse.record import (
 from cogent3.parse.record_finder import LabeledRecordFinder
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
 maketrans = str.maketrans
 strip = str.strip
 rstrip = str.rstrip

--- a/src/cogent3/parse/ncbi_taxonomy.py
+++ b/src/cogent3/parse/ncbi_taxonomy.py
@@ -6,15 +6,6 @@ from functools import total_ordering
 from cogent3.core.tree import TreeNode
 
 
-__author__ = "Jason Carnes"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jason Carnes", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Jason Carnes"
-__email__ = "jason.carnes@sbri.org"
-__status__ = "Development"
-
 strip = str.strip
 
 

--- a/src/cogent3/parse/newick.py
+++ b/src/cogent3/parse/newick.py
@@ -21,15 +21,6 @@ from cogent3.parse.record import FileFormatError
 
 EOT = None
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Andrew Butterfield", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
 
 class TreeParseError(FileFormatError):
     pass

--- a/src/cogent3/parse/nexus.py
+++ b/src/cogent3/parse/nexus.py
@@ -12,15 +12,6 @@ from cogent3.parse.record import RecordError
 from cogent3.util.io import open_
 
 
-__author__ = "Catherine Lozupone"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Catherine Lozuopone", "Rob Knight", "Micah Hamady", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Catherine Lozupone"
-__email__ = "lozupone@colorado.edu"
-__status__ = "Production"
-
 strip = str.strip
 
 

--- a/src/cogent3/parse/paml.py
+++ b/src/cogent3/parse/paml.py
@@ -2,16 +2,6 @@
 from io import TextIOWrapper
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def PamlParser(data):
     if isinstance(data, TextIOWrapper):
         data = data.read().splitlines()

--- a/src/cogent3/parse/paml_matrix.py
+++ b/src/cogent3/parse/paml_matrix.py
@@ -4,15 +4,6 @@ import numpy
 Float = numpy.core.numerictypes.sctype2char(float)
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 three_letter_order = "ARNDCQEGHILKMFPSTWYV"
 aa_order = numpy.array([ord(aa) for aa in three_letter_order])
 reorder = numpy.argsort(aa_order)

--- a/src/cogent3/parse/phylip.py
+++ b/src/cogent3/parse/phylip.py
@@ -3,16 +3,6 @@ from cogent3.core.alignment import Alignment
 from cogent3.parse.record import RecordError
 
 
-__author__ = "Micah Hamady"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Micah Hamady", "Peter Maxwell", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Micah Hamady"
-__email__ = "hamady@colorado.edu"
-__status__ = "Prototype"
-
-
 def is_blank(x):
     """Checks if x is blank."""
     return not x.strip()

--- a/src/cogent3/parse/psl.py
+++ b/src/cogent3/parse/psl.py
@@ -6,16 +6,6 @@
 from cogent3.util.table import Table
 
 
-__author__ = "Gavin Huttley, Anuj Pahwa"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Gavin Huttley", "Anuj Pahwa"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Development"
-
-
 def make_header(lines):
     """returns one header line from multiple header lines"""
     lengths = list(map(len, lines))

--- a/src/cogent3/parse/rdb.py
+++ b/src/cogent3/parse/rdb.py
@@ -11,15 +11,6 @@ from cogent3.parse.record import RecordError
 from cogent3.parse.record_finder import DelimitedRecordFinder
 
 
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sandra Smit", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Development"
-
 strip = str.strip
 maketrans = str.maketrans
 

--- a/src/cogent3/parse/record.py
+++ b/src/cogent3/parse/record.py
@@ -6,16 +6,6 @@ from copy import deepcopy
 from cogent3.util.misc import iterable
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
-
 class FileFormatError(Exception):
     """Exception raised when a file can not be parsed."""
 

--- a/src/cogent3/parse/record_finder.py
+++ b/src/cogent3/parse/record_finder.py
@@ -15,15 +15,6 @@ str.  Note that its default constuctor is rstrip instead of strip.
 from cogent3.parse.record import RecordError
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Gavin Huttley", "Zongzhi Liu"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 strip = str.strip
 rstrip = str.rstrip
 

--- a/src/cogent3/parse/sequence.py
+++ b/src/cogent3/parse/sequence.py
@@ -20,21 +20,6 @@ from cogent3.parse.record import FileFormatError
 from cogent3.util.io import get_format_suffixes, open_
 
 
-__author__ = "Cath Lawrence"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Cath Lawrence",
-    "Gavin Huttley",
-    "Peter Maxwell",
-    "Matthew Wakefield",
-    "Rob Knight",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 _lc_to_wc = "".join([[chr(x), "?"]["A" <= chr(x) <= "Z"] for x in range(256)])
 _compression = re.compile(r"\.(gz|bz2)$")
 

--- a/src/cogent3/parse/table.py
+++ b/src/cogent3/parse/table.py
@@ -6,16 +6,6 @@ from cogent3.util.io import open_
 from .record_finder import is_empty
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class FilteringParser:
     """A parser for a delimited tabular file that returns records matching a condition."""
 

--- a/src/cogent3/parse/tinyseq.py
+++ b/src/cogent3/parse/tinyseq.py
@@ -8,15 +8,6 @@ import xml.dom.minidom
 from cogent3.core import annotation, moltype
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield", "Peter Maxwell", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 """
 CAUTION:
 This XML PARSER uses minidom. This means a bad performance for

--- a/src/cogent3/parse/tree.py
+++ b/src/cogent3/parse/tree.py
@@ -21,15 +21,6 @@ from cogent3.core.tree import PhyloNode
 from cogent3.parse.record import RecordError
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Catherine Lozupone", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
 strip = str.strip
 maketrans = str.maketrans
 

--- a/src/cogent3/parse/tree_xml.py
+++ b/src/cogent3/parse/tree_xml.py
@@ -31,16 +31,6 @@ Parameters are inherited by contained clades unless overridden.
 import xml.sax
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class TreeHandler(xml.sax.ContentHandler):
     def __init__(self, tree_builder):
         self.build_edge = tree_builder

--- a/src/cogent3/parse/unigene.py
+++ b/src/cogent3/parse/unigene.py
@@ -13,15 +13,6 @@ from cogent3.parse.record import (
 from cogent3.parse.record_finder import GbFinder
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Development"
-
 maketrans = str.maketrans
 strip = str.strip
 rstrip = str.rstrip

--- a/src/cogent3/phylo/__init__.py
+++ b/src/cogent3/phylo/__init__.py
@@ -6,12 +6,3 @@ __all__ = [
     "tree_space",
     "util",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Peter Maxwell", "Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/phylo/consensus.py
+++ b/src/cogent3/phylo/consensus.py
@@ -10,16 +10,6 @@ from cogent3.core.tree import TreeBuilder
 from cogent3.util.misc import extend_docstring_from
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield", "Peter Maxwell", "Gavin Huttley", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
-
 def majority_rule(trees, strict=False):
     """Determines the consensus tree from a list of rooted trees using the
      majority rules method of Margush and McMorris 1981

--- a/src/cogent3/phylo/least_squares.py
+++ b/src/cogent3/phylo/least_squares.py
@@ -11,15 +11,6 @@ from .util import (
 )
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
 # This is a fairly slow implementation and NOT suitable for large trees.
 
 # Trees are represented as "ancestry" matricies in which A[i,j] iff j is an

--- a/src/cogent3/phylo/maximum_likelihood.py
+++ b/src/cogent3/phylo/maximum_likelihood.py
@@ -3,16 +3,6 @@ from .tree_collection import LogLikelihoodScoredTreeCollection
 from .tree_space import TreeEvaluator, ancestry2tree
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class ML(TreeEvaluator):
     """(err, best_tree) = ML(model, alignment, [dists]).trex()
 

--- a/src/cogent3/phylo/nj.py
+++ b/src/cogent3/phylo/nj.py
@@ -20,16 +20,6 @@ from cogent3.phylo.util import distance_dict_to_2D
 from cogent3.util import progress_display as UI
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class LightweightTreeTip(str):
     def convert(self, constructor, length):
         node = constructor([], str(self), {})

--- a/src/cogent3/phylo/tree_collection.py
+++ b/src/cogent3/phylo/tree_collection.py
@@ -5,15 +5,6 @@ from cogent3.util.io import atomic_write
 from . import consensus
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-
-
 class _UserList(list):
     def __getitem__(self, index):
         # Helpful to keep type after truncation like [self[:10]],

--- a/src/cogent3/phylo/tree_space.py
+++ b/src/cogent3/phylo/tree_space.py
@@ -10,16 +10,6 @@ from cogent3.util import checkpointing
 from cogent3.util import progress_display as UI
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def ismallest(data, size):
     """There are many ways to get the k smallest items from an N sequence, and
     which one performs best depends on k, N and k/N.  This algorithm appears to

--- a/src/cogent3/phylo/util.py
+++ b/src/cogent3/phylo/util.py
@@ -8,15 +8,6 @@ Float = numpy.core.numerictypes.sctype2char(float)
 # need to be converted into numpy arrays before being fed into phylogenetic
 # reconstruction algorithms.
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "pm67nz@gmail.com"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 
 def names_from_distance_dict(dists):
     """Unique names from within the tuples which make up the keys of 'dists'"""

--- a/src/cogent3/recalculation/__init__.py
+++ b/src/cogent3/recalculation/__init__.py
@@ -1,11 +1,2 @@
 #!/usr/bin/envthon
 __all__ = ["calculation", "definition", "scope", "setting"]
-
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"

--- a/src/cogent3/recalculation/calculation.py
+++ b/src/cogent3/recalculation/calculation.py
@@ -16,14 +16,6 @@ Float = numpy.core.numerictypes.sctype2char(float)
 TRACE_DEFAULT = "COGENT3_TRACE" in os.environ
 TRACE_SCALE = 100000
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
 
 # This is the 'live' layer of the recalculation system
 # Cells and OptPars are held by a Calculator

--- a/src/cogent3/recalculation/definition.py
+++ b/src/cogent3/recalculation/definition.py
@@ -83,16 +83,6 @@ from .setting import ConstVal, Var
 # classes from calculation.py
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 DIM_PLURALS = {
     "bin": "bins",
     "edge": "edges",

--- a/src/cogent3/recalculation/scope.py
+++ b/src/cogent3/recalculation/scope.py
@@ -14,16 +14,6 @@ from .calculation import Calculator
 from .setting import ConstVal, Var
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class ScopeError(KeyError):
     pass
 

--- a/src/cogent3/recalculation/setting.py
+++ b/src/cogent3/recalculation/setting.py
@@ -5,16 +5,6 @@ by a parameter controller"""
 from cogent3.util.misc import adjusted_gt_minprob
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 class Setting(object):
     def get_param_rule_dict(self, names=None, is_probs=False):
         """returns component for a param rule dict"""

--- a/src/cogent3/util/__init__.py
+++ b/src/cogent3/util/__init__.py
@@ -12,23 +12,3 @@ __all__ = [
     "union_dict",
     "warning",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Gavin Huttley",
-    "Rob Knight",
-    "Sandra Smit",
-    "Peter Maxwell",
-    "Amanda Birmingham",
-    "Zongzhi Liu",
-    "Andrew Butterfield",
-    "Daniel McDonald",
-    "Greg Caporaso",
-    "Thomas La",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/src/cogent3/util/checkpointing.py
+++ b/src/cogent3/util/checkpointing.py
@@ -4,16 +4,6 @@ import pickle
 import time
 
 
-__author__ = ["Peter Maxwell", "Gavin Huttley"]
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class Checkpointer(object):
     def __init__(self, filename, interval=None, noisy=True):
         if interval is None:

--- a/src/cogent3/util/deserialise.py
+++ b/src/cogent3/util/deserialise.py
@@ -9,15 +9,6 @@ from cogent3.core.genetic_code import get_code
 from cogent3.util.io import open_, path_exists
 
 
-__author__ = ["Gavin Huttley"]
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 _deserialise_func_map = {}
 
 

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -26,18 +26,9 @@ from itertools import combinations, product
 
 import numpy
 
+from cogent3._version import __version__
 from cogent3.util.io import atomic_write
 from cogent3.util.misc import get_object_provenance
-
-
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
 
 
 def convert_1D_dict(data, row_order=None):

--- a/src/cogent3/util/io.py
+++ b/src/cogent3/util/io.py
@@ -19,15 +19,6 @@ from chardet import detect
 from cogent3.util.misc import _wout_period
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # support prefixes for urls
 _urls = compile("^(http[s]*|file)")
 

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -14,25 +14,6 @@ import numpy
 from numpy import array, finfo, float64
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Peter Maxwell",
-    "Amanda Birmingham",
-    "Sandra Smit",
-    "Zongzhi Liu",
-    "Daniel McDonald",
-    "Kyle Bittinger",
-    "Marcin Cieslik",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _adjusted_gt_minprob_vector(probs, minprob):
     # operates on a 1D numpy vector
     total = probs.sum()

--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -11,14 +11,6 @@ multiprocessing.set_start_method(
     "forkserver" if sys.platform == "darwin" else "spawn", force=True
 )
 
-__author__ = "Sheng Han Moses Koh"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Sheng Han Moses Koh", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
 
 if os.environ.get("DONT_USE_MPI", 0):
     MPI = None

--- a/src/cogent3/util/progress_display.py
+++ b/src/cogent3/util/progress_display.py
@@ -7,17 +7,6 @@ import time
 from tqdm import notebook, tqdm
 
 from cogent3.util import parallel as PAR
-
-
-__author__ = "Sheng Han Moses Koh"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Sheng Han Moses Koh"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
 from cogent3.util.misc import in_jupyter
 
 

--- a/src/cogent3/util/recode_alignment.py
+++ b/src/cogent3/util/recode_alignment.py
@@ -41,16 +41,6 @@ from cogent3.core.alignment import ArrayAlignment
 from cogent3.evolve.models import DSO78_freqs, DSO78_matrix
 
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Greg Caporaso"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
-__status__ = "Beta"
-
-
 class RecodeError(Exception):
     """A generic error to be raised when errors occur in recoding"""
 

--- a/src/cogent3/util/table.py
+++ b/src/cogent3/util/table.py
@@ -35,14 +35,6 @@ try:
 except ImportError:
     display = lambda x: print(repr(x))
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Felix Schill", "Sheng Koh"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 # making reversed characters for use in reverse order sorting
 _all_chrs = [chr(i) for i in range(256)]

--- a/src/cogent3/util/transform.py
+++ b/src/cogent3/util/transform.py
@@ -13,14 +13,6 @@ Functions for generating combinations, permutations, or cartesian products
 of lists.
 """
 
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sandra Smit", "Rob Knight", "Zongzhi Liu"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Production"
 
 maketrans = str.maketrans
 

--- a/src/cogent3/util/union_dict.py
+++ b/src/cogent3/util/union_dict.py
@@ -2,16 +2,6 @@
 """
 
 
-__author__ = "Thomas La"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class UnionDict(dict):
     """dictionary class that can be updated as a union with another dict
     entries are also accessible directly as attributes on the object"""

--- a/src/cogent3/util/warning.py
+++ b/src/cogent3/util/warning.py
@@ -6,16 +6,6 @@ from warnings import catch_warnings, simplefilter
 from warnings import warn as _warn
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Jai Ram Rideout", "Richard Morris"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def deprecated(_type, old, new, version, reason=None, stack_level=3):
     """a convenience function for deprecating classes, functions, arguments.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,19 +9,3 @@ sub_modules = ["test_draw", "test_phylo"]
 
 for sub_module in sub_modules:
     exec(f"from {__name__} import {sub_module}")
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Matthew Wakefield",
-    "Andrew Butterfield",
-    "Edward Lang",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -12,15 +12,6 @@ from cogent3.maths import optimisers
 from cogent3.util import parallel
 
 
-__author__ = "Peter Maxwell and  Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 ALIGNMENT = load_aligned_seqs(filename="data/brca1.fasta")
 TREE = load_tree(filename="data/murphy.tree")
 

--- a/tests/benchmark_aligning.py
+++ b/tests/benchmark_aligning.py
@@ -8,16 +8,6 @@ from cogent3 import DNA
 from cogent3.align.align import classic_align_pairwise, make_dna_scoring_dict
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Peter Maxwell"
-__email__ = "pm67nz@gmail.com"
-__status__ = "Production"
-
-
 def _s2i(s):
     return numpy.array(["ATCG".index(c) for c in s])
 

--- a/tests/test_align/__init__.py
+++ b/tests/test_align/__init__.py
@@ -1,11 +1,2 @@
 #!/usr/bin/env python
 __all__ = ["test_align"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Peter Maxwell", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Jeremy Widmann"
-__email__ = "jeremy.widmann@colorado.edu"
-__status__ = "Production"

--- a/tests/test_align/test_align.py
+++ b/tests/test_align/test_align.py
@@ -22,16 +22,6 @@ dna_model = cogent3.evolve.substitution_model.TimeReversibleNucleotide(
 )
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def matchedColumns(align):
     """Count the matched columns in an alignment"""
 

--- a/tests/test_align/test_compare.py
+++ b/tests/test_align/test_compare.py
@@ -15,16 +15,6 @@ from cogent3.align.pycompare import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def _brute_force(
     seq1,
     seq2,

--- a/tests/test_app/test_align.py
+++ b/tests/test_app/test_align.py
@@ -23,15 +23,6 @@ from cogent3.core.alignment import Aligned, ArrayAlignment
 from cogent3.core.location import gap_coords_to_map
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 _seqs = {
     "Human": "GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT",
     "Bandicoot": "NACTCATTAATGCTTGAAACCAGCAGTTTATTGTCCAAC",

--- a/tests/test_app/test_app_mpi.py
+++ b/tests/test_app/test_app_mpi.py
@@ -6,15 +6,6 @@ from cogent3 import get_app, open_data_store
 from cogent3.util import parallel
 
 
-__author__ = "Sheng Han Moses Koh"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Sheng Han Moses Koh"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -49,16 +49,6 @@ from cogent3.app.typing import (
 from cogent3.core.alignment import Alignment, SequenceCollection
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_app/test_data_store_new.py
+++ b/tests/test_app/test_data_store_new.py
@@ -31,15 +31,6 @@ from cogent3.util.table import Table
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_app/test_dist.py
+++ b/tests/test_app/test_dist.py
@@ -8,15 +8,6 @@ from cogent3.app.composable import WRITER
 from cogent3.evolve.fast_distance import HammingPair, TN93Pair
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Stephen Ma", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 _seqs1 = {
     "Human": "GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT",
     "Bandicoot": "NACTCATTAATGCTTGAAACCAGCAGTTTATTGTCCAAC",

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -25,15 +25,6 @@ from cogent3.evolve.models import get_model
 from cogent3.util.deserialise import deserialise_object
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 data_dir = join(dirname(dirname(__file__)), "data")
 
 

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -19,16 +19,6 @@ from cogent3.util.misc import get_object_provenance
 from cogent3.util.table import Table
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def _get_all_composables(tmp_dir_name):
     tmp_dir_name = Path(tmp_dir_name)
     test_model1 = get_app("model", "HKY85")

--- a/tests/test_app/test_io_new.py
+++ b/tests/test_app/test_io_new.py
@@ -26,16 +26,6 @@ from cogent3.util.deserialise import deserialise_object
 from cogent3.util.table import Table
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_app/test_result.py
+++ b/tests/test_app/test_result.py
@@ -16,16 +16,6 @@ from cogent3.util.deserialise import deserialise_object
 from cogent3.util.dict_array import DictArray
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestGenericResult(TestCase):
     def test_deserialised_values(self):
         """correctly deserialises values"""

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -6,16 +6,6 @@ from cogent3.app.composable import NotCompleted
 from cogent3.core import alignment
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TranslateTests(TestCase):
     def _codon_positions(self, array_align):
         """correctly return codon positions"""

--- a/tests/test_app/test_sqlite_data_store.py
+++ b/tests/test_app/test_sqlite_data_store.py
@@ -25,15 +25,6 @@ from cogent3.app.sqlite_data_store import (
 from cogent3.util.table import Table
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_app/test_translate.py
+++ b/tests/test_app/test_translate.py
@@ -12,16 +12,6 @@ from cogent3.app.translate import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestTranslatable(TestCase):
     """testing translation functions"""
 

--- a/tests/test_app/test_tree.py
+++ b/tests/test_app/test_tree.py
@@ -10,15 +10,6 @@ from cogent3.core.tree import PhyloNode
 from cogent3.evolve.fast_distance import DistanceMatrix
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
 base_path = os.path.dirname(os.path.dirname(__file__))
 data_path = os.path.join(base_path, "data")
 

--- a/tests/test_app/test_typing.py
+++ b/tests/test_app/test_typing.py
@@ -17,16 +17,6 @@ from cogent3.app.typing import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def test_get_constraint_names():
     """returns the correct names"""
     from cogent3.core.alignment import (

--- a/tests/test_cluster/__init__.py
+++ b/tests/test_cluster/__init__.py
@@ -1,11 +1,2 @@
 #!/usr/bin/env python
 __all__ = ["test_UPGMA"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Catherine Lozuopone", "Peter Maxwell", "Rob Knight", "Justin Kuczynski"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_cluster/test_UPGMA.py
+++ b/tests/test_cluster/test_UPGMA.py
@@ -22,16 +22,6 @@ from cogent3.util.dict_array import DictArray
 Float = numpy.core.numerictypes.sctype2char(float)
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class UPGMATests(TestCase):
     """test the functions to cluster using UPGMA using numpy"""
 

--- a/tests/test_core/__init__.py
+++ b/tests/test_core/__init__.py
@@ -15,21 +15,3 @@ __all__ = [
     "test_sequence",
     "test_tree",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Catherine Lozupone",
-    "Peter Maxwell",
-    "Rob Knight",
-    "Gavin Huttley",
-    "Jeremy Widmann",
-    "Greg Caporaso",
-    "Sandra Smit",
-    "Justin Kuczynski",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -23,6 +23,7 @@ from cogent3 import (
     make_seq,
     open_,
 )
+from cogent3._version import __version__
 from cogent3.core.alignment import (
     Aligned,
     Alignment,
@@ -53,23 +54,6 @@ from cogent3.core.sequence import ArraySequence, RnaSequence, Sequence
 from cogent3.maths.util import safe_p_log_p
 from cogent3.parse.fasta import MinimalFastaParser
 from cogent3.util.misc import get_object_provenance
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Jeremy Widmann",
-    "Catherine Lozuopone",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Daniel McDonald",
-    "Jan Kosinski",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"

--- a/tests/test_core/test_alphabet.py
+++ b/tests/test_core/test_alphabet.py
@@ -29,15 +29,6 @@ DnaBases = CharAlphabet("TCAG")
 RnaBases = CharAlphabet("UCAG")
 AminoAcids = CharAlphabet("ACDEFGHIKLMNPQRSTVWY")
 
-__author__ = "Rob Knight, Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Rob Knight", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 
 class translation_table_tests(TestCase):
     """Tests of top-level translation table functions"""

--- a/tests/test_core/test_annotation.py
+++ b/tests/test_core/test_annotation.py
@@ -6,16 +6,6 @@ from cogent3 import DNA, make_aligned_seqs, make_unaligned_seqs
 from cogent3.core.location import Map, Span, as_map
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def makeSampleSequence(name, with_gaps=False):
     raw_seq = "AACCCAAAATTTTTTGGGGGGGGGGCCCC"
     cds = (15, 25)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -15,15 +15,6 @@ from cogent3.core.sequence import Sequence
 from cogent3.util import deserialise
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Katherine Caley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_core/test_core_standalone.py
+++ b/tests/test_core/test_core_standalone.py
@@ -28,15 +28,6 @@ from cogent3.core.alphabet import AlphabetError
 from cogent3.parse.record import FileFormatError
 
 
-__author__ = "Peter Maxwell, Gavin Huttley and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 base_path = os.path.dirname(os.path.dirname(__file__))
 data_path = os.path.join(base_path, "data")
 

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -4,19 +4,8 @@ import pytest
 
 from cogent3 import ASCII, DNA, get_moltype, make_aligned_seqs
 from cogent3.core.annotation_db import GffAnnotationDb
-
 # Complete version of manipulating sequence annotations
 from cogent3.util.deserialise import deserialise_object
-
-
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
 
 
 class FeaturesTest(TestCase):

--- a/tests/test_core/test_genetic_code.py
+++ b/tests/test_core/test_genetic_code.py
@@ -17,16 +17,6 @@ from cogent3.core.genetic_code import (
 )
 
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Greg Caporaso", "Rob Knight", "Peter Maxwell", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Greg Caporaso"
-__email__ = "caporaso@colorado.edu"
-__status__ = "Production"
-
-
 class GeneticCodeTests(TestCase):
     """Tests of the GeneticCode class."""
 

--- a/tests/test_core/test_info.py
+++ b/tests/test_core/test_info.py
@@ -8,16 +8,6 @@ from unittest import TestCase, main
 from cogent3.core.info import DbRef, DbRefs, Info, _make_list
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class DbRefTests(TestCase):
     """Tests of the DbRef object."""
 

--- a/tests/test_core/test_location.py
+++ b/tests/test_core/test_location.py
@@ -12,16 +12,6 @@ from cogent3.core.location import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class SpanTests(TestCase):
     """Tests of the Span object."""
 

--- a/tests/test_core/test_maps.py
+++ b/tests/test_core/test_maps.py
@@ -4,16 +4,6 @@ from cogent3 import DNA, make_aligned_seqs
 from cogent3.core.location import Map, Span
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Rob Knight", "Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class MapTest(unittest.TestCase):
     """Testing annotation of and by maps"""
 

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -3,6 +3,9 @@ import pickle
 
 from unittest import TestCase, main
 
+# ind some of the standard alphabets to reduce typing
+from numpy.testing import assert_allclose
+
 from cogent3.core import sequence
 from cogent3.core.moltype import (
     DNA,
@@ -27,19 +30,6 @@ from cogent3.core.moltype import (
     make_pairs,
 )
 from cogent3.data.molecular_weight import DnaMW, RnaMW
-
-
-__author__ = "Gavin Huttley, Peter Maxwell, and Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Gavin Huttley", "Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-# ind some of the standard alphabets to reduce typing
-from numpy.testing import assert_allclose
 
 
 RnaBases = RNA.alphabets.base

--- a/tests/test_core/test_profile.py
+++ b/tests/test_core/test_profile.py
@@ -10,16 +10,6 @@ from numpy.testing import assert_allclose
 from cogent3.core.profile import PSSM, MotifCountsArray, MotifFreqsArray
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sandra Smit", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class MotifCountsArrayTests(TestCase):
     def test_construct_succeeds(self):
         """construct from int array or list"""

--- a/tests/test_core/test_seq_aln_integration.py
+++ b/tests/test_core/test_seq_aln_integration.py
@@ -4,22 +4,11 @@
 from unittest import TestCase, main
 
 from numpy import alltrue, array, transpose
+from numpy.testing import assert_equal
 
 from cogent3.core.alignment import Alignment, ArrayAlignment
 from cogent3.core.moltype import RNA
 from cogent3.core.sequence import ArraySequence, RnaSequence
-
-
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sandra Smit", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Production"
-
-from numpy.testing import assert_equal
 
 
 class AllTests(TestCase):

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 import cogent3
 
+from cogent3._version import __version__
 from cogent3.core.moltype import (
     ASCII,
     BYTES,
@@ -41,15 +42,6 @@ from cogent3.core.sequence import (
 )
 from cogent3.util.misc import get_object_provenance
 
-
-__author__ = "Rob Knight, Gavin Huttley and Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Gavin Huttley", "Peter Maxwell", "Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 DATADIR = pathlib.Path(__file__).parent.parent / "data"
 

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -14,31 +14,11 @@ from numpy import array
 from numpy.testing import assert_allclose, assert_equal
 
 from cogent3 import load_tree, make_tree, open_
+from cogent3._version import __version__
 from cogent3.core.tree import PhyloNode, TreeError, TreeNode
 from cogent3.maths.stats.test import correlation
 from cogent3.parse.tree import DndParser
 from cogent3.util.misc import get_object_provenance
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Catherine Lozupone",
-    "Daniel McDonald",
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Andrew Butterfield",
-    "Matthew Wakefield",
-    "Justin Kuczynski",
-    "Jens Reeder",
-    "Jose Carlos Clemente Litran",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 
 base_path = os.path.dirname(os.path.dirname(__file__))

--- a/tests/test_data/__init__.py
+++ b/tests/test_data/__init__.py
@@ -1,11 +1,2 @@
 #!/usr/bin/env python
 __all__ = ["test_molecular_weight"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_data/test_molecular_weight.py
+++ b/tests/test_data/test_molecular_weight.py
@@ -3,19 +3,9 @@
 """
 from unittest import TestCase, main
 
-from cogent3.data.molecular_weight import ProteinMW, RnaMW
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 from numpy.testing import assert_allclose
+
+from cogent3.data.molecular_weight import ProteinMW, RnaMW
 
 
 class WeightCalculatorTests(TestCase):

--- a/tests/test_draw/__init__.py
+++ b/tests/test_draw/__init__.py
@@ -5,12 +5,3 @@ __all__ = [
     "test_logo",
     "test_shapes",
 ]
-
-__author__ = "Gavin Huttley and Rahul Ghangas"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"

--- a/tests/test_draw/test_dendrogram.py
+++ b/tests/test_draw/test_dendrogram.py
@@ -12,16 +12,6 @@ from cogent3.util.deserialise import deserialise_object
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Gavin Huttley and Rahul Ghangas"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Rahul Ghangas"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestDendro(TestCase):
     def test_geometry(self):
         """tree geometry class get_edge_names works"""

--- a/tests/test_draw/test_dotplot.py
+++ b/tests/test_draw/test_dotplot.py
@@ -11,16 +11,6 @@ from cogent3.draw.dotplot import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestUtilFunctions(TestCase):
     def test_len_seq(self):
         """returns length of sequence minus gaps"""

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -9,16 +9,6 @@ from cogent3.draw.drawable import AnnotatedDrawable, Drawable, get_domain
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def load_alignment(annotate1=False, annotate2=False):
     """creates an alignment with None, one or two sequences annotated"""
     db = GffAnnotationDb()

--- a/tests/test_draw/test_logo.py
+++ b/tests/test_draw/test_logo.py
@@ -5,16 +5,6 @@ from cogent3.draw.logo import _char_hts_as_lists, get_logo
 from cogent3.util.dict_array import DictArrayTemplate
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class LogoTests(TestCase):
     """testing utility functions"""
 

--- a/tests/test_draw/test_shapes.py
+++ b/tests/test_draw/test_shapes.py
@@ -5,16 +5,6 @@ from numpy.testing import assert_allclose
 from cogent3.draw import drawable
 
 
-__author__ = "Gavin Huttley and Rahul Ghangas"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Rahul Ghangas"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class Test_Shapes(TestCase):
     def test_shift(self):
         """Tests if the shape remains consistent with a shift of coordinate system along the line x=y"""

--- a/tests/test_evolve/__init__.py
+++ b/tests/test_evolve/__init__.py
@@ -12,12 +12,3 @@ __all__ = [
     "test_coevolution",
     "test_models",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Greg Caporaso"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_evolve/test_best_likelihood.py
+++ b/tests/test_evolve/test_best_likelihood.py
@@ -4,6 +4,8 @@ import math
 
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose
+
 from cogent3 import DNA, make_aligned_seqs
 from cogent3.evolve.best_likelihood import (
     BestLogLikelihood,
@@ -14,18 +16,6 @@ from cogent3.evolve.best_likelihood import (
     get_G93_lnL_from_array,
     get_ML_probs,
 )
-
-
-__author__ = "Helen Lindsay"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Helen Lindsay"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Helen Lindsay"
-__email__ = "helen.lindsay@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose
 
 
 IUPAC_DNA_ambiguities = "NRYWSKMBDHV"

--- a/tests/test_evolve/test_bootstrap.py
+++ b/tests/test_evolve/test_bootstrap.py
@@ -7,21 +7,6 @@ from cogent3 import load_aligned_seqs, load_tree
 from cogent3.evolve import bootstrap, substitution_model
 
 
-__author__ = "Peter Maxwell and  Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Matthew Wakefield",
-    "Helen Lindsay",
-    "Andrew Butterfield",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 base_path = os.getcwd()
 data_path = os.path.join(base_path, "data")
 

--- a/tests/test_evolve/test_coevolution.py
+++ b/tests/test_evolve/test_coevolution.py
@@ -13,6 +13,7 @@ from numpy import (
     sqrt,
     zeros,
 )
+from numpy.testing import assert_allclose, assert_equal
 
 from cogent3 import (
     DNA,
@@ -91,18 +92,6 @@ from cogent3.evolve.coevolution import (
     validate_tree,
 )
 from cogent3.maths.stats.number import CategoryCounter
-
-
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Greg Caporaso"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
-__status__ = "Beta"
-
-from numpy.testing import assert_allclose, assert_equal
 
 
 class CoevolutionTests(TestCase):

--- a/tests/test_evolve/test_distance.py
+++ b/tests/test_evolve/test_distance.py
@@ -47,16 +47,6 @@ warnings.filterwarnings("ignore", "Not using MPI as mpi4py not found")
 numpy.seterr(invalid="ignore")
 
 
-__author__ = "Gavin Huttley, Yicheng Zhu and Ben Kaehler"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Yicheng Zhu", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class TestPair(TestCase):
     dna_char_indices = get_moltype_index_array(DNA)
     rna_char_indices = get_moltype_index_array(RNA)

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -51,21 +51,6 @@ warnings.filterwarnings("ignore", "Ignoring tree edge lengths")
 TimeReversibleNucleotide = substitution_model.TimeReversibleNucleotide
 MotifChange = predicate.MotifChange
 
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Matthew Wakefield",
-    "Brett Easton",
-    "Ananias Iliadis",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
 
 base_path = os.getcwd()
 data_path = os.path.join(base_path, "data")

--- a/tests/test_evolve/test_models.py
+++ b/tests/test_evolve/test_models.py
@@ -20,16 +20,6 @@ from cogent3.evolve.models import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class CannedModelsTest(TestCase):
     """Check each canned model can actually be instantiated."""
 

--- a/tests/test_evolve/test_motifchange.py
+++ b/tests/test_evolve/test_motifchange.py
@@ -6,22 +6,6 @@ from cogent3.core.moltype import CodonAlphabet
 from cogent3.evolve.predicate import MotifChange, parse
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Matthew Wakefield",
-    "Brett Easton",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class FakeModel(object):
     def __init__(self, alphabet):
         self.alphabet = alphabet

--- a/tests/test_evolve/test_newq.py
+++ b/tests/test_evolve/test_newq.py
@@ -30,16 +30,6 @@ warnings.filterwarnings("ignore", "Motif probs overspecified")
 warnings.filterwarnings("ignore", "Model not reversible")
 
 
-__author__ = "Peter Maxwell and  Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _dinuc_root_probs(x, y=None):
     if y is None:
         y = x

--- a/tests/test_evolve/test_ns_substitution_model.py
+++ b/tests/test_evolve/test_ns_substitution_model.py
@@ -23,16 +23,6 @@ from cogent3.evolve.predicate import MotifChange
 from cogent3.evolve.substitution_model import TimeReversibleNucleotide
 
 
-__author__ = "Peter Maxwell and  Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Ananias Iliadis"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _make_likelihood(model, tree, results, is_discrete=False):
     """creates the likelihood function"""
     # discrete model fails to make a likelihood function if tree has

--- a/tests/test_evolve/test_parameter_controller.py
+++ b/tests/test_evolve/test_parameter_controller.py
@@ -3,22 +3,12 @@ import warnings
 
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose, assert_almost_equal
+
 import cogent3.evolve.parameter_controller
 import cogent3.evolve.substitution_model
 
 from cogent3 import make_aligned_seqs, make_tree
-
-
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose, assert_almost_equal
 
 
 base_path = os.getcwd()

--- a/tests/test_evolve/test_scale_rules.py
+++ b/tests/test_evolve/test_scale_rules.py
@@ -11,15 +11,6 @@ def a_c(x, y):
     return (x == "A" and y == "C") or (x == "C" and y == "A")
 
 
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 a_c = MotifChange("A", "C")
 trans = MotifChange("A", "G") | MotifChange("T", "C")
 

--- a/tests/test_evolve/test_simulation.py
+++ b/tests/test_evolve/test_simulation.py
@@ -9,16 +9,6 @@ from cogent3 import make_tree
 from cogent3.evolve import substitution_model
 
 
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def _est_simulations():
     # specify the 4 taxon tree, and a 'dummy' alignment
     t = make_tree(treestring="(a:0.4,b:0.3,(c:0.15,d:0.2)edge.0:0.1)root;")

--- a/tests/test_evolve/test_substitution_model.py
+++ b/tests/test_evolve/test_substitution_model.py
@@ -9,15 +9,6 @@ from cogent3.evolve.models import F81, GN, HKY85
 from cogent3.evolve.predicate import MotifChange
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 base_path = os.getcwd()
 data_path = os.path.join(base_path, "data")
 

--- a/tests/test_format/__init__.py
+++ b/tests/test_format/__init__.py
@@ -1,17 +1,2 @@
 #!/usr/bin/env python
 __all__ = ["test_bedgraph", "test_clustal", "test_fasta"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Gavin Huttley",
-    "Sandra Smit",
-    "Marcin Cieslik",
-    "Jeremy Widmann",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_format/test_bedgraph.py
+++ b/tests/test_format/test_bedgraph.py
@@ -5,16 +5,6 @@ from unittest import TestCase, main
 from cogent3.util.table import Table
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class FormatBedgraph(TestCase):
     def test_only_required_columns(self):
         """generate bedgraph from minimal data"""

--- a/tests/test_format/test_clustal.py
+++ b/tests/test_format/test_clustal.py
@@ -7,16 +7,6 @@ from cogent3.core.alignment import Alignment
 from cogent3.format.clustal import clustal_from_alignment
 
 
-__author__ = "Jeremy Widmann"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Jeremy Widmann"
-__email__ = "jeremy.widmann@colorado.edu"
-__status__ = "Production"
-
-
 class ClustalTests(TestCase):
     """Tests for Clustal writer."""
 

--- a/tests/test_format/test_fasta.py
+++ b/tests/test_format/test_fasta.py
@@ -9,16 +9,6 @@ from cogent3.core.sequence import Sequence
 from cogent3.format.fasta import alignment_to_fasta
 
 
-__author__ = "Jeremy Widmann"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Gavin Huttley", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Jeremy Widmann"
-__email__ = "jeremy.widmann@colorado.edu"
-__status__ = "Production"
-
-
 class FastaTests(TestCase):
     """Tests for Fasta writer."""
 

--- a/tests/test_maths/__init__.py
+++ b/tests/test_maths/__init__.py
@@ -7,20 +7,3 @@ __all__ = [
     "test_stats",
     "test_util",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Peter Maxwell",
-    "Catherine Lozupone",
-    "Gavin Huttley",
-    "Sandra Smit",
-    "Marcin Cieslik",
-    "Antonio Gonzalez Pena",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_maths/test_distance_transform.py
+++ b/tests/test_maths/test_distance_transform.py
@@ -45,16 +45,6 @@ from cogent3.maths.distance_transform import (
 )
 
 
-__author__ = "Justin Kuczynski"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = ["Justin Kuczynski", "Zongzhi Liu", "Greg Caporaso"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Justin Kuczynski"
-__email__ = "justinak@gmail.com"
-__status__ = "Prototype"
-
-
 class functionTests(TestCase):
     """Tests of top-level functions."""
 

--- a/tests/test_maths/test_geometry.py
+++ b/tests/test_maths/test_geometry.py
@@ -23,16 +23,6 @@ from cogent3.maths.geometry import (
 )
 
 
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sandra Smit", "Rob Knight", "Helmut Simon"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Production"
-
-
 class CenterOfMassTests(TestCase):
     """Tests for the center of mass functions"""
 

--- a/tests/test_maths/test_matrix_exponential_integration.py
+++ b/tests/test_maths/test_matrix_exponential_integration.py
@@ -3,22 +3,11 @@ from unittest import TestCase, main
 import numpy as np
 
 from numpy import array, diag, dot, exp
+from numpy.testing import assert_allclose
 
 import cogent3.maths.matrix_exponentiation as cmme
 
 from cogent3.maths import matrix_exponential_integration as expm
-
-
-__author__ = "Ben Kaehler"
-__copyright__ = "Copyright 2007-2014, The Cogent Project"
-__credits__ = ["Ben Kaehler", "Ananias Iliadis", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Ben Kaehler"
-__email__ = "benjamin.kaehler@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose
 
 
 class TestIntegratingExponentiator(TestCase):

--- a/tests/test_maths/test_matrix_logarithm.py
+++ b/tests/test_maths/test_matrix_logarithm.py
@@ -3,24 +3,13 @@
 from unittest import TestCase, main
 
 from numpy import array
+from numpy.testing import assert_allclose
 
 from cogent3.maths.matrix_logarithm import (
     is_generator_unique,
     logm,
     logm_taylor,
 )
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Gavin Huttley", "Ben Kaehler"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose
 
 
 class logarithm_tests(TestCase):

--- a/tests/test_maths/test_measure.py
+++ b/tests/test_maths/test_measure.py
@@ -14,16 +14,6 @@ from cogent3.maths.measure import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Stephen Ka-Wah Ma"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def gen_q_p():
     q1 = random((4, 4))
     indices = diag_indices(4)

--- a/tests/test_maths/test_optimisers.py
+++ b/tests/test_maths/test_optimisers.py
@@ -9,16 +9,6 @@ from unittest import TestCase, main
 from cogent3.maths.optimisers import MaximumEvaluationsReached, maximise
 
 
-__author__ = "Peter Maxwell and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 def quartic(x):
     # Has global maximum at -4 and local maximum at 2
     # http://www.wolframalpha.com/input/?i=x**2*%283*x**2%2B8*x-48%29

--- a/tests/test_maths/test_period.py
+++ b/tests/test_maths/test_period.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, main
 
 from numpy import arange, array, convolve, exp, float64, pi, random, sin, zeros
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from cogent3.maths.period import _autocorr_inner2 as py_autocorr_inner
 from cogent3.maths.period import _goertzel_inner as py_goertzel_inner
@@ -9,18 +10,6 @@ from cogent3.maths.period import auto_corr, dft, goertzel, hybrid, ipdft
 from cogent3.maths.period_numba import autocorr_inner as numba_autocorr_inner
 from cogent3.maths.period_numba import goertzel_inner as numba_goertzel_inner
 from cogent3.maths.period_numba import ipdft_inner as numba_ipdft_inner
-
-
-__author__ = "Hua Ying, Julien Epps and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Julien Epps", "Hua Ying", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 
 class TestPeriod(TestCase):

--- a/tests/test_maths/test_stats/__init__.py
+++ b/tests/test_maths/test_stats/__init__.py
@@ -1,11 +1,2 @@
 #!/usr/bin/env python
 __all__ = ["test_distribution", "test_special", "test_ks", "test_test"]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Catherine Lozupone", "Gavin Huttley", "Sandra Smit"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_maths/test_stats/test_contingency.py
+++ b/tests/test_maths/test_stats/test_contingency.py
@@ -8,16 +8,6 @@ from cogent3.maths.stats.contingency import CategoryCounts, calc_expected
 from cogent3.util.dict_array import DictArrayTemplate
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class ContingencyTests(TestCase):
     def test_chisq(self):
         """correctly compute chisq test"""

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -6,6 +6,8 @@ Currently using tests against calculations in R, spreadsheets being unreliable.
 
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose, assert_almost_equal
+
 from cogent3.maths.stats.distribution import (
     bdtr,
     bdtrc,
@@ -29,18 +31,6 @@ from cogent3.maths.stats.distribution import (
     tprob,
     zprob,
 )
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Rob Knight", "Sandra Smit"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose, assert_almost_equal
 
 
 class DistributionsTests(TestCase):

--- a/tests/test_maths/test_stats/test_information_criteria.py
+++ b/tests/test_maths/test_stats/test_information_criteria.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python
 from unittest import TestCase, main
 
-from cogent3.maths.stats.information_criteria import aic, bic
-
-
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 from numpy.testing import assert_allclose
+
+from cogent3.maths.stats.information_criteria import aic, bic
 
 
 class InformationCriteria(TestCase):

--- a/tests/test_maths/test_stats/test_jackknife.py
+++ b/tests/test_maths/test_stats/test_jackknife.py
@@ -2,19 +2,9 @@ from unittest import TestCase, main
 
 import numpy as np
 
-from cogent3.maths.stats.jackknife import JackknifeStats
-
-
-__author__ = "Anuj Pahwa, Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Anuj Pahwa", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 from numpy.testing import assert_allclose
+
+from cogent3.maths.stats.jackknife import JackknifeStats
 
 
 def pmcc(data, axis=1):

--- a/tests/test_maths/test_stats/test_ks.py
+++ b/tests/test_maths/test_stats/test_ks.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose
+
 from cogent3.maths.stats.ks import (
     pkolmogorov1x,
     pkolmogorov2x,
@@ -8,18 +10,6 @@ from cogent3.maths.stats.ks import (
     psmirnov2x,
 )
 from cogent3.maths.stats.test import ks_boot, ks_test
-
-
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose
 
 
 class KSTests(TestCase):

--- a/tests/test_maths/test_stats/test_number.py
+++ b/tests/test_maths/test_stats/test_number.py
@@ -8,16 +8,6 @@ from cogent3 import make_aligned_seqs
 from cogent3.maths.stats import number
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestNumber(TestCase):
     def test_construction(self):
         nums = number.CategoryCounter("AAAACCCGGGGT")

--- a/tests/test_maths/test_stats/test_period.py
+++ b/tests/test_maths/test_stats/test_period.py
@@ -2,6 +2,8 @@ from unittest import TestCase, main
 
 import numpy
 
+from numpy.testing import assert_allclose, assert_equal
+
 from cogent3.maths.period import AutoCorrelation, Hybrid, Ipdft, ipdft
 from cogent3.maths.stats.period import (
     SeqToSymbols,
@@ -12,18 +14,6 @@ from cogent3.maths.stats.period import (
     g_statistic,
     seq_to_symbols,
 )
-
-
-__author__ = "Hua Ying, Julien Epps and Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Julien Epps", "Hua Ying", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose, assert_equal
 
 
 class TestPeriodStat(TestCase):

--- a/tests/test_maths/test_stats/test_special.py
+++ b/tests/test_maths/test_stats/test_special.py
@@ -5,6 +5,8 @@ import math
 
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose
+
 from cogent3.maths.stats.special import (
     combinations,
     combinations_exact,
@@ -20,18 +22,6 @@ from cogent3.maths.stats.special import (
     permutations,
     permutations_exact,
 )
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Rob Knight", "Sandra Smit"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose
 
 
 class SpecialTests(TestCase):

--- a/tests/test_maths/test_stats/test_test.py
+++ b/tests/test_maths/test_stats/test_test.py
@@ -17,6 +17,7 @@ from numpy import (
     testing,
     tril,
 )
+from numpy.testing import assert_allclose, assert_equal
 
 from cogent3.maths.stats.number import NumberCounter
 from cogent3.maths.stats.test import (
@@ -77,26 +78,6 @@ from cogent3.maths.stats.test import (
     tail,
     z_test,
 )
-
-
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Catherine Lozupone",
-    "Gavin Huttley",
-    "Sandra Smit",
-    "Daniel McDonald",
-    "Jai Ram Rideout",
-    "Michael Dwan",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose, assert_equal
 
 
 def is_prob(value):

--- a/tests/test_maths/test_util.py
+++ b/tests/test_maths/test_util.py
@@ -27,15 +27,6 @@ filterwarnings("ignore", "invalid value encountered in", category=RuntimeWarning
 
 Float = numpy.core.numerictypes.sctype2char(float)
 
-__author__ = "Rob Knight and Jeremy Widmann"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jeremy Widmann", "Rob Knight", "Sandra Smit"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 
 class ArrayMathTests(TestCase):
     def test_safe_p_log_p(self):

--- a/tests/test_parse/__init__.py
+++ b/tests/test_parse/__init__.py
@@ -17,26 +17,3 @@ __all__ = [
     "test_tree",
     "test_unigene",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Jeremy Widmann",
-    "Catherine Lozuopone",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Sandra Smit",
-    "Micah Hamady",
-    "Jeremy Widmann",
-    "Hua Ying",
-    "Greg Caporaso",
-    "Zongzhi Liu",
-    "Jason Carnes",
-    "Peter Maxwell",
-    "Marcin Cieslik",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_parse/test_blast.py
+++ b/tests/test_parse/test_blast.py
@@ -1,5 +1,7 @@
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose, assert_equal
+
 from cogent3.parse.blast import (
     FastacmdTaxonomyParser,
     GenericBlastParser9,
@@ -19,18 +21,6 @@ from cogent3.parse.blast import (
     make_label,
     query_finder,
 )
-
-
-__author__ = "Micah Hamady"
-__copyright__ = "Copyright 2007-2016, The Cogent Project"
-__credits__ = ["Micah Hamady", "Rob Knight"]
-__license__ = "GPL"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Micah Hamady"
-__email__ = "hamady@colorado.edu"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose, assert_equal
 
 
 class BlastTests(TestCase):

--- a/tests/test_parse/test_blast_xml.py
+++ b/tests/test_parse/test_blast_xml.py
@@ -3,16 +3,6 @@
 # test_blast_xml.py
 #
 
-__author__ = "Kristian Rother"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__contributors__ = ["Micah Hamady"]
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Kristian Rother"
-__email__ = "krother@rubor.de"
-__status__ = "Prototype"
-
 
 import xml.dom.minidom
 

--- a/tests/test_parse/test_cigar.py
+++ b/tests/test_parse/test_cigar.py
@@ -11,16 +11,6 @@ from cogent3.parse.cigar import (
 )
 
 
-__author__ = "Hua Ying"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Hua Ying", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Hua Ying"
-__email__ = "hua.ying@anu.edu.au"
-__status__ = "Production"
-
-
 class TestCigar(unittest.TestCase):
     def setUp(self):
         self.cigar_text = "3D2M3D6MDM2D3MD"

--- a/tests/test_parse/test_clustal.py
+++ b/tests/test_parse/test_clustal.py
@@ -12,15 +12,6 @@ from cogent3.parse.clustal import (
 from cogent3.parse.record import RecordError
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Sandra Smit"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 # Note: the data are all strings and hence immutable, so it's OK to define
 # them here instead of in setUp and then subclassing everything from that
 # base class. If the data were mutable, we'd need to take more precautions

--- a/tests/test_parse/test_dialign.py
+++ b/tests/test_parse/test_dialign.py
@@ -6,16 +6,6 @@ from cogent3 import PROTEIN
 from cogent3.parse.dialign import DialignParser, parse_data_line
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 data = """
                            DIALIGN 2.2.1 
                            *************

--- a/tests/test_parse/test_ebi.py
+++ b/tests/test_parse/test_ebi.py
@@ -60,16 +60,6 @@ from cogent3.parse.ebi import (
 )
 
 
-__author__ = "Zongzhi Liu"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Zongzhi Liu", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Zongzhi Liu"
-__email__ = "zongzhi.liu@gmail.com"
-__status__ = "Development"
-
-
 def item_empty_filter(d):
     """return a dict with only nonempty values"""
     pairs = [(k, v) for (k, v) in d.items() if v]

--- a/tests/test_parse/test_fasta.py
+++ b/tests/test_parse/test_fasta.py
@@ -21,15 +21,6 @@ from cogent3.parse.fasta import (
 from cogent3.parse.record import RecordError
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 base_path = os.path.dirname(os.path.dirname(__file__))
 data_path = os.path.join(base_path, "data")
 

--- a/tests/test_parse/test_gbseq.py
+++ b/tests/test_parse/test_gbseq.py
@@ -5,15 +5,6 @@ from unittest import TestCase, main
 from cogent3.parse.gbseq import GbSeqXmlParser
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 data = """<?xml version="1.0"?>
  <!DOCTYPE GBSet PUBLIC "-//NCBI//NCBI GBSeq/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_GBSeq.dtd">
  <GBSet>

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -21,16 +21,6 @@ from cogent3.parse.genbank import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class GenBankTests(TestCase):
     """Tests of the GenBank main functions."""
 

--- a/tests/test_parse/test_gff.py
+++ b/tests/test_parse/test_gff.py
@@ -12,15 +12,6 @@ import pytest
 from cogent3.parse.gff import gff_parser, parse_attributes_gff2
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 headers = [

--- a/tests/test_parse/test_greengenes.py
+++ b/tests/test_parse/test_greengenes.py
@@ -9,15 +9,8 @@ from cogent3.parse.greengenes import (
 )
 
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"  # consider project name
+# consider project name
 # remember to add yourself if you make changes
-__credits__ = ["Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Daniel McDonald"
-__email__ = "daniel.mcdonald@colorado.edu"
-__status__ = "Prototype"
 
 
 class ParseGreengenesRecordsTests(TestCase):

--- a/tests/test_parse/test_locuslink.py
+++ b/tests/test_parse/test_locuslink.py
@@ -21,16 +21,6 @@ from cogent3.parse.locuslink import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class locuslinkTests(TestCase):
     """Tests toplevel functions."""
 

--- a/tests/test_parse/test_ncbi_taxonomy.py
+++ b/tests/test_parse/test_ncbi_taxonomy.py
@@ -16,15 +16,6 @@ from cogent3.parse.ncbi_taxonomy import (
 )
 
 
-__author__ = "Jason Carnes"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Jason Carnes", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 good_nodes = """1\t|\t1\t|\tno rank\t|\t\t|\t8\t|\t0\t|\t1\t|\t0\t|\t0\t|\t0\t|\t0\t|\t0\t|\t\t|
 2\t|\t1\t|\tsuperkingdom\t|\t\t|\t0\t|\t0\t|\t11\t|\t0\t|\t0\t|\t0\t|\t0\t|\t0\t|\t\t|
 6\t|\t2\t|\tgenus\t|\t\t|\t0\t|\t1\t|\t11\t|\t1\t|\t0\t|\t1\t|\t0\t|\t0\t|\t|\t

--- a/tests/test_parse/test_nexus.py
+++ b/tests/test_parse/test_nexus.py
@@ -18,15 +18,6 @@ from cogent3.parse.nexus import (
 )
 
 
-__author__ = "Catherine Lozupone"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Catherine Lozupone", "Rob Knight", "Micah Hamady"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Catherine Lozupone"
-__email__ = "lozupone@colorado.edu"
-__status__ = "Production"
-
 Nexus_tree = """#NEXUS 
 
 Begin trees;  [Treefile saved Wednesday, May 5, 2004  5:02 PM]

--- a/tests/test_parse/test_pamlmatrix.py
+++ b/tests/test_parse/test_pamlmatrix.py
@@ -2,20 +2,10 @@
 from io import StringIO
 from unittest import TestCase, main
 
+from numpy.testing import assert_equal
+
 from cogent3.evolve.models import DSO78_freqs, DSO78_matrix
 from cogent3.parse.paml_matrix import PamlMatrixParser
-
-
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
-from numpy.testing import assert_equal
 
 
 data = """

--- a/tests/test_parse/test_phylip.py
+++ b/tests/test_parse/test_phylip.py
@@ -8,16 +8,6 @@ from unittest import TestCase, main
 from cogent3.parse.phylip import MinimalPhylipParser, get_align_for_phylip
 
 
-__author__ = "Micah Hamady"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Micah Hamady", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Micah Hamady"
-__email__ = "hamady@colorado.edu"
-__status__ = "Production"
-
-
 class PhylipGenericTest(TestCase):
     """Setup data for Phylip parsers."""
 

--- a/tests/test_parse/test_psl.py
+++ b/tests/test_parse/test_psl.py
@@ -8,15 +8,6 @@ from unittest import TestCase, main
 from cogent3.parse.psl import MinimalPslParser, PslToTable
 
 
-__author__ = "Gavin Huttley, Anuj Pahwa"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Gavin Huttley", "Anuj Pahwa"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Development"
-
 fname = "data/test.psl"
 
 

--- a/tests/test_parse/test_pwm_parsers.py
+++ b/tests/test_parse/test_pwm_parsers.py
@@ -7,16 +7,6 @@ from cogent3.core.moltype import get_moltype
 from cogent3.parse import cisbp, jaspar
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2012, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestPwmParsers(TestCase):
     def test_jaspar(self):
         """correctly load jaspar formatted counts matrix"""

--- a/tests/test_parse/test_rdb.py
+++ b/tests/test_parse/test_rdb.py
@@ -16,16 +16,6 @@ from cogent3.parse.rdb import (
 from cogent3.parse.record import RecordError
 
 
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Sandra Smit", "Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Production"
-
-
 class RdbTests(TestCase):
     """Tests for top-level functions in Rdb.py"""
 

--- a/tests/test_parse/test_record.py
+++ b/tests/test_parse/test_record.py
@@ -24,16 +24,6 @@ from cogent3.parse.record import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class recordsTests(TestCase):
     """Tests of top-level functionality in records."""
 

--- a/tests/test_parse/test_record_finder.py
+++ b/tests/test_parse/test_record_finder.py
@@ -13,16 +13,6 @@ from cogent3.parse.record_finder import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Zongzhi Liu"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class TailedRecordFinderTests(TestCase):
     """Tests of the TailedRecordFinder factory function."""
 

--- a/tests/test_parse/test_tinyseq.py
+++ b/tests/test_parse/test_tinyseq.py
@@ -5,15 +5,6 @@ from unittest import TestCase, main
 from cogent3.parse.tinyseq import TinyseqParser
 
 
-__author__ = "Matthew Wakefield"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Matthew Wakefield"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Matthew Wakefield"
-__email__ = "wakefield@wehi.edu.au"
-__status__ = "Production"
-
 data = """<?xml version="1.0"?>
  <!DOCTYPE TSeqSet PUBLIC "-//NCBI//NCBI TSeq/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_TSeq.dtd">
  <TSeqSet>

--- a/tests/test_parse/test_tree.py
+++ b/tests/test_parse/test_tree.py
@@ -15,14 +15,6 @@ from cogent3.parse.tree import DndParser, DndTokenizer, RecordError
 #        return NodeClass(children = list(children or []), name=name, params=attribs)
 #    return parse_string(data, constructor)
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Peter Maxwell", "Daniel McDonald"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
 
 sample = """
 (

--- a/tests/test_parse/test_unigene.py
+++ b/tests/test_parse/test_unigene.py
@@ -14,16 +14,6 @@ from cogent3.parse.unigene import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class unigeneTests(TestCase):
     """Tests toplevel functions."""
 

--- a/tests/test_phylo.py
+++ b/tests/test_phylo.py
@@ -25,21 +25,6 @@ from cogent3.util.io import remove_files
 warnings.filterwarnings("ignore", "Not using MPI as mpi4py not found")
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Peter Maxwell",
-    "Gavin Huttley",
-    "Matthew Wakefield",
-    "Daniel McDonald",
-    "Ben Kaehler",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 base_path = os.path.dirname(__file__)
 data_path = os.path.join(base_path, "data")
 

--- a/tests/test_recalculation.py
+++ b/tests/test_recalculation.py
@@ -7,16 +7,6 @@ from cogent3.recalculation.scope import (
 )
 
 
-__author__ = "Peter Maxwell"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class RecalculationTest(TestCase):
     def test_recalculation(self):
         def add(*args):

--- a/tests/test_util/__init__.py
+++ b/tests/test_util/__init__.py
@@ -8,21 +8,3 @@ __all__ = [
     "test_union_dict",
     "test_warning",
 ]
-
-__author__ = ""
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Jeremy Widmann",
-    "Sandra Smit",
-    "Gavin Huttley",
-    "Rob Knight",
-    "Zongzhi Liu",
-    "Amanda Birmingham",
-    "Greg Caporaso",
-    "Richard Morris",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"

--- a/tests/test_util/test_deserialise.py
+++ b/tests/test_util/test_deserialise.py
@@ -29,16 +29,6 @@ from cogent3.util.deserialise import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class TestDeserialising(TestCase):
     def test_roundtrip_codon_alphabet(self):
         """codon alphabet to_json enables roundtrip"""

--- a/tests/test_util/test_dictarray.py
+++ b/tests/test_util/test_dictarray.py
@@ -21,16 +21,6 @@ from cogent3.util.dict_array import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 class DictArrayTest(TestCase):
     a = numpy.identity(3, int)
 

--- a/tests/test_util/test_io.py
+++ b/tests/test_util/test_io.py
@@ -19,15 +19,6 @@ from cogent3.util.io import (
 )
 
 
-__author__ = "Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Nick Shahmaras"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
 DATADIR = pathlib.Path(__file__).parent.parent / "data"
 
 

--- a/tests/test_util/test_misc.py
+++ b/tests/test_util/test_misc.py
@@ -46,23 +46,6 @@ from cogent3.util.misc import (
 )
 
 
-__author__ = "Rob Knight"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = [
-    "Rob Knight",
-    "Amanda Birmingham",
-    "Sandra Smit",
-    "Zongzhi Liu",
-    "Peter Maxwell",
-    "Daniel McDonald",
-]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class UtilsTests(TestCase):
     """Tests of individual functions in utils"""
 

--- a/tests/test_util/test_parallel.py
+++ b/tests/test_util/test_parallel.py
@@ -9,16 +9,6 @@ import numpy
 from cogent3.util import parallel
 
 
-__author__ = "Sheng Han Moses Koh"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Sheng Han Moses Koh"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "Gavin.Huttley@anu.edu.au"
-__status__ = "Alpha"
-
-
 def get_process_value(n):
     # Sleep to accommodate Windows process creation overhead
     time.sleep(1)

--- a/tests/test_util/test_recode_alignment.py
+++ b/tests/test_util/test_recode_alignment.py
@@ -15,16 +15,6 @@ from cogent3.util.recode_alignment import (
 )
 
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Greg Caporaso"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
-__status__ = "Beta"
-
-
 class RecodeAlignmentTests(TestCase):
     """Tests of functions in recode_alphabet.py
 

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -40,15 +40,6 @@ except ImportError:
 
 TEST_ROOT = pathlib.Path(__file__).parent.parent
 
-__author__ = "Thomas La"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Thomas La", "Christopher Bradley"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 
 class TrapOutput:
     def __call__(self, data, *args, **kwargs):

--- a/tests/test_util/test_transform.py
+++ b/tests/test_util/test_transform.py
@@ -3,6 +3,8 @@
 """
 from unittest import TestCase, main
 
+from numpy.testing import assert_allclose
+
 from cogent3.util.transform import (
     KeepChars,
     first_index_in_set,
@@ -10,18 +12,6 @@ from cogent3.util.transform import (
     per_longest,
     per_shortest,
 )
-
-
-__author__ = "Sandra Smit"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Rob Knight", "Sandra Smit", "Zongzhi Liu"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Sandra Smit"
-__email__ = "sandra.smit@colorado.edu"
-__status__ = "Production"
-
-from numpy.testing import assert_allclose
 
 
 class has_x(object):

--- a/tests/test_util/test_union_dict.py
+++ b/tests/test_util/test_union_dict.py
@@ -7,16 +7,6 @@ from unittest import TestCase, main
 from cogent3.util.union_dict import UnionDict
 
 
-__author__ = "Thomas La"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Thomas La"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 class UnionDictTests(TestCase):
     """Tests of individual functions in union_dict"""
 

--- a/tests/test_util/test_warning.py
+++ b/tests/test_util/test_warning.py
@@ -6,16 +6,6 @@ import pytest
 from cogent3.util.warning import deprecated_args, deprecated_callable
 
 
-__author__ = "Richard Morris"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Gavin Huttley", "Richard Morris"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_function_deprecated_args():
     @deprecated_args(

--- a/tests/timetrial.py
+++ b/tests/timetrial.py
@@ -11,15 +11,6 @@ import sys
 import time
 
 
-__author__ = "Peter Maxwell and  Gavin Huttley"
-__copyright__ = "Copyright 2007-2022, The Cogent Project"
-__credits__ = ["Peter Maxwell", "Gavin Huttley", "Edward Lang"]
-__license__ = "BSD-3"
-__version__ = "2023.2.12a1"
-__maintainer__ = "Gavin Huttley"
-__email__ = "gavin.huttley@anu.edu.au"
-__status__ = "Production"
-
 # Values that affect the running of the program.
 minimum_accepted_time = 2
 


### PR DESCRIPTION
[REMOVED] having a private attributes header in every file is
        difficult to keep up-to-date, updating can cause conflicts,
        etc..., this is now removed!

[NEW]    __version__ is now defined in only two places,
        cogent3.__init__.py and cogent3._version.py

[CHANGED]credits is now tracked using GitHub, see contributors at
        https://github.com/cogent3/cogent3/graphs/contributors,
        thanks to all contributors!!

fixes #1341