### PR TITLE
API: align.pycompare.find_matched_paths() requires keyword arguments

### DIFF
--- a/src/cogent3/align/pycompare.py
+++ b/src/cogent3/align/pycompare.py
@@ -555,13 +555,14 @@ def _calc_seed_size(w: int, t: int) -> int:
 
 
 def find_matched_paths(
+    *,
     seq_kmers: SeqKmers,
     seq1: Sequence,
     seq2: Optional[Sequence] = None,
     window: int = 20,
     threshold: int = 17,
 ) -> MatchedSeqPaths:
-    """determine all matches between seq1 and seq21
+    """determine all matches between seq1 and seq2
 
     Parameters
     ----------

--- a/src/cogent3/draw/dotplot.py
+++ b/src/cogent3/draw/dotplot.py
@@ -256,7 +256,7 @@ class Dotplot(Drawable):
         sk = SeqKmers(seq1, k=k, canonical=set(seq1.moltype))
         seq2 = None if seq1 == seq2 else seq2
         fwd = find_matched_paths(
-            sk, seq1=seq1, seq2=seq2, window=window, threshold=threshold
+            seq_kmers=sk, seq1=seq1, seq2=seq2, window=window, threshold=threshold
         )
         fwd.name = "+ strand"
         if rc:
@@ -266,7 +266,7 @@ class Dotplot(Drawable):
             seq2 = seq1.rc() if seq2 is None else seq2.rc()
             seq2.name = f"{seq2.name}-rc"
             rev = find_matched_paths(
-                sk, seq1=seq1, seq2=seq2, window=window, threshold=threshold
+                seq_kmers=sk, seq1=seq1, seq2=seq2, window=window, threshold=threshold
             )
             rev.name = "- strand"
         else:

--- a/tests/test_align/test_compare.py
+++ b/tests/test_align/test_compare.py
@@ -55,7 +55,7 @@ def test_find_matched_k_eq_1():
     s2 = make_seq("CTGGAAGGGT", name="2")
     expect = _brute_force(s1, s2, window=5, threshold=3)
     sk = SeqKmers(s1, k=1, canonical=set("ACGT"))
-    got = find_matched_paths(sk, s1, s2, window=5, threshold=3)
+    got = find_matched_paths(seq_kmers=sk, seq1=s1, seq2=s2, window=5, threshold=3)
     assert got.paths == expect.paths
 
 
@@ -295,9 +295,9 @@ def test_find_matched_paths_2seq(aseq1, aseq2):
     expect = _brute_force(aseq1, aseq2, 3, 3)
     sk = SeqKmers(aseq1, k=3, canonical=set("ACGT"))
     got = find_matched_paths(
-        sk,
-        aseq1,
-        aseq2,
+        seq_kmers=sk,
+        seq1=aseq1,
+        seq2=aseq2,
         window=3,
         threshold=3,
     )
@@ -345,9 +345,9 @@ def test_find_matched_paths_moltype(aseq1, aseq2, moltype):
     expect = _brute_force(s1, s2, 3, 3)
     sk = SeqKmers(aseq1, k=3, canonical="ACGT")
     got = find_matched_paths(
-        sk,
-        s1,
-        s2,
+        seq_kmers=sk,
+        seq1=s1,
+        seq2=s2,
         window=3,
         threshold=3,
     )
@@ -362,7 +362,7 @@ def test_find_matched_with_rc():
     expect = _brute_force(s, r, 4, 4)
     sk = SeqKmers(s, k=k, canonical="ACGT")
     # note there's a bug here, it creates a y_intercept at -11
-    got = find_matched_paths(sk, s, r, window=4, threshold=4)
+    got = find_matched_paths(seq_kmers=sk, seq1=s, seq2=r, window=4, threshold=4)
     assert got.paths == expect.paths
     x, y = got.paths[4][0]
     yrc = y.for_rc(len(s))
@@ -375,16 +375,16 @@ def test_find_matched_1seq(w, t):
     s = make_seq("CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
     expect = _brute_force(s, s, w, t)
     sk = SeqKmers(s, k=w, canonical=set("ACGT"))
-    got = find_matched_paths(sk, s, window=w, threshold=t)
+    got = find_matched_paths(seq_kmers=sk, seq1=s, window=w, threshold=t)
     assert got.paths == expect.paths
 
 
 def test_plotly_trace(aseq1, aseq2):
     sk = SeqKmers(aseq1, k=3, canonical=set("ACGT"))
     got = find_matched_paths(
-        sk,
-        aseq1,
-        aseq2,
+        seq_kmers=sk,
+        seq1=aseq1,
+        seq2=aseq2,
         window=3,
         threshold=3,
     )


### PR DESCRIPTION
[CHANGED] a precursor to enabling modifying the signature