### PR TITLE
ENH: added lower bound parameter to app.model(), fixes #1452

### DIFF
--- a/changelog.d/20230525_111647_Gavin.Huttley.md
+++ b/changelog.d/20230525_111647_Gavin.Huttley.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Contributers
+
+- A bullet item for the Contributers category.
+
+-->
+### ENH
+
+- Added optional argument `lower` to `app.model()`. This provides a global
+  mechanism for setting the lower bound on rate and length parameters.
+
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -39,7 +39,7 @@ class TestModel(TestCase):
             "model(sm='HKY85', tree=None, unique_trees=False, "
             "name=None, optimise_motif_probs=False, sm_args=None, lf_args=None, "
             "time_het='max', param_rules=None, "
-            "opt_args=None, upper=50, split_codons=False, "
+            "opt_args=None, lower=1e-06, upper=50, split_codons=False, "
             "show_progress=False, verbose=False)"
         )
         self.assertEqual(
@@ -189,6 +189,27 @@ class TestModel(TestCase):
         expect_nfp = 11 * 2 + 3 + 3
         self.assertEqual(result.lf.nfp, expect_nfp)
 
+    def test_setting_model_bounds(self):
+        upper = 10.0
+        lower = 0.5
+        app = evo_app.model(
+            "HKY85",
+            optimise_motif_probs=True,
+            show_progress=False,
+            unique_trees=True,
+            time_het="max",
+            lower=lower,
+            upper=upper,
+        )
+
+        aln = make_aligned_seqs(data=dict(s1="ACGT", s2="ACGC", s3="AAGT"))
+        result = app(aln)
+        rules = result.lf.get_param_rules()
+        kappa_bounds = {
+            (r["lower"], r["upper"]) for r in rules if r["par_name"] == "kappa"
+        }
+        assert kappa_bounds == set([(lower, upper)])
+
     def test_model_param_rules(self):
         """applies upper bound if sensible"""
         mod = evo_app.model(
@@ -268,11 +289,11 @@ class TestModel(TestCase):
         expect = (
             "hypothesis(null=model(sm='HKY85', tree=None, unique_trees=False, "
             "name=None, optimise_motif_probs=False, sm_args=None, lf_args=None, "
-            "time_het=None, param_rules=None, opt_args=None, upper=50, "
+            "time_het=None, param_rules=None, opt_args=None, lower=1e-06, upper=50, "
             "split_codons=False, show_progress=False, verbose=False), "
             "alternates=(model(sm='HKY85', tree=None, unique_trees=False, "
             "name='hky85-max-het', optimise_motif_probs=False, sm_args=None, lf_args=None, "
-            "time_het='max', param_rules=None, opt_args=None, upper=50,"
+            "time_het='max', param_rules=None, opt_args=None, lower=1e-06, upper=50,"
             " split_codons=False, show_progress=False, verbose=False),),"
             " sequential=True, init_alt=None)"
         )


### PR DESCRIPTION
[NEW] We now use a function for ensuring consistency of setting bounds,
    plus apply the new lower bound to all model branch length and substitution
    model rate parameters.

[CHANGED] the issue was not entirely correct. It related to the fact that
    param_rules that specified a rate term in a model that also defined time_het
    were ignored.