### PR TITLE
MAINT: better NotCompleted result from sp_score

### DIFF
--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -4,9 +4,8 @@ from bisect import bisect_left
 from itertools import combinations
 from typing import Optional, Union
 
-from numpy import array
+from numpy import array, isnan
 
-from cogent3 import make_tree
 from cogent3.align import (
     global_pairwise,
     make_dna_scoring_dict,
@@ -713,6 +712,18 @@ class sp_score:
 
         self._calc(aln, show_progress=False)
         dmat = self._calc.dists
+
+        if isnan(dmat.array).sum():
+            nans = isnan(dmat.array).sum(axis=0) > 0
+            names = ", ".join(f"{n!r}" for n in array(dmat.names)[nans])
+            return NotCompleted(
+                "ERROR",
+                self,
+                f"Some genetic distances involving {names} were NaN's. "
+                "Using calc='pdist' will prevent this issue.",
+                source=aln,
+            )
+
         lengths = self._calc.lengths
         for i, j in combinations(range(aln.num_seqs), 2):
             n1, n2 = dmat.names[i], dmat.names[j]

--- a/tests/test_app/test_align.py
+++ b/tests/test_app/test_align.py
@@ -562,6 +562,16 @@ def test_sp_score_exclude_gap():
     assert_allclose(got, expect)
 
 
+def test_sp_fail():
+    aln = make_aligned_seqs(
+        data={"a": "ATG---------AATCGAAGA", "b": "GTG---------GAAAAGCAG"}, moltype="dna"
+    )
+    app = get_app("sp_score")
+    got = app.main(aln)
+    assert isinstance(got, NotCompleted)
+    assert "NaN" in got.message
+
+
 def test_sp_score_additive_gap():
     # additive gap score
     app = get_app("sp_score", calc="pdist", gap_extend=1, gap_insert=0)


### PR DESCRIPTION
[CHANGED] The alignment quality sp_score relies on computing pairwise
     genetic distanxces. This can fail due to NaN's in those distances.
     Return a more informative NotCompleted object.