### PR TITLE
API: added strict argument to has_terminal_stop() method

### DIFF
--- a/changelog.d/20230712_102325_Gavin.Huttley.md
+++ b/changelog.d/20230712_102325_Gavin.Huttley.md
@@ -1,0 +1,44 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Contributors
+
+- A bullet item for the Contributors category.
+
+-->
+<!--
+### ENH
+
+- A bullet item for the ENH category.
+
+-->
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+
+### Deprecations
+
+- <collection>.has_terminal_stops() is being deprecated for
+  <collection>.has_terminal_stop(), because it returns True if a single
+  sequence has a terminal stop.
+
+
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3594,3 +3594,35 @@ def test_aligned_rich_dict(reverse):
     rd = seq.to_rich_dict()
     got = Aligned.from_rich_dict(rd)
     assert str(seq) == str(got)
+
+
+@pytest.mark.parametrize("cls", (SequenceCollection, Alignment, ArrayAlignment))
+@pytest.mark.parametrize(
+    "gc,seqs", ((1, ("TCCTGA", "GATTT?")), (2, ("GATTTT", "TCCAGG")))
+)
+def test_has_terminal_stop_true(cls, gc, seqs):
+    gc = get_code(gc)
+    data = {f"s{i}": s for i, s in enumerate(seqs)}
+    seqs = cls(data=data, moltype="dna")
+    assert seqs.has_terminal_stop(gc=gc)
+
+
+@pytest.mark.parametrize("cls", (SequenceCollection, Alignment, ArrayAlignment))
+@pytest.mark.parametrize(
+    "gc,seqs",
+    ((1, ("TCCTCA", "GATTTT")), (2, ("GATTTT", "TCCCGG")), (1, ("CCTCA", "ATTTT"))),
+)
+def test_has_terminal_stop_false(cls, gc, seqs):
+    gc = get_code(gc)
+    data = {f"s{i}": s for i, s in enumerate(seqs)}
+    seqs = cls(data=data, moltype="dna")
+    assert not seqs.has_terminal_stop(gc=gc)
+
+
+@pytest.mark.parametrize("cls", (SequenceCollection, Alignment, ArrayAlignment))
+def test_has_terminal_stop_strict(cls):
+    gc = get_code(1)
+    data = {f"s{i}": s for i, s in enumerate(("CCTCA", "ATTTT"))}
+    seqs = cls(data=data, moltype="dna")
+    with pytest.raises(ValueError):
+        seqs.has_terminal_stop(gc=gc, strict=True)

--- a/tests/test_core/test_core_standalone.py
+++ b/tests/test_core/test_core_standalone.py
@@ -760,38 +760,6 @@ class AlignmentTestMethods(unittest.TestCase):
         aln = aln.trim_stop_codons()
         self.assertEqual(aln.info["key"], "value")
 
-    def test_has_terminal_stops(self):
-        """test truth values for terminal stops"""
-        # seq collections
-        seq_coll = make_unaligned_seqs(
-            data={"seq1": "ACGTAA", "seq2": "ACG", "seq3": "ACGCGT"}, moltype=DNA
-        )
-        assert seq_coll.has_terminal_stops() == True
-        seq_coll = make_unaligned_seqs(
-            data={"seq1": "ACGTAC", "seq2": "ACGACG", "seq3": "ACGCGT"}, moltype=DNA
-        )
-        assert seq_coll.has_terminal_stops() == False
-        # alignments
-        aln = make_aligned_seqs(
-            data={"seq1": "ACGTAA", "seq2": "ACGCAA", "seq3": "ACGCGT"}, moltype=DNA
-        )
-        assert aln.has_terminal_stops() == True
-        aln = make_aligned_seqs(
-            data={"seq1": "ACGTAA", "seq2": "ACGTAG", "seq3": "ACGTGA"}, moltype=DNA
-        )
-        assert aln.has_terminal_stops() == True
-        aln = make_aligned_seqs(
-            data={"seq1": "ACGCAA", "seq2": "ACGCAA", "seq3": "ACGCGT"}, moltype=DNA
-        )
-        assert aln.has_terminal_stops() == False
-
-        # ValueError if ragged end
-        aln = make_aligned_seqs(
-            data={"seq1": "ACGCAA", "seq2": "ACGTAA", "seq3": "ACGCG-"}, moltype=DNA
-        )
-        self.assertRaises(ValueError, aln.has_terminal_stops)
-        self.assertTrue(aln.has_terminal_stops(allow_partial=True))
-
     def test_slice(self):
         seqs = {"seq1": "ACGTANGT", "seq2": "ACGTACGT", "seq3": "ACGTACGT"}
         alignment = make_aligned_seqs(data=seqs)
@@ -955,20 +923,6 @@ class SequenceTestMethods(unittest.TestCase):
         self.assertRaises(ValueError, seq.trim_stop_codon)
         # unless explicitly over-ride length issue using allow_partial
         seq2 = seq.trim_stop_codon(allow_partial=True)
-
-    def test_has_terminal_stop(self):
-        """test check for terminal stop codons"""
-        seq = make_seq(moltype=DNA, seq="ACTTAA")
-        assert seq.has_terminal_stop() == True
-        seq = make_seq(moltype=DNA, seq="ACTTAT") == False
-
-        # for sequence not divisible by 3
-        seq = make_seq(moltype=DNA, seq="ACTTA")
-        # fail
-        self.assertRaises(ValueError, seq.has_terminal_stop)
-        # unless explicitly over-ride length issue using allow_partial
-        # in which case, returns False
-        self.assertFalse(seq.has_terminal_stop(allow_partial=True))
 
 
 def test_load_seq_new():

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2388,3 +2388,26 @@ def test_get_drawable():
     # and their names should indicate they're incomplete
     for trace in full.traces:
         assert "(incomplete)" in trace.text
+
+
+@pytest.mark.parametrize("gc,seq", ((1, "TCCTGA"), (2, "TCCAGG")))
+def test_has_terminal_stop_true(gc, seq):
+    gc = cogent3.get_code(gc)
+    seq = cogent3.make_seq(seq, moltype="dna")
+    assert seq.has_terminal_stop(gc=gc)
+
+
+@pytest.mark.parametrize(
+    "gc,seq", ((1, "TCCAGG"), (2, "TCCAAA"), (1, "CCTGA"), (2, "CCAGG"))
+)
+def test_has_terminal_stop_false(gc, seq):
+    gc = cogent3.get_code(gc)
+    seq = cogent3.make_seq(seq, moltype="dna")
+    assert not seq.has_terminal_stop(gc=gc)
+
+
+def test_has_terminal_stop_strict():
+    gc = cogent3.get_code(1)
+    seq = cogent3.make_seq("TCCAG", moltype="dna")
+    with pytest.raises(ValueError):
+        seq.has_terminal_stop(gc=gc, strict=True)


### PR DESCRIPTION
[NEW] if seq / align length not divisible by 3, raises an exception

[CHANGED] deprecated allow_partial argument

[NEW] <collection>.has_terminal_stops() is being deprecated for
    <collection>.has_terminal_stop(), because it returns True if a single
    sequence has a terminal stop.