### PR TITLE
DEP: moved Alphabet methods resolve_ambiguity() and get_matched_array()

### DIFF
--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -66,7 +66,7 @@ def tree_align(
     param_vals = dict(param_vals) if param_vals else {}
 
     model = get_model(model)
-    moltype = model.alphabet.moltype
+    moltype = model.moltype
 
     num_states = len(model.alphabet)
 

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -470,7 +470,7 @@ class progressive_align:
         )
         kwargs = {} if gc is None else dict(gc=gc)
         sm = get_model(sm, **kwargs)
-        moltype = sm.alphabet.moltype
+        moltype = sm.moltype
         self._model = sm
         self._scalar = sm.word_length
         self._indel_length = indel_length

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1619,8 +1619,9 @@ class _SequenceCollectionBase:
 
         only non-overlapping motifs are counted
         """
+        moltype = self.moltype
         if alphabet is None:
-            alphabet = self.moltype.alphabet
+            alphabet = moltype.alphabet
             if allow_gap:
                 alphabet = alphabet.gapped
 
@@ -1647,7 +1648,7 @@ class _SequenceCollectionBase:
                 probs[motif] = pseudocount
 
         for motif, count in list(counts.items()):
-            motif_set = alphabet.resolve_ambiguity(motif)
+            motif_set = moltype.resolve_ambiguity(motif, alphabet=alphabet)
             if len(motif_set) > 1:
                 if include_ambiguity:
                     count = float(count) / len(motif_set)

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -565,13 +565,13 @@ class Alphabet(Enumeration):
             motif_subset = [m for m in self if m not in motif_subset]
         return self._with(motif_subset)
 
-    # todo: move onto moltype
+    @c3warns.deprecated_callable(
+        "2024.3",
+        reason="does not belong on alphabet",
+        new="<moltype>.resolve_ambiguity()",
+    )
     def resolve_ambiguity(self, ambig_motif):
-        """Returns set of symbols corresponding to ambig_motif.
-
-        Handles multi-character symbols and screens against the set of
-        valid motifs, unlike the MolType version.
-        """
+        """deprecated, use method on MolType"""
         # shortcut easy case
         if ambig_motif in self._quick_motifset:
             return (ambig_motif,)
@@ -605,20 +605,13 @@ class Alphabet(Enumeration):
 
         return tuple(motif_set)
 
-    # todo: move onto moltype
+    @c3warns.deprecated_callable(
+        "2024.3",
+        reason="does not belong on alphabet",
+        new="cogent3.evolve.likelihood_tree.get_matched_array",
+    )
     def get_matched_array(self, motifs, dtype=float):
-        """Returns an array in which rows are motifs, columns are items in self.
-
-        Result is an array of Float in which a[i][j] indicates whether the ith
-        motif passed in as motifs is a symbol that matches the jth character
-        in self. For example, on the DNA alphabet 'TCAG', the degenerate symbol
-        'Y' would correspond to the row [1,1,0,0] because Y is a degenerate
-        symbol that encompasses T and C but not A or G.
-
-        This code is similar to code in the Profile class, and should perhaps
-        be merged with it (in particular, because there is nothing likelihood-
-        specific about the resulting match table).
-        """
+        """deprecated, use function in evolve.likelihood_tree"""
         result = zeros([len(motifs), len(self)], dtype)
         obj_to_index = self._obj_to_index
         for u, ambig_motif in enumerate(motifs):

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1742,6 +1742,7 @@ class NucleicAcidSequence(Sequence):
         protein = get_moltype("protein_with_stop" if include_stop else "protein")
         gc = get_code(gc)
         codon_alphabet = gc.get_alphabet(include_stop=include_stop).with_gap_motif()
+        moltype = self.moltype
         # translate the codons
         translation = []
         if include_stop or not trim_stop:
@@ -1753,7 +1754,9 @@ class NucleicAcidSequence(Sequence):
         for posn in range(0, len(seq) - 2, 3):
             orig_codon = str(seq[posn : posn + 3])
             try:
-                resolved = codon_alphabet.resolve_ambiguity(orig_codon)
+                resolved = moltype.resolve_ambiguity(
+                    orig_codon, alphabet=codon_alphabet
+                )
             except AlphabetError:
                 if not incomplete_ok or "-" not in orig_codon:
                     raise AlphabetError(

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -205,12 +205,29 @@ def _indexed(values):
     return unique, counts, index
 
 
+def get_matched_array(alphabet, moltype, motifs, dtype=float) -> numpy.ndarray:
+    """Returns an array in which rows are motifs, columns are items in self.
+
+    Result is an array of dtype in which a[i][j] indicates whether the ith
+    motif passed in as motifs is a symbol that matches the jth character
+    in self. For example, on the DNA alphabet 'TCAG', the degenerate symbol
+    'Y' would correspond to the row [1,1,0,0] because Y is a degenerate
+    symbol that encompasses T and C but not A or G.
+    """
+    result = numpy.zeros([len(motifs), len(alphabet)], dtype)
+    obj_to_index = alphabet.to_indices
+    for u, ambig_motif in enumerate(motifs):
+        for motif in moltype.resolve_ambiguity(ambig_motif, alphabet=alphabet):
+            result[u, obj_to_index((motif,))] = 1.0
+    return result
+
+
 def make_likelihood_tree_leaf(sequence, alphabet, seq_name):
     motif_len = alphabet.get_motif_len()
     sequence2 = sequence.get_in_motif_size(motif_len)
 
     # Convert sequence to indexed list of unique motifs
-    (uniq_motifs, counts, index) = _indexed(sequence2)
+    uniq_motifs, counts, index = _indexed(sequence2)
 
     # extra column for gap
     uniq_motifs.append("?" * motif_len)
@@ -220,7 +237,9 @@ def make_likelihood_tree_leaf(sequence, alphabet, seq_name):
 
     # Convert list of unique motifs to array of unique profiles
     try:
-        likelihoods = alphabet.get_matched_array(uniq_motifs, float)
+        likelihoods = get_matched_array(
+            alphabet, alphabet.moltype, uniq_motifs, dtype=float
+        )
     except alphabet.AlphabetError as detail:
         motif = str(detail)
         posn = list(sequence2).index(motif) * motif_len

--- a/src/cogent3/evolve/motif_prob_model.py
+++ b/src/cogent3/evolve/motif_prob_model.py
@@ -49,11 +49,10 @@ class MotifProbModel(object):
 
     def count_motifs(self, alignment, include_ambiguity=False, recode_gaps=True):
         result = None
+        alpha = self.get_counted_alphabet()
         for seq_name in alignment.names:
             sequence = alignment.get_gapped_seq(seq_name, recode_gaps)
-            leaf = make_likelihood_tree_leaf(
-                sequence, self.get_counted_alphabet(), seq_name
-            )
+            leaf = make_likelihood_tree_leaf(sequence, alpha, seq_name)
             count = leaf.get_motif_counts(include_ambiguity=include_ambiguity)
             if result is None:
                 result = count.copy()

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -388,7 +388,7 @@ class _SubstitutionModel(object):
         return result
 
     def convert_sequence(self, sequence, name):
-        # make_likelihood_tree_leaf, sort of an indexed profile where duplicate
+        # make_likelihood_tree_leaf, a sort of indexed profile where duplicate
         # columns stored once, so likelihoods only calc'd once
         return make_likelihood_tree_leaf(sequence, self.get_alphabet(), name)
 


### PR DESCRIPTION
[CHANGED] resolve_ambiguity() is now on the MolType, while get_matched_array()
    is a standalone function in the likelihood_tree module (the only place
    it's used).

[CHANGED] where possible, now using moltype directly rather than from alphabet
    class