### PR TITLE
BUG: Aligned.get_seq() returns SeqView, fixes #1639

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -5019,7 +5019,8 @@ class Alignment(AlignmentI, SequenceCollection):
 
         Note: always returns Sequence object, not ArraySequence.
         """
-        return self.named_seqs[seqname].data
+        seq = self.named_seqs[seqname]
+        return seq.data[seq.map.without_gaps()]
 
     @c3warn.deprecated_args(
         "2023.3",

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3709,3 +3709,16 @@ def test_get_translation_incomplete(cls):
     assert got.to_dict() == {"seq1": "D?", "seq2": "XS"}
     with pytest.raises(AlphabetError):
         _ = alignment.get_translation(incomplete_ok=False)
+
+
+def test_get_seq_returns_view():
+    seqs = {
+        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
+        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
+        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln[1:5]
+    expect = str(a1.named_seqs["s1"])
+    got = str(a1.get_seq("s1"))
+    assert got == expect, (got, expect)

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3712,7 +3712,7 @@ def test_get_translation_incomplete(cls):
 
 
 @pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
-def test_get_seq_returns_view(seq):
+def test_get_seq_with_sliced_aln(seq):
     seqs = {
         "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
         "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
@@ -3720,26 +3720,18 @@ def test_get_seq_returns_view(seq):
     }
     aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
     a1 = aln[1:5]
+    
+    s1 = a1.get_seq(seq)
+    assert isinstance(s1, Sequence), s1
+
+    got = str(s1)
     expect = str(a1.named_seqs[seq]).replace("-", "")
-    got = str(a1.get_seq(seq)) # we dont want gaps 
     assert got == expect, (got, expect)
 
 
-@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
-def test_get_seq_returns_sequence(seq):
-    seqs = {
-        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
-        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
-        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
-    }
-    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
-    a1 = aln[1:5]
-    got = a1.get_seq(seq)
-    assert isinstance(got, Sequence), got
-
 
 @pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
-def test_get_seq_reversed_seq(seq):
+def test_get_seq_with_sliced_reversed_aln(seq):
     seqs = {
         "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
         "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
@@ -3753,7 +3745,7 @@ def test_get_seq_reversed_seq(seq):
 
 
 @pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
-def test_get_seq_reverse_complement(seq):
+def test_get_seq_with_sliced_rced_aln(seq):
     seqs = {
         "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
         "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
@@ -3763,4 +3755,48 @@ def test_get_seq_reverse_complement(seq):
     a1 = aln.rc()[1:5]
     expect = str(a1.named_seqs[seq]).replace("-", "")
     got = str(a1.get_seq(seq))
+    assert got == expect, (got, expect)
+
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_with_sliced_aln_multiple_spans(seq):
+    seqs = {
+        "s1": "GTTGA--TAGTAGAAGTTCCAAATAATGAA", # span gap span 
+        "s2": "G----TT------AAGTTCCAAATAATGAA", # gap span gap 
+        "s3": "G--GA--TA--GGAAGTTGCAAAT---GAA", # gap span gap span gap
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln[1:10]
+    s1 = a1.get_seq(seq)
+    assert isinstance(s1, Sequence), s1
+
+    expect = str(a1.named_seqs[seq]).replace("-", "")
+    got = str(s1) 
+    assert got == expect, (got, expect)
+
+
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_with_sliced_reversed_aln_multiple_spans(seq):
+    seqs = {
+        "s1": "GTTGA--TAGTAGAAGTTCCAAATAATGAA", # span gap span 
+        "s2": "G----TT------AAGTTCCAAATAATGAA", # gap span gap 
+        "s3": "G--GA--TA--GGAAGTTGCAAAT---GAA", # gap span gap span gap
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln[10:1]
+    expect = str(a1.named_seqs[seq]).replace("-", "")
+    got = str(a1.get_seq(seq)) 
+    assert got == expect, (got, expect)
+
+
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_with_sliced_rced_aln_multiple_spans(seq):
+    seqs = {
+        "s1": "GTTGA--TAGTAGAAGTTCCAAATAATGAA", # span gap span 
+        "s2": "G----TT------AAGTTCCAAATAATGAA", # gap span gap 
+        "s3": "G--GA--TA--GGAAGTTGCAAAT---GAA", # gap span gap span gap
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln.rc()[-10:-1]
+    expect = str(a1.named_seqs[seq]).replace("-", "")
+    got = str(a1.get_seq(seq)) 
     assert got == expect, (got, expect)

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3722,3 +3722,28 @@ def test_get_seq_returns_view():
     expect = str(a1.named_seqs["s1"])
     got = str(a1.get_seq("s1"))
     assert got == expect, (got, expect)
+
+
+def test_get_seq_returns_view_with_gaps():
+    seqs = {
+        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
+        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
+        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln[1:5]
+    expect = str(a1.named_seqs["s2"])
+    got = str(a1.get_seq("s2"))
+    assert got == expect, (got, expect)
+
+
+def test_get_seq_returns_sequence():
+    seqs = {
+        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
+        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
+        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln[1:5]
+    got = a1.get_seq("s1")
+    assert isinstance(got, Sequence), got

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3711,7 +3711,8 @@ def test_get_translation_incomplete(cls):
         _ = alignment.get_translation(incomplete_ok=False)
 
 
-def test_get_seq_returns_view():
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_returns_view(seq):
     seqs = {
         "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
         "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
@@ -3719,12 +3720,13 @@ def test_get_seq_returns_view():
     }
     aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
     a1 = aln[1:5]
-    expect = str(a1.named_seqs["s1"])
-    got = str(a1.get_seq("s1"))
+    expect = str(a1.named_seqs[seq]).replace("-", "")
+    got = str(a1.get_seq(seq)) # we dont want gaps 
     assert got == expect, (got, expect)
 
 
-def test_get_seq_returns_view_with_gaps():
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_returns_sequence(seq):
     seqs = {
         "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
         "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
@@ -3732,18 +3734,33 @@ def test_get_seq_returns_view_with_gaps():
     }
     aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
     a1 = aln[1:5]
-    expect = str(a1.named_seqs["s2"])
-    got = str(a1.get_seq("s2"))
-    assert got == expect, (got, expect)
-
-
-def test_get_seq_returns_sequence():
-    seqs = {
-        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
-        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
-        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
-    }
-    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
-    a1 = aln[1:5]
-    got = a1.get_seq("s1")
+    got = a1.get_seq(seq)
     assert isinstance(got, Sequence), got
+
+
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_reversed_seq(seq):
+    seqs = {
+        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
+        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
+        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln[6:1]
+    got = a1.get_seq(seq)
+    expect = str(a1.named_seqs[seq]).replace("-", "")
+    assert got == expect, (got, expect)
+
+
+@pytest.mark.parametrize("seq", ("s1", "s2", "s3"))
+def test_get_seq_reverse_complement(seq):
+    seqs = {
+        "s1": "GTTGAAGTAGTAGAAGTTCCAAATAATGAA",
+        "s2": "GTG------GTAGAAGTTCCAAATAATGAA",
+        "s3": "GCTGAAGTAGTGGAAGTTGCAAAT---GAA",
+    }
+    aln = make_aligned_seqs(data=seqs, moltype="dna", array_align=False)
+    a1 = aln.rc()[1:5]
+    expect = str(a1.named_seqs[seq]).replace("-", "")
+    got = str(a1.get_seq(seq))
+    assert got == expect, (got, expect)

--- a/tests/test_core/test_annotation.py
+++ b/tests/test_core/test_annotation.py
@@ -160,7 +160,7 @@ def test_feature_projection_ungapped(ann_aln):
     assert ann_aln.annotation_db.num_matches() == num + 1
     assert str(seq_ltr.get_slice()) == expected
     assert seq_ltr.seqid == seq_name
-    assert seq_ltr.parent is ann_aln.get_seq(seq_name)
+    assert seq_ltr.parent == ann_aln.get_seq(seq_name)
 
 
 def test_feature_projection_gapped(ann_aln):
@@ -179,7 +179,7 @@ def test_feature_projection_gapped(ann_aln):
     expected = expected.replace("-", "")
     assert str(seq_ltr.get_slice()) == expected
     assert seq_ltr.seqid == seq_name
-    assert seq_ltr.parent is ann_aln.get_seq(seq_name)
+    assert seq_ltr.parent == ann_aln.get_seq(seq_name)
 
 
 @pytest.fixture()


### PR DESCRIPTION
[CHANGED] slight change in `get_seq()` behaviour: now, when it returns a `SeqView`, it creates a new `Sequence` instance (because `Sequences` are immutable!). This affects tests that expect g`et_seq()` to return the original `Sequence` used to construct the `Alignment`.