### PR TITLE
API: no longer raise ValueError if input data already processed or empty, fixes #1635

### DIFF
--- a/changelog.d/20231204_133511_Gavin.Huttley.md
+++ b/changelog.d/20231204_133511_Gavin.Huttley.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Contributors
+
+- A bullet item for the Contributors category.
+
+-->
+### ENH
+
+- app.as_completed() and app.apply_to() no longer raise a
+  ValueError if there's no work to be done.
+
+
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -680,7 +680,7 @@ def _as_completed(self, dstore, parallel=False, par_kw=None, **kwargs) -> Genera
         dstore = [dstore]
     mapped = _proxy_input(dstore)
     if not mapped:
-        raise ValueError("dstore is empty")
+        return mapped
 
     if parallel:
         par_kw = par_kw or {}


### PR DESCRIPTION
[CHANGED] app.as_completed() and app.apply_to() used to raise this
    error if, for example, all members were already present in an
    output data store if the member itself was empty. We now just
    pass through this condition silently rather than raise an
    exception.