### PR TITLE
DEV: edit pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,9 @@ exclude = ["doc/*.html"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     ]
-
-addopts = ["--strict-config", "-ra"]
 testpaths = "tests"
+addopts = ["--strict-config"]
+norecursedirs = ["doc", ".nox"]
 filterwarnings = [
     'ignore:FORCED EXIT from optimiser',
     'ignore:Motif probs overspecified',


### PR DESCRIPTION
[CHANGED] running pytest in the project root would fail if docs had been
    built. Adding norecursedirs option to toml fixes this. Removed the
    -ra option from config as it seems to have no effect, aside from
    breaking debug in wingide.