### PR TITLE
DEP: dropping the CodonArrayAlignment class

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -4723,7 +4723,10 @@ class ArrayAlignment(AlignmentI, _SequenceCollectionBase):
         return gapped
 
 
-class CodonArrayAlignment(ArrayAlignment):
+@c3warn.deprecated_callable(
+    "2024.3", reason="not being used", is_discontinued=True, stack_level=3
+)
+class CodonArrayAlignment(ArrayAlignment):  # pragma: no cover
     """Stores alignment of gapped codons, no degenerate symbols."""
 
     _input_handlers = {


### PR DESCRIPTION
[CHANGED] it's not being used anywhere and we will be radically refactoring
    how alignments work anyway.