### PR TITLE
Docstring examples for app.sample.concat and omit_degenerates.

### DIFF
--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -34,7 +34,7 @@ def union(groups):
 class concat:
     """Creates a concatenated alignment from a series."""
 
-    def __init__(self, join_seq="", intersect=True, moltype=None):
+    def __init__(self, join_seq: str="", intersect: bool=True, moltype: str | None=None):
         """
         Parameters
         ----------
@@ -49,39 +49,46 @@ class concat:
         Examples
         --------
 
-        Create app to concatenate two alignments
+        Create an app to concatenate two alignments
 
         >>> from cogent3 import app_help, get_app, make_aligned_seqs
+        >>> concat_alns = get_app("concat", moltype="dna")
 
-        >>> concat_alns = get_app("concat")
-
-
-        Create sample alignments with matching names and a moltype specified
+        Create sample alignments with matching sequence names
 
         >>> aln1 = make_aligned_seqs({"s1": "AAA", "s2": "CAA", "s3": "AAA"}, moltype="dna")
         >>> aln2 = make_aligned_seqs({"s1": "GCG", "s2": "GGG", "s3": "GGT"}, moltype="dna")
 
-        Concatenate alignments
+        Concatenate alignments. By default, sequences without matching names in
+        the corresponding alignment are omitted (intersect=True).
 
-        >>> concatenated = concat_alns([aln1, aln2])
-        >>> sorted(concatenated.to_dict().items())
-        [('s1', 'AAAGCG'), ('s2', 'CAAGGG'), ('s3', 'AAAGGT')]
+        >>> result = concat_alns([aln1, aln2])
+        >>> print(result.to_pretty(name_order=["s1","s2","s3"]))
+        s1    AAAGCG
+        s2    C...G.
+        s3    ....GT
+        
+        Create an app that includes missing sequences across alignments.
+        Missing sequences are replaced by a sequence of "?".
 
-        Sequences that do not have matching names in the corresponding
-        alignment are omitted
+        >>> concat_missing = get_app("concat", moltype="dna", intersect=False)
+        >>> aln3 = make_aligned_seqs({"s4": "GCG", "s5": "GGG"}, moltype="dna")
+        >>> result = concat_missing([aln1, aln3])
+        >>> print(result.to_pretty(name_order=["s1","s2","s3","s4","s5"]))
+        s1    AAA???
+        s2    C.....
+        s3    ......
+        s4    ???GCG
+        s5    ???GGG
 
-        >>> aln3 = make_aligned_seqs({"s4": "GCG", "s5": "GGG", "s3": "GGT"}, moltype="dna")
-        >>> concatenated = concat_alns([aln1, aln3])
-        >>> concatenated.to_dict()
-        {'s3': 'AAAGGT'}
-
-        Sequences with no matching names returns a NotCompleted (see
-        https://cogent3.org/doc/app/not-completed.html)
-
-        >>> aln4 = make_aligned_seqs({"x": "GCG", "y": "GGG", "z": "GGT"}, moltype="dna")
-        >>> result = concat_alns([aln1, aln4])
-        >>> result.message
-        'Traceback...
+        Create an app that delimits concatenated alignments with "N"
+        
+        >>> concat_delim = get_app("concat", join_seq="N", moltype="dna")
+        >>> result = concat_delim([aln1, aln2])
+        >>> print(result.to_pretty(name_order=["s1","s2","s3"]))
+        s1    AAANGCG
+        s2    C....G.
+        s3    .....GT
         """
         self._name_callback = {True: intersection}.get(intersect, union)
         self._intersect = intersect

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -45,6 +45,51 @@ class concat:
             missings sequences will be replaced by a sequence of '?'.
         moltype : str
             molecular type, must be either DNA or RNA
+
+        Examples
+        --------
+
+        Create app to concatenate two alignments
+
+        >>> from cogent3 import app_help, get_app, make_aligned_seqs
+
+        >>> concat_alns = get_app("concat")
+
+
+        Create sample alignments with matching names and a moltype specified
+
+        >>> aln1 = make_aligned_seqs({"s1": "AAA", "s2": "CAA", "s3": "AAA"}, moltype="dna")
+        >>> aln2 = make_aligned_seqs({"s1": "GCG", "s2": "GGG", "s3": "GGT"}, moltype="dna")
+
+        Concatenate alignments
+
+        >>> concatenated = concat_alns([aln1, aln2])
+        >>> sorted(concatenated.to_dict().items())
+        [('s1', 'AAAGCG'), ('s2', 'CAAGGG'), ('s3', 'AAAGGT')]
+
+        Sequences that do not have matching names in the corresponding
+        alignment are omitted
+
+        >>> aln3 = make_aligned_seqs({"s4": "GCG", "s5": "GGG", "s3": "GGT"}, moltype="dna")
+        >>> concatenated = concat_alns([aln1, aln3])
+        >>> concatenated.to_dict()
+        {'s3': 'AAAGGT'}
+
+        Sequences with no matching names returns a NotCompleted (see
+        https://cogent3.org/doc/app/not-completed.html)
+
+        >>> aln4 = make_aligned_seqs({"x": "GCG", "y": "GGG", "z": "GGT"}, moltype="dna")
+        >>> result = concat_alns([aln1, aln4])
+        >>> result.message
+        'Traceback...
+
+        Alignments without a moltype returns a NotCompleted
+
+        >>> aln5 = make_aligned_seqs({"s1": "AAA", "s2": "CAA", "s3": "AAA"})
+        >>> aln6 = make_aligned_seqs({"s1": "GCG", "s2": "GGG", "s3": "GGT"})
+        >>> result = concat_alns([aln5, aln6])
+        >>> result.message
+        'Traceback...
         """
         self._name_callback = {True: intersection}.get(intersect, union)
         self._intersect = intersect

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -34,7 +34,9 @@ def union(groups):
 class concat:
     """Creates a concatenated alignment from a series."""
 
-    def __init__(self, join_seq: str="", intersect: bool=True, moltype: str | None=None):
+    def __init__(
+        self, join_seq: str = "", intersect: bool = True, moltype: str | None = None
+    ):
         """
         Parameters
         ----------
@@ -67,7 +69,7 @@ class concat:
         s1    AAAGCG
         s2    C...G.
         s3    ....GT
-        
+
         Create an app that includes missing sequences across alignments.
         Missing sequences are replaced by a sequence of "?".
 
@@ -82,7 +84,7 @@ class concat:
         s5    ???GGG
 
         Create an app that delimits concatenated alignments with "N"
-        
+
         >>> concat_delim = get_app("concat", join_seq="N", moltype="dna")
         >>> result = concat_delim([aln1, aln2])
         >>> print(result.to_pretty(name_order=["s1","s2","s3"]))
@@ -144,7 +146,9 @@ class omit_degenerates:
     """Excludes alignment columns with degenerate characters. Can accomodate
     reading frame."""
 
-    def __init__(self, moltype=None, gap_is_degen=True, motif_length=1):
+    def __init__(
+        self, moltype: str = None, gap_is_degen: bool = True, motif_length: int = 1
+    ):
         """
         Parameters
         ----------
@@ -159,31 +163,49 @@ class omit_degenerates:
 
         Examples
         --------
+        Degenerate IUPAC base symbols represents a site position that can have
+        multiple possible nucleotides. For example, "Y" represents
+        pyrimidines where the site can be either "C" or "T".
+
+        Note: In molecular evolutionary and phylogenetic analyses, the gap
+        character "-" is considered to be any base "N".
 
         Create sample data with degenerate characters
 
         >>> from cogent3 import app_help, get_app, make_aligned_seqs
-
         >>> aln = make_aligned_seqs({"s1": "ACGA-GACG", "s2": "GATGATGYT"}, moltype="dna")
 
-        Create an app to omit degenerate characters from an alignment
+        Create an app that omits aligned columns containing a degenerate
+        character from an alignment
 
-        >>> app = get_app("omit_degenerates")
+        >>> app = get_app("omit_degenerates", moltype="dna")
         >>> result = app(aln)
-        >>> result.to_dict()
-        {'s1': 'ACGAGAG', 's2': 'GATGTGT'}
+        >>> print(result.to_pretty())
+        s1    ACGAGAG
+        s2    GATGTGT
 
         Create an app which omits degenerate characters, but retains gaps
 
-        >>> app = get_app("omit_degenerates", gap_is_degen=False)
+        >>> app = get_app("omit_degenerates", moltype="dna", gap_is_degen=False)
         >>> result = app(aln)
-        >>> result.to_dict()
-        {'s1': 'ACGA-GAG', 's2': 'GATGATGT'}
+        >>> print(result.to_pretty())
+        s1    ACGA-GAG
+        s2    GATGATGT
 
-        Alignments without a moltype returns a NotCompleted
-        (see https://cogent3.org/doc/app/not-completed.html)
+        Split sequences into non-overlapping tuples of length 2 and exclude
+        any tuple that contains a degenerate character
+
+        >>> app = get_app("omit_degenerates", moltype="dna", motif_length=2)
+        >>> result = app(aln)
+        >>> print(result.to_pretty())
+        s1    ACGA
+        s2    GATG
+
+        A NotCompleted object (see https://cogent3.org/doc/app/not-completed.html)
+        is returned if the moltype is not specified in the alignment or app
 
         >>> aln = make_aligned_seqs({"s1": "ACGA-GACG", "s2": "GATGATGYT"})
+        >>> app = get_app("omit_degenerates")
         >>> result = app(aln)
         >>> result.message
         'Traceback...

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -156,6 +156,37 @@ class omit_degenerates:
             sequences split into non-overlapping tuples of this size. If a
             tuple contains a degen character at any position the entire tuple
             is excluded
+
+        Examples
+        --------
+
+        Create sample data with degenerate characters
+
+        >>> from cogent3 import app_help, get_app, make_aligned_seqs
+
+        >>> aln = make_aligned_seqs({"s1": "ACGA-GACG", "s2": "GATGATGYT"}, moltype="dna")
+
+        Create an app to omit degenerate characters from an alignment
+
+        >>> app = get_app("omit_degenerates")
+        >>> result = app(aln)
+        >>> result.to_dict()
+        {'s1': 'ACGAGAG', 's2': 'GATGTGT'}
+
+        Create an app which omits degenerate characters, but retains gaps
+
+        >>> app = get_app("omit_degenerates", gap_is_degen=False)
+        >>> result = app(aln)
+        >>> result.to_dict()
+        {'s1': 'ACGA-GAG', 's2': 'GATGATGT'}
+
+        Alignments without a moltype returns a NotCompleted
+        (see https://cogent3.org/doc/app/not-completed.html)
+
+        >>> aln = make_aligned_seqs({"s1": "ACGA-GACG", "s2": "GATGATGYT"})
+        >>> result = app(aln)
+        >>> result.message
+        'Traceback...
         """
         if moltype:
             moltype = get_moltype(moltype)

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Union
+from typing import List, Optional, Union
 
 from numpy import array
 from numpy import random as np_random
@@ -35,7 +35,7 @@ class concat:
     """Creates a concatenated alignment from a series."""
 
     def __init__(
-        self, join_seq: str = "", intersect: bool = True, moltype: str | None = None
+        self, join_seq: str = "", intersect: bool = True, moltype: Optional[str] = None
     ):
         """
         Parameters

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -543,3 +543,12 @@ class TranslateTests(TestCase):
         take = sample.take_n_seqs(2, random=True, seed=123)
         got = take(seqs1)
         self.assertNotIsInstance(got, NotCompleted)
+
+
+def test_concat_coerced_moltype():
+    # moltype of final result is the first one seen
+    concat = sample.concat()
+    aln1 = make_aligned_seqs({"s1": "AAA", "s2": "CAA", "s3": "AAA"}, moltype="dna")
+    aln2 = make_aligned_seqs({"s1": "GCG", "s2": "GGG", "s3": "GGT"})
+    result = concat([aln1, aln2])
+    assert result.moltype.label == "dna"

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -61,6 +61,13 @@ class TranslateTests(TestCase):
         got = degen(aln)
         self.assertIsInstance(got, alignment.Alignment)
 
+        # motif length exludes tuples with a degenerate site
+        aln = make_aligned_seqs({"a": "ACGA-GACG", "b": "GATGATGYT"})
+        degen = sample.omit_degenerates(moltype="dna", motif_length=2)
+        got = degen(aln)
+        expect = make_aligned_seqs({"a": "ACGA", "b": "GATG"}, moltype="dna")
+        assert got == expect
+
     def test_omit_gapped(self):
         """omit_gap_pos correctly drops aligned columns"""
         # array alignment


### PR DESCRIPTION
Related to #1636.

Not too sure about lines 67-68 here, as the order of dict items change across `pytest --doctest-module` runs`concatenated.to_dict()` 