### PR TITLE
ENH: new Sequence.parent_coordinates() method

### DIFF
--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2566,3 +2566,29 @@ def test_gapped_by_map_segment_iter():
     m, seq = moltype.make_seq("-TCC--AG").parse_out_gaps()
     g = list(seq.gapped_by_map_segment_iter(m, allow_gaps=True, recode_gaps=False))
     print(g)
+
+
+@pytest.mark.parametrize("rev", (False, True))
+@pytest.mark.parametrize("sliced", (False, True))
+@pytest.mark.parametrize("start_stop", ((None, None), (3, 7)))
+def test_copied_parent_coordinates(sliced, rev, start_stop):
+    seq = DNA.make_seq("ACGGTGGGAC")
+    start, stop = start_stop
+    start = start or 0
+    stop = stop or len(seq)
+    sl = slice(start, stop)
+    seq = seq[sl]
+    if rev:
+        seq = seq.rc()
+    copied = seq.copy(sliced=sliced)
+    assert copied.parent_coordinates() == (start, stop)
+
+
+@pytest.mark.parametrize("rev", (False, True))
+def test_parent_coordinates(rev):
+    seq = DNA.make_seq("ACGGTGGGAC")
+    seq = seq[1:1]
+    if rev:
+        seq = seq.rc()
+
+    assert seq.parent_coordinates() == (0, 0)


### PR DESCRIPTION
[NEW] Sequence.parent_coordinates() returns the start, and stop
     of a Sequence on its parent, using the methods on the
     bound SeqView instance.

[NEW] Sequence.copy() gets a new argument, "sliced". (This matches
     the argument on Aligned.deepcopy().) It means the underlying
     data is truly sliced and the offset of the SeqView updated.