### PR TITLE
DEV: configure dependabot to also update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: weekly
       time: "19:00"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "19:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot now checks for updates to GitHub Actions