### PR TITLE
DEV: Fix coveralls job reporting

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -42,16 +42,13 @@ jobs:
         with:
           parallel: true
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.test_number }}
+          flag-name: run-${{matrix.python-version}}-${{matrix.os}}
           file: "tests/lcov-${{matrix.os}}-${{matrix.python-version}}.lcov"
 
   finish:
+    name: "Finish Coveralls"
     needs: tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Fixes a longstanding issue with coveralls requiring different job names for parallel builds. Otherwise, it may only accept the last job.

Under a build, coverage is displayed per job (os/python-version) and an aggregate report is displayed at the bottom.

The pull request also modifies the "finish" GitHub action job in the CI - only one parallel-finished call to coveralls is required rather than per os/python-version.

I have also modified the settings on coveralls for cogent3 to only send a status update for the overall build rather than per job. This limits the GitHub checks to only display the coverage change for the complete build instead of for each os/python-version.
