### PR TITLE
DEV: Add `seq_len` attribute to `SeqView`

### DIFF
--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -2141,6 +2141,7 @@ class SeqView:
             step=self.step * step,
             offset=self.offset,
             seqid=self.seqid,
+            seq_len=self.seq_len,
         )
 
     def _get_forward_slice_from_reverse_seqview_(self, slice_start, slice_stop, step):
@@ -2167,6 +2168,7 @@ class SeqView:
             step=self.step * step,
             offset=self.offset,
             seqid=self.seqid,
+            seq_len=self.seq_len,
         )
 
     def _get_reverse_slice(self, segment, step):
@@ -2222,6 +2224,7 @@ class SeqView:
             step=self.step * step,
             offset=self.offset,
             seqid=self.seqid,
+            seq_len=self.seq_len,
         )
 
     def _get_reverse_slice_from_reverse_seqview_(self, slice_start, slice_stop, step):
@@ -2260,6 +2263,7 @@ class SeqView:
             step=self.step * step,
             offset=self.offset,
             seqid=self.seqid,
+            seq_len=self.seq_len,
         )
 
     def __getitem__(self, segment):
@@ -2272,6 +2276,7 @@ class SeqView:
                 step=step,
                 offset=self.offset,
                 seqid=self.seqid,
+                seq_len=self.seq_len,
             )
 
         if segment.start is segment.stop is segment.step is None:
@@ -2308,6 +2313,7 @@ class SeqView:
                 step=self.step,
                 offset=self.offset,
                 seqid=self.seqid,
+                seq_len=self.seq_len,
             )
 
         return self.__class__(new_seq)
@@ -2326,7 +2332,7 @@ class SeqView:
         return (
             f"{self.__class__.__name__}(seq={seq!r}, start={self.start}, "
             f"stop={self.stop}, step={self.step}, offset={self.offset}, "
-            f"seqid={self.seqid!r})"
+            f"seqid={self.seqid!r}, seqlen={self.seq_len})"
         )
 
     def to_rich_dict(self):
@@ -2344,6 +2350,7 @@ class SeqView:
         data["init_args"]["seq"] = self.seq[start:stop]
         data["init_args"]["offset"] = self.parent_start
         data["init_args"]["seqid"] = self.seqid
+        data["init_args"]["seq_len"] = self.seq_len
         return data
 
     @classmethod
@@ -2371,6 +2378,7 @@ class SeqView:
                 step=self.step,
                 offset=self.offset,
                 seqid=self.seqid,
+                seq_len=self.seq_len,
             )
         return self.from_rich_dict(self.to_rich_dict())
 

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1923,12 +1923,12 @@ class SeqView:
         self,
         seq,
         *,
-        start: int = None,
-        stop: int = None,
-        step: int = None,
+        start: Optional[int] = None,
+        stop: Optional[int] = None,
+        step: Optional[int] = None,
         offset: int = 0,
-        seqid: str = None,
-        seq_len: int = None,
+        seqid: Optional[str] = None,
+        seq_len: Optional[int] = None,
     ):
         if step == 0:
             raise ValueError("step cannot be 0")
@@ -1942,6 +1942,8 @@ class SeqView:
         self.step = step
         self._offset = offset
         self._seqid = seqid
+        if seq_len and seq_len != len(seq):
+            raise AssertionError(f"{seq_len} != {len(self.seq)})")
         self._seq_len = seq_len or len(self.seq)
 
     @property
@@ -2047,7 +2049,7 @@ class SeqView:
             offset = self.offset
 
             if (
-                tmp := ((self.seq_len - (abs_index - offset)) + self.start + 1)
+                tmp := (self.seq_len - abs_index + offset + self.start + 1)
             ) % self.step == 0 or stop:
                 rel_pos = tmp // abs(self.step)
             else:

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1972,7 +1972,7 @@ class SeqView:
         if self.reverse:
             # self.stop becomes the start, self.stop will be negative
             assert self.stop < 0, "expected stop on reverse strand SeqView < 0"
-            start = self.stop + len(self.seq) + 1
+            start = self.stop + self.seq_len + 1
         else:
             start = self.start
 
@@ -1990,7 +1990,7 @@ class SeqView:
         if self.reverse:
             # self.start becomes the stop, self.start will be negative
             assert self.start < 0, "expected start on reverse strand SeqView < 0"
-            stop = self.start + len(self.seq) + 1
+            stop = self.start + self.seq_len + 1
         else:
             stop = self.stop
         return self.offset + stop
@@ -2348,7 +2348,6 @@ class SeqView:
         data["init_args"]["seq"] = self.seq[start:stop]
         data["init_args"]["offset"] = self.parent_start
         data["init_args"]["seqid"] = self.seqid
-        data["init_args"]["seq_len"] = self.seq_len
         return data
 
     @classmethod

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1917,7 +1917,7 @@ def _input_vals_neg_step(seqlen, start, stop, step):
 
 
 class SeqView:
-    __slots__ = ("seq", "start", "stop", "step", "_offset", "_seqid")
+    __slots__ = ("seq", "start", "stop", "step", "_offset", "_seqid", "_seq_len")
 
     def __init__(
         self,
@@ -1928,6 +1928,7 @@ class SeqView:
         step: int = None,
         offset: int = 0,
         seqid: str = None,
+        seq_len: int = None,
     ):
         if step == 0:
             raise ValueError("step cannot be 0")
@@ -1941,6 +1942,7 @@ class SeqView:
         self.step = step
         self._offset = offset
         self._seqid = seqid
+        self._seq_len = seq_len or len(self.seq)
 
     @property
     def offset(self) -> int:
@@ -1953,6 +1955,10 @@ class SeqView:
     @property
     def seqid(self) -> str:
         return self._seqid
+
+    @property
+    def seq_len(self) -> int:
+        return self._seq_len
 
     @property
     def parent_start(self) -> int:

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1942,7 +1942,7 @@ class SeqView:
         self.step = step
         self._offset = offset
         self._seqid = seqid
-        if seq_len and seq_len != len(seq):
+        if seq_len is not None and seq_len != len(seq):
             raise AssertionError(f"{seq_len} != {len(self.seq)})")
         self._seq_len = seq_len or len(self.seq)
 
@@ -2332,7 +2332,7 @@ class SeqView:
         return (
             f"{self.__class__.__name__}(seq={seq!r}, start={self.start}, "
             f"stop={self.stop}, step={self.step}, offset={self.offset}, "
-            f"seqid={self.seqid!r}, seqlen={self.seq_len})"
+            f"seqid={self.seqid!r}, seq_len={self.seq_len})"
         )
 
     def to_rich_dict(self):

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2741,7 +2741,7 @@ def test_seqview_seqlen_init(start, stop, step, length):
     assert sv.seq_len == expect
     assert sv._seq_len == expect
 
-    """Expect input seq_len to be 'correct' if provided"""
+    # Expect input seq_len to be correct if provided
     got = SeqView(seq="ACTG", seq_len=length).seq_len
     assert got == length
 
@@ -2757,5 +2757,5 @@ def test_seqview_seq_len_modified_seq():
     seq = "ACGGTGGGAC"
     sv = SeqView(seq)
 
-    sv.seq = "ATGC"  # this should not modifiy seq_len
+    sv.seq = "ATGC"  # this should not modify seq_len
     assert sv.seq_len == len(seq)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2732,18 +2732,17 @@ def test_empty_seqview_translate_position():
 @pytest.mark.parametrize("stop", (None, 10, 8, 1, 0, -1, -11))
 @pytest.mark.parametrize("step", (None, 1, 2, -1, -2))
 @pytest.mark.parametrize("length", (1, 8, 999))
-def test_seqview_seqlen_init(start, stop, step, length):
-    """seq_len is length of seq when None"""
-    seq_data = "0123456789"
+def test_seqview_seq_len_init(start, stop, step, length):
+    # seq_len is length of seq when None
+    seq_data = "A" * length
     sv = SeqView(seq_data, start=start, stop=stop, step=step)
     expect = len(seq_data)
     # Check property and slot
     assert sv.seq_len == expect
     assert sv._seq_len == expect
 
-    # Expect input seq_len to be correct if provided
-    got = SeqView(seq="ACTG", seq_len=length).seq_len
-    assert got == length
+    with pytest.raises(AssertionError):
+        SeqView(seq_data, seq_len=length * 2)
 
 
 def test_seqview_copy_propagates_seq_len():

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -1838,36 +1838,34 @@ def test_seqview_repr():
     seq = "ACGT"
     view = SeqView(seq)
     expected = (
-        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid=None, seqlen=4)"
+        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid=None, seq_len=4)"
     )
     assert repr(view) == expected
 
     # Long sequence
     seq = "ACGT" * 10
     view = SeqView(seq)
-    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=0, stop=40, step=1, offset=0, seqid=None, seqlen=40)"
+    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=0, stop=40, step=1, offset=0, seqid=None, seq_len=40)"
     assert repr(view) == expected
 
     # Non-zero start, stop, and step values
     seq = "ACGT" * 10
     view = SeqView(seq, start=5, stop=35, step=2)
-    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=5, stop=35, step=2, offset=0, seqid=None, seqlen=40)"
+    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=5, stop=35, step=2, offset=0, seqid=None, seq_len=40)"
     assert repr(view) == expected
 
     # offset
     seq = "ACGT"
     view = SeqView(seq, offset=5)
     expected = (
-        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=5, seqid=None, seqlen=4)"
+        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=5, seqid=None, seq_len=4)"
     )
     assert repr(view) == expected
 
     # seqid
     seq = "ACGT"
     view = SeqView(seq, seqid="seq1")
-    expected = (
-        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid='seq1', seqlen=4)"
-    )
+    expected = "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid='seq1', seq_len=4)"
     assert repr(view) == expected
 
 
@@ -2741,8 +2739,12 @@ def test_seqview_seq_len_init(start, stop, step, length):
     assert sv.seq_len == expect
     assert sv._seq_len == expect
 
+
+@pytest.mark.parametrize("seq, seq_len", [("A", 0), ("", 1), ("A", 2)])
+def test_seqview_seq_len_mismatch(seq, seq_len):
+    # If provided, seq_len must match len(seq)
     with pytest.raises(AssertionError):
-        SeqView(seq_data, seq_len=length * 2)
+        SeqView(seq, seq_len=seq_len)
 
 
 def test_seqview_copy_propagates_seq_len():

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -1837,31 +1837,37 @@ def test_seqview_repr():
     # Short sequence, defaults
     seq = "ACGT"
     view = SeqView(seq)
-    expected = "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid=None)"
+    expected = (
+        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid=None, seqlen=4)"
+    )
     assert repr(view) == expected
 
     # Long sequence
     seq = "ACGT" * 10
     view = SeqView(seq)
-    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=0, stop=40, step=1, offset=0, seqid=None)"
+    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=0, stop=40, step=1, offset=0, seqid=None, seqlen=40)"
     assert repr(view) == expected
 
     # Non-zero start, stop, and step values
     seq = "ACGT" * 10
     view = SeqView(seq, start=5, stop=35, step=2)
-    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=5, stop=35, step=2, offset=0, seqid=None)"
+    expected = "SeqView(seq='ACGTACGTAC...TACGT', start=5, stop=35, step=2, offset=0, seqid=None, seqlen=40)"
     assert repr(view) == expected
 
     # offset
     seq = "ACGT"
     view = SeqView(seq, offset=5)
-    expected = "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=5, seqid=None)"
+    expected = (
+        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=5, seqid=None, seqlen=4)"
+    )
     assert repr(view) == expected
 
     # seqid
     seq = "ACGT"
     view = SeqView(seq, seqid="seq1")
-    expected = "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid='seq1')"
+    expected = (
+        "SeqView(seq='ACGT', start=0, stop=4, step=1, offset=0, seqid='seq1', seqlen=4)"
+    )
     assert repr(view) == expected
 
 
@@ -2736,3 +2742,20 @@ def test_seqview_seqlen_init(start, stop, step, length):
     """Expect input seq_len to be 'correct' if provided"""
     got = SeqView(seq="ACTG", seq_len=length).seq_len
     assert got == length
+
+
+def test_seqview_serialisation_propogates_seq_len():
+    seq = "ACGGTGGGAC"
+    sv = SeqView(seq)
+    rd = sv.to_rich_dict()
+    assert rd["init_args"]["seq_len"] == len(seq)
+
+    got = SeqView.from_rich_dict(rd)
+    assert got.seq_len == sv.seq_len
+
+
+def test_seqview_copy_propagates_seq_len():
+    seq = "ACGGTGGGAC"
+    sv = SeqView(seq)
+    copied = sv.copy()
+    assert copied.seq_len == len(seq)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2720,3 +2720,19 @@ def test_empty_seqview_translate_position():
     sv = SeqView("")
     assert sv.absolute_position(0) == 0
     assert sv.relative_position(0) == 0
+
+
+@pytest.mark.parametrize("start", (None, 0, 1, 10, -1, -10))
+@pytest.mark.parametrize("stop", (None, 10, 8, 1, 0, -1, -11))
+@pytest.mark.parametrize("step", (None, 1, 2, -1, -2))
+@pytest.mark.parametrize("length", (1, 8, 999))
+def test_seqview_seqlen_init(start, stop, step, length):
+    """seq_len is length of seq when None"""
+    seq_data = "0123456789"
+    got = SeqView(seq_data, start=start, stop=stop, step=step).seq_len
+    expect = len(seq_data)
+    assert got == expect
+
+    """Expect input seq_len to be 'correct' if provided"""
+    got = SeqView(seq="ACTG", seq_len=length).seq_len
+    assert got == length

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2735,9 +2735,11 @@ def test_empty_seqview_translate_position():
 def test_seqview_seqlen_init(start, stop, step, length):
     """seq_len is length of seq when None"""
     seq_data = "0123456789"
-    got = SeqView(seq_data, start=start, stop=stop, step=step).seq_len
+    sv = SeqView(seq_data, start=start, stop=stop, step=step)
     expect = len(seq_data)
-    assert got == expect
+    # Check property and slot
+    assert sv.seq_len == expect
+    assert sv._seq_len == expect
 
     """Expect input seq_len to be 'correct' if provided"""
     got = SeqView(seq="ACTG", seq_len=length).seq_len
@@ -2759,3 +2761,11 @@ def test_seqview_copy_propagates_seq_len():
     sv = SeqView(seq)
     copied = sv.copy()
     assert copied.seq_len == len(seq)
+
+
+def test_seqview_seq_len_modified_seq():
+    seq = "ACGGTGGGAC"
+    sv = SeqView(seq)
+
+    sv.seq = "ATGC"  # this should not modifiy seq_len
+    assert sv.seq_len == len(seq)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2746,16 +2746,6 @@ def test_seqview_seqlen_init(start, stop, step, length):
     assert got == length
 
 
-def test_seqview_serialisation_propogates_seq_len():
-    seq = "ACGGTGGGAC"
-    sv = SeqView(seq)
-    rd = sv.to_rich_dict()
-    assert rd["init_args"]["seq_len"] == len(seq)
-
-    got = SeqView.from_rich_dict(rd)
-    assert got.seq_len == sv.seq_len
-
-
 def test_seqview_copy_propagates_seq_len():
     seq = "ACGGTGGGAC"
     sv = SeqView(seq)


### PR DESCRIPTION
Addresses #1715.

- Add `seq_len` attribute and property
- Add tests for initialisation and `.copy()`
- Replaces `SeqView` use of `len(self.seq)` with `seq.seq_len`