### PR TITLE
DOC: add Python 3.12 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ]
 
 [project.urls]


### PR DESCRIPTION
In release 2024.2.5a1, support was added for Python 3.12. This pull request updates the classifier list to include Python 3.12 as a supported language. 

Note that the supported python versions badge in the README only lists 3.9, 3.10, 3.11, not 3.12 (I believe the badge fetches data from PyPI). The incorrect badge is also shown on [cogent3's PyPI page](https://pypi.org/project/cogent3/).