### PR TITLE
DEV: added ignore patterns for Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ lib
 lib64
 doc/_build
 
+# docker stuff
+.devcontainer/*
+
 # Installer logs
 pip-log.txt
 

--- a/.hgignore
+++ b/.hgignore
@@ -37,3 +37,4 @@ dist/*
 working/*
 lcov*.info
 .ruff_cache/*
+.devcontainer/*


### PR DESCRIPTION
[NEW] exclude .devcontainer and any contents from being included