### PR TITLE
DEV: fix linting action repo owner and isort command

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   linters:
     runs-on: ubuntu-latest
-    if: github.repository == 'cogent/cogent3'
+    if: github.repository == 'cogent3/cogent3'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -33,7 +33,7 @@ jobs:
       - name: Format code using black
         run: black .
       - name: Sort import statements using isort
-        run: isort
+        run: isort .
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
Fixes a typo in the owner of `github.repository`, and the usage of the `isort` command