### PR TITLE
feature/issue 1731

### DIFF
--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -74,9 +74,7 @@ def poisson_exact(successes, mean):
 
 
 @c3warn.deprecated_callable(
-    version="2024.9",
-    reason="use scipy.stats.binom.pmf()instead", 
-    is_discontinued=True
+    version="2024.9", reason="use scipy.stats.binom.pmf()instead", is_discontinued=True
 )
 def binomial_exact(successes, trials, prob):
     """Returns binomial probability of exactly X successes.

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -5,7 +5,7 @@ which is (c) Stephen L. Moshier 1984, 1995.
 
 from numpy import arctan as atan
 from numpy import array, exp, sqrt
-from scipy.stats import binom, f, norm, t
+from scipy.stats import f, norm, t
 from scipy.stats.distributions import chi2
 
 from cogent3.maths.stats.special import (
@@ -23,8 +23,8 @@ from cogent3.maths.stats.special import (
     log1p,
     ndtri,
 )
-from cogent3.util import warning as c3warn
 
+from cogent3.util import warning as c3warn
 
 # ndtri import b/c it should be available via this module
 
@@ -72,13 +72,21 @@ def poisson_exact(successes, mean):
     else:  # successes > mean: use right tail
         return pdtrc(successes - 1, mean) - pdtrc(successes, mean)
 
-
-@c3warn.deprecated_callable(
-    version="2024.9", reason="use scipy.stats.binom.pmf()instead", is_discontinued=True
-)
+@c3warn.deprecated_callable(version="2024.6", reason="use scipy.stats.binom.pmf()instead", is_discontinued=True)
 def binomial_exact(successes, trials, prob):
-    """being removed"""
-    return binom.pmf(successes, trials, prob)
+    """Returns binomial probability of exactly X successes.
+
+    Works for integer and floating point values.
+
+    Note: this function is only a probability mass function for integer
+    values of 'trials' and 'successes', i.e. if you sum up non-integer
+    values you probably won't get a sum of 1.
+    """
+    if (prob < 0) or (prob > 1):
+        raise ValueError("Binomial prob must be between 0 and 1.")
+    if (successes < 0) or (trials < successes):
+        raise ValueError("Binomial successes must be between 0 and trials.")
+    return exp(ln_binomial(successes, trials, prob))
 
 
 def fprob(dfn, dfd, F, side="right"):

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -23,8 +23,8 @@ from cogent3.maths.stats.special import (
     log1p,
     ndtri,
 )
-
 from cogent3.util import warning as c3warn
+
 
 # ndtri import b/c it should be available via this module
 
@@ -76,15 +76,8 @@ def poisson_exact(successes, mean):
 @c3warn.deprecated_callable(
     version="2024.9", reason="use scipy.stats.binom.pmf()instead", is_discontinued=True
 )
-def binomial_exact(successes, trials, prob):
-    """Returns binomial probability of exactly X successes.
-
-    Works for integer and floating point values.
-
-    Note: this function is only a probability mass function for integer
-    values of 'trials' and 'successes', i.e. if you sum up non-integer
-    values you probably won't get a sum of 1.
-    """
+def binomial_exact(successes, trials, prob):  # pragma: no cover
+    """being removed"""
     if (prob < 0) or (prob > 1):
         raise ValueError("Binomial prob must be between 0 and 1.")
     if (successes < 0) or (trials < successes):

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -5,7 +5,7 @@ which is (c) Stephen L. Moshier 1984, 1995.
 
 from numpy import arctan as atan
 from numpy import array, exp, sqrt
-from scipy.stats import f, norm, t
+from scipy.stats import binom, f, norm, t
 from scipy.stats.distributions import chi2
 
 from cogent3.maths.stats.special import (
@@ -23,6 +23,7 @@ from cogent3.maths.stats.special import (
     log1p,
     ndtri,
 )
+from cogent3.util import warning as c3warn
 
 
 # ndtri import b/c it should be available via this module
@@ -72,20 +73,12 @@ def poisson_exact(successes, mean):
         return pdtrc(successes - 1, mean) - pdtrc(successes, mean)
 
 
+@c3warn.deprecated_callable(
+    version="2024.9", reason="use scipy.stats.binom.pmf()instead", is_discontinued=True
+)
 def binomial_exact(successes, trials, prob):
-    """Returns binomial probability of exactly X successes.
-
-    Works for integer and floating point values.
-
-    Note: this function is only a probability mass function for integer
-    values of 'trials' and 'successes', i.e. if you sum up non-integer
-    values you probably won't get a sum of 1.
-    """
-    if (prob < 0) or (prob > 1):
-        raise ValueError("Binomial prob must be between 0 and 1.")
-    if (successes < 0) or (trials < successes):
-        raise ValueError("Binomial successes must be between 0 and trials.")
-    return exp(ln_binomial(successes, trials, prob))
+    """being removed"""
+    return binom.pmf(successes, trials, prob)
 
 
 def fprob(dfn, dfd, F, side="right"):

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -72,7 +72,12 @@ def poisson_exact(successes, mean):
     else:  # successes > mean: use right tail
         return pdtrc(successes - 1, mean) - pdtrc(successes, mean)
 
-@c3warn.deprecated_callable(version="2024.6", reason="use scipy.stats.binom.pmf()instead", is_discontinued=True)
+
+@c3warn.deprecated_callable(
+    version="2024.9",
+    reason="use scipy.stats.binom.pmf()instead", 
+    is_discontinued=True
+)
 def binomial_exact(successes, trials, prob):
     """Returns binomial probability of exactly X successes.
 

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -190,7 +190,6 @@ class DistributionsTests(TestCase):
         for key, value in list(expected.items()):
             assert_allclose(poisson_exact(*key), value, rtol=1e-6)
 
-
     def test_fprob(self):
         """fprob should return twice the tail on a particular side"""
         error = 1e-4

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -190,58 +190,6 @@ class DistributionsTests(TestCase):
         for key, value in list(expected.items()):
             assert_allclose(poisson_exact(*key), value, rtol=1e-6)
 
-    def test_binomial_series(self):
-        """binomial_exact should match values from R on a whole series"""
-        expected = list(
-            map(
-                float,
-                "0.0282475249 0.1210608210 0.2334744405 0.2668279320 0.2001209490 0.1029193452 0.0367569090 0.0090016920 0.0014467005 0.0001377810 0.0000059049".split(),
-            )
-        )
-
-        for i in range(len(expected)):
-            assert_allclose(binomial_exact(i, 10, 0.3), expected[i])
-
-    def test_binomial_exact(self):
-        """binomial_exact should match values from R for integer successes"""
-        expected = {
-            (0, 1, 0.5): 0.5,
-            (1, 1, 0.5): 0.5,
-            (1, 1, 0.0000001): 1e-07,
-            (1, 1, 0.9999999): 0.9999999,
-            (3, 5, 0.75): 0.2636719,
-            (0, 60, 0.5): 8.673617e-19,
-            (129, 130, 0.5): 9.550892e-38,
-            (299, 300, 0.099): 1.338965e-298,
-            (9, 27, 0.0003): 9.175389e-26,
-            (1032, 2050, 0.5): 0.01679804,
-        }
-        for key, value in list(expected.items()):
-            assert_almost_equal(binomial_exact(*key), value, 1e-4)
-
-    def test_binomial_exact_floats(self):
-        """binomial_exact should be within limits for floating point numbers"""
-        expected = {
-            (18.3, 100, 0.2): (0.09089812, 0.09807429),
-            (2.7, 1050, 0.006): (0.03615498, 0.07623827),
-            (2.7, 1050, 0.06): (1.365299e-25, 3.044327e-24),
-            (2, 100.5, 0.6): (7.303533e-37, 1.789727e-36),
-            (10, 100.5, 0.5): (7.578011e-18, 1.365543e-17),
-            (0.2, 60, 0.5): (8.673617e-19, 5.20417e-17),
-            (0.5, 5, 0.3): (0.16807, 0.36015),
-        }
-
-        for key, value in list(expected.items()):
-            min_val, max_val = value
-            assert min_val < binomial_exact(*key) < max_val
-            # assert_almost_equal(binomial_exact(*key), value, 1e-4)
-
-    def test_binomial_exact_errors(self):
-        """binomial_exact should raise errors on invalid input"""
-        self.assertRaises(ValueError, binomial_exact, 10.2, 5, 0.33)
-        self.assertRaises(ValueError, binomial_exact, -2, 5, 0.33)
-        self.assertRaises(ValueError, binomial_exact, 10, 50, -2)
-        self.assertRaises(ValueError, binomial_exact, 10, 50, 3)
 
     def test_fprob(self):
         """fprob should return twice the tail on a particular side"""


### PR DESCRIPTION
DEP: remove the binomial_exact() function and the related tests , fixes #1731  
Remove the `cogent3.maths.stats.binomial_exact()` function, and removed the related `test_binomial_series()`,  `test_binomial_exact()`, `test_binomial_exact_floats()`, and `test_binomial_exact_errors()` 
