### PR TITLE
feature/issue 1732

### DIFF
--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -5,9 +5,10 @@ which is (c) Stephen L. Moshier 1984, 1995.
 
 from numpy import arctan as atan
 from numpy import array, exp, sqrt
-from scipy.stats import f, norm, poisson, t
+from scipy.stats import f, norm, t
 from scipy.stats.distributions import chi2
 
+from cogent3.util import warning as c3warn
 from cogent3.maths.stats.special import (
     MACHEP,
     MAXNUM,
@@ -23,7 +24,6 @@ from cogent3.maths.stats.special import (
     log1p,
     ndtri,
 )
-from cogent3.util import warning as c3warn
 
 
 # ndtri import b/c it should be available via this module
@@ -51,7 +51,7 @@ def tprob(x, df):
 )
 def poisson_high(successes, mean):  # pragma: no cover
     """being removed"""
-    return poisson.sf(successes, mean)
+    return pdtrc(successes, mean)
 
 
 def poisson_low(successes, mean):

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -5,7 +5,7 @@ which is (c) Stephen L. Moshier 1984, 1995.
 
 from numpy import arctan as atan
 from numpy import array, exp, sqrt
-from scipy.stats import f, norm, t
+from scipy.stats import f, norm, poisson, t
 from scipy.stats.distributions import chi2
 
 from cogent3.maths.stats.special import (
@@ -23,6 +23,7 @@ from cogent3.maths.stats.special import (
     log1p,
     ndtri,
 )
+from cogent3.util import warning as c3warn
 
 
 # ndtri import b/c it should be available via this module
@@ -43,12 +44,14 @@ def tprob(x, df):
     return 2 * t.sf(abs(x), df)
 
 
-def poisson_high(successes, mean):
-    """Returns right tail of Poission distribution, Pr(X > x).
-
-    successes ranges from 0 to infinity. mean must be positive.
-    """
-    return pdtrc(successes, mean)
+@c3warn.deprecated_callable(
+    version="2024.9",
+    reason="use scipy.stats.poisson.sf() instead",
+    is_discontinued=True,
+)
+def poisson_high(successes, mean):  # pragma: no cover
+    """being removed"""
+    return poisson.sf(successes, mean)
 
 
 def poisson_low(successes, mean):

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -148,28 +148,6 @@ class DistributionsTests(TestCase):
         for key, value in list(expected.items()):
             assert_allclose(poisson_low(*key), value, rtol=1e-6)
 
-    def test_poisson_high(self):
-        """Upper tail of poisson should match R for integer successes"""
-        # WARNING: Results only guaranteed for integer successes: floating
-        # point _should_ yield reasonable values, but R rounds to int.
-        expected = {
-            (0, 0): 0,
-            (0, 0.75): 0.5276334,
-            (0, 1): 0.6321206,
-            (0, 5): 0.993262,
-            (0, 113.7): 1,
-            (2, 0): 0,
-            (2, 3): 0.5768099,
-            (2, 17.8): 0.9999967,
-            (17, 29.6): 0.9912467,
-            (180, 0): 0,
-            (180, 137.4): 0.0002159856,
-            (180, 318): 1,
-            (180, 1024): 1,
-        }
-        for key, value in list(expected.items()):
-            assert_allclose(poisson_high(*key), value)
-
     def test_poisson_exact(self):
         """Poisson exact should match expected values from R"""
         expected = {


### PR DESCRIPTION
DEP: discontinued 'cogent3.maths.stats.poisson_high()' and removed the related 'test_poisson_high()', fixes #1732