### PR TITLE
feature/issue 1632

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -5528,6 +5528,15 @@ def _coerce_to_array_aligned_seqs(data, names, label_to_name=str, moltype=None) 
         seq = _construct_array_aligned_seq(data[name], moltype=moltype)
         seqs.append(seq)
 
+    # Ensure all sequences are of equal length
+    seq_lengths = {len(seq) for seq in seqs}
+    if len(seq_lengths) > 1:
+        raise ValueError(f"Input sequences are not all the same length. "
+                         f"Unique lengths found: {seq_lengths}. "
+                         f"Please ensure all sequences are properly aligned or "
+                         f"correct the input file format.")
+
+
     return numpy.array(seqs), names
 
 


### PR DESCRIPTION
ENH: Improved error message for sequence length validation, fixed #1632
Added a clear and informative error message that triggers if input sequences are not of the same length, detailing the unique lengths found.