### PR TITLE
Feature/issue 1739

### DIFF
--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -41,7 +41,6 @@ def zprob(x):
 @c3warn.deprecated_callable(
     version="2024.9", reason="use scipy.stats.t.sf() instead", is_discontinued=True
 )
-
 def tprob(x, df):
     """Returns both tails of t distribution (-infinity to -x, infinity to x)"""
     return 2 * t.sf(abs(x), df)

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -24,6 +24,7 @@ from cogent3.maths.stats.special import (
     ndtri,
 )
 
+from cogent3.util import warning as c3warn
 
 # ndtri import b/c it should be available via this module
 
@@ -37,6 +38,9 @@ def zprob(x):
     """Returns both tails of z distribution (-inf to -x, inf to x)."""
     return 2 * norm.sf(abs(x))
 
+@c3warn.deprecated_callable(
+    version="2024.9", reason="use scipy.stats.t.sf() instead", is_discontinued=True
+)
 
 def tprob(x, df):
     """Returns both tails of t distribution (-infinity to -x, infinity to x)"""

--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -30,7 +30,7 @@ from numpy.random import permutation, randint
 from scipy.stats import binom, f, norm, t
 from scipy.stats.distributions import chi2
 
-from cogent3.maths.stats.distribution import fprob, ndtri, tprob, zprob
+from cogent3.maths.stats.distribution import fprob, ndtri, zprob
 from cogent3.maths.stats.kendall import kendalls_tau, pkendall
 from cogent3.maths.stats.ks import pkstwo, psmirnov2x
 from cogent3.maths.stats.number import NumberCounter
@@ -1239,17 +1239,6 @@ def z_tailed_prob(z, tails):
         return zprob(z)
 
 
-def t_tailed_prob(x, df, tails):
-    """Return appropriate p-value for given t and df, depending on tails."""
-    tails = tails or "2"
-    tails = _get_alternate(str(tails))
-
-    if tails == ALT_HIGH:
-        return t.sf(x, df)
-    elif tails == ALT_LOW:
-        return t.cdf(x, df)
-    else:
-        return tprob(x, df)
 
 
 def reverse_tails(tails):


### PR DESCRIPTION
DEP: discontinued cogent3.maths.distribution.tprob(), fixes #1739 
Mark tprob() function for removal and delete test for tprob() Not used in cogent3, available in scipy.stats