### PR TITLE
DEV: added better message when deprecating a class

### DIFF
--- a/src/cogent3/util/warning.py
+++ b/src/cogent3/util/warning.py
@@ -203,6 +203,11 @@ def deprecated_callable(
         sig = set(inspect.signature(func).parameters)
         _type = "method" if sig & {"self", "cls", "klass"} else "function"
         old = func.__name__
+        if is_discontinued and old == "__init__":
+            # we're really deprecating a class, so get that name
+            old = func.__qualname__.split(".")[-2]
+            _type = "class"
+
         params = dict(
             _type=_type,
             old=old,

--- a/tests/test_util/test_warning.py
+++ b/tests/test_util/test_warning.py
@@ -227,3 +227,14 @@ def test_function_deprecated_args_deprecated_callable_chained_decorators(recwarn
     assert any("argument x which will be removed" in warning for warning in warnings)
     assert any("argument b is discontinued" in warning for warning in warnings)
     assert any("function changed is discontinued" in warning for warning in warnings)
+
+
+def test_class_deprecated(recwarn):
+    class fooclass:
+        @deprecated_callable("2023.6", "Improved change function", is_discontinued=True)
+        def __init__(self):
+            ...
+
+    fooclass()
+    warnings = [warning.message.args[0] for warning in recwarn.list]
+    assert any("fooclass is discontinued" in warning for warning in warnings)


### PR DESCRIPTION
[CHANGED] deprecating an __init__ method is now resolved to
    display the class name as being deprecated.