### PR TITLE
BUG: fix representation of numpy arrays in sqlite databases

### DIFF
--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -60,8 +60,8 @@ def sqlite_to_array(data):
 
         warnings.warn(
             "Old OS dependent file format detected. "
-            "Please update file format to latest version. "
-            "See: https://github.com/cogent3/cogent3/issues/1776.",
+            "Update the file format using cogent3.core.annotation_db.update_file_format() "
+            "For reason see https://github.com/cogent3/cogent3/issues/1776.",
             DeprecationWarning,
         )
 

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -47,7 +47,16 @@ def array_to_sqlite(data):
 def sqlite_to_array(data):
     out = io.BytesIO(data)
     out.seek(0)
-    return numpy.load(out)
+    try:
+        result = numpy.load(out)
+    except ValueError:
+        # array is not stored in the numpy.save format
+        # attempt to read from the old format where the
+        # array was saved using numpy.ndarray.tobytes
+        result = numpy.frombuffer(data, dtype=int)
+        dim = result.shape[0] // 2
+        result = result.reshape((dim, 2))
+    return result
 
 
 def dict_to_sqlite_as_json(data: dict) -> str:

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -1658,7 +1658,7 @@ def _update_array_format(data: bytes) -> bytes:
 
 
 def update_file_format(
-    source_file: os.PathLike,
+    source_path: os.PathLike,
     db_class: typing.Union[
         type[BasicAnnotationDb],
         type[GenbankAnnotationDb],
@@ -1683,7 +1683,7 @@ def update_file_format(
 
     Parameters
     ----------
-    source_file : os.PathLike
+    source_path : os.PathLike
         The database file to reformat.
     db_class : typing.Union[ type[BasicAnnotationDb], type[GenbankAnnotationDb], type[GffAnnotationDb], ]
         The type of database the file is.
@@ -1691,13 +1691,14 @@ def update_file_format(
         If True (default), performs a backup of the database before updating.
         Otherwise does not perform a backup prior to update (not recommended).
     """
-    anno_db = db_class(source=source_file)
+    source_path = pathlib.Path(source_path)
+    anno_db = db_class(source=source_path)
 
     if backup:
-        backup_path = source_file + ".bak"
+        backup_path = source_path.parent / f"{source_path.name}.bak"
         if os.path.exists(backup_path):
             raise FileExistsError(
-                f"Backup file already exists for {source_file}. "
+                f"Backup file already exists for {source_path}. "
                 f"If there was a problem with the conversion process, "
                 f"update_file_format should be run on the backed up file. "
                 f"Ensure update_file_format is run on the same OS used to generate the file."

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -76,11 +76,14 @@ class FeatureDataType(typing.TypedDict):
 
 @typing.runtime_checkable
 class SerialisableType(typing.Protocol):  # pragma: no cover
-    def to_rich_dict(self) -> dict: ...
+    def to_rich_dict(self) -> dict:
+        ...
 
-    def to_json(self) -> str: ...
+    def to_json(self) -> str:
+        ...
 
-    def from_dict(self, data): ...
+    def from_dict(self, data):
+        ...
 
 
 @typing.runtime_checkable
@@ -97,15 +100,18 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
         on_alignment: OptionalBool = None,
-    ) -> typing.Iterator[FeatureDataType]: ...
+    ) -> typing.Iterator[FeatureDataType]:
+        ...
 
     def get_feature_children(
         self, *, name: str, start: OptionalInt = None, end: OptionalInt = None, **kwargs
-    ) -> typing.List[FeatureDataType]: ...
+    ) -> typing.List[FeatureDataType]:
+        ...
 
     def get_feature_parent(
         self, *, name: str, start: OptionalInt = None, end: OptionalInt = None, **kwargs
-    ) -> typing.List[FeatureDataType]: ...
+    ) -> typing.List[FeatureDataType]:
+        ...
 
     def num_matches(
         self,
@@ -116,7 +122,8 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
         on_alignment: OptionalBool = None,
-    ) -> int: ...
+    ) -> int:
+        ...
 
     def subset(
         self,
@@ -128,7 +135,8 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         end: OptionalInt = None,
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
-    ): ...
+    ):
+        ...
 
 
 @typing.runtime_checkable
@@ -145,7 +153,8 @@ class SupportsWriteFeatures(typing.Protocol):  # pragma: no cover
         attributes: OptionalStr = None,
         strand: OptionalStr = None,
         on_alignment: bool = False,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def add_records(
         self,
@@ -153,7 +162,8 @@ class SupportsWriteFeatures(typing.Protocol):  # pragma: no cover
         records: typing.Sequence[dict],
         # seqid required for genbank
         seqid: OptionalStr = None,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def update(self, annot_db, seqids: OptionalStrList = None) -> None:
         # update records with those from an instance of the same type


### PR DESCRIPTION
Stores arrays in the sqlite database in the [.npy format](https://numpy.org/devdocs/reference/generated/numpy.lib.format.html) to restore OS independence.

Importantly, this change is not backwards compatible with previously saved databases that include numpy arrays. Notably, previous versions of `GffAnnotationDb` and `GenbankAnnotationDb` will not be able to be loaded.

Fixes #1776 