### PR TITLE
DEP: remove the erf() and erfc function fixes #1778

### DIFF
--- a/src/cogent3/maths/stats/special.py
+++ b/src/cogent3/maths/stats/special.py
@@ -1,8 +1,9 @@
 """Translations of functions from Release 2.3 of the Cephes Math Library,
 (c) Stephen L. Moshier 1984, 1995.
 """
-from cogent3.util import warning as c3warn
 from numpy import exp, floor, log, sin, sqrt
+
+from cogent3.util import warning as c3warn
 
 
 log_epsilon = 1e-6  # for threshold in log/exp close to 1
@@ -248,7 +249,11 @@ ZU = [
 ]
 
 
-@c3warn.deprecated_callable(version="2024.9", reason="use scipy.special.erf(x, out=None) instead", is_discontinued=True)
+@c3warn.deprecated_callable(
+    version="2024.9",
+    reason="use scipy.special.erf(x, out=None) instead",
+    is_discontinued=True,
+)
 def erf(a):  # pragma: no cover
     """being removed"""
     if abs(a) > 1:
@@ -257,7 +262,11 @@ def erf(a):  # pragma: no cover
     return a * polevl(z, ZT) / polevl(z, ZU)
 
 
-@c3warn.deprecated_callable(version="2024.9", reason="use scipy.special.erfc(z, out=None) instead", is_discontinued=True)
+@c3warn.deprecated_callable(
+    version="2024.9",
+    reason="use scipy.special.erfc(z, out=None) instead",
+    is_discontinued=True,
+)
 def erfc(a):  # pragma: no cover
     """being removed"""
     if a < 0:
@@ -295,8 +304,6 @@ def erfc(a):  # pragma: no cover
             return 0
     else:
         return y
-
-
 
 
 # Coefficients for Gamma follow:

--- a/src/cogent3/maths/stats/special.py
+++ b/src/cogent3/maths/stats/special.py
@@ -1,7 +1,7 @@
 """Translations of functions from Release 2.3 of the Cephes Math Library,
 (c) Stephen L. Moshier 1984, 1995.
 """
-
+from cogent3.util import warning as c3warn
 from numpy import exp, floor, log, sin, sqrt
 
 
@@ -248,16 +248,18 @@ ZU = [
 ]
 
 
-def erf(a):
-    """Returns the error function of a: see Cephes docs."""
+@c3warn.deprecated_callable(version="2024.9", reason="use scipy.special.erf(x, out=None) instead", is_discontinued=True)
+def erf(a):  # pragma: no cover
+    """being removed"""
     if abs(a) > 1:
         return 1 - erfc(a)
     z = a * a
     return a * polevl(z, ZT) / polevl(z, ZU)
 
 
-def erfc(a):
-    """Returns the complement of the error function of a: see Cephes docs."""
+@c3warn.deprecated_callable(version="2024.9", reason="use scipy.special.erfc(z, out=None) instead", is_discontinued=True)
+def erfc(a):  # pragma: no cover
+    """being removed"""
     if a < 0:
         x = -a
     else:
@@ -293,6 +295,8 @@ def erfc(a):
             return 0
     else:
         return y
+
+
 
 
 # Coefficients for Gamma follow:


### PR DESCRIPTION
This time, I used GitHub Desktop. Previously, I used the Git command line, but there was a line ending issue: I am on a Windows system, and after downloading cogent3 to my computer, all the files had \r\n line endings instead of \n, which resulted in over a million modifications when compared to the original repository. This problem doesn't occur with GitHub Desktop. However, I still want to know how to solve this issue if using the Git command line.