### PR TITLE
BUG: Alignment.quick_tree() defaults to pdist calculator

### DIFF
--- a/changelog.d/20240329_152534_Gavin.Huttley.md
+++ b/changelog.d/20240329_152534_Gavin.Huttley.md
@@ -22,12 +22,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   length is set to None. Think of this tree as the true "evolutionary tree".
   Thanks to Von Bing Yap for suggesting this!
 
-<!--
 ### BUG
 
-- A bullet item for the BUG category.
+- Alignment.quick_tree() default settings referred to a distance calculator
+  that has been removed. Now updated to the pdist calculator.
 
--->
 <!--
 ### DOC
 

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -3276,7 +3276,7 @@ class AlignmentI(object):
     @extend_docstring_from(distance_matrix, pre=False)
     def quick_tree(
         self,
-        calc="percent",
+        calc="pdist",
         bootstrap=None,
         drop_invalid=False,
         show_progress=False,

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3608,11 +3608,6 @@ def test_array_align_error_with_mixed_length():
         make_aligned_seqs(data=data)
 
 
-@pytest.fixture(scope="session")
-def brca1_data():
-    return load_aligned_seqs("data/brca1.fasta").to_dict()
-
-
 @pytest.mark.parametrize("cls", (Alignment, ArrayAlignment))
 @pytest.mark.parametrize("calc", ("hamming", None))
 def test_quick_tree(cls, calc, brca1_data):


### PR DESCRIPTION
[FIXED] previous default was discontinued!

[NEW] test default settings of quick_tree()