### PR TITLE
MAINT: reduce max_workers if too large

### DIFF
--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -216,9 +216,8 @@ def _as_completed_mpi(f, s, max_workers, if_serial, chunksize=None):
 
 def _as_completed_mproc(f, s, max_workers):
     """multiprocess version of as_completed"""
-    if not max_workers:
+    if not max_workers or max_workers > multiprocessing.cpu_count():
         max_workers = multiprocessing.cpu_count() - 1
-    assert max_workers < multiprocessing.cpu_count()
 
     f = PicklableAndCallable(f)
 


### PR DESCRIPTION
[CHANGED] was raising an exception if max_workers exceeds the number
    of CPUs. Now just revert to the default behaviour of the maximum
    number available.