### PR TITLE
DEV: downgrade macos from latest to 13

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
For the CI, the setup python action does not support Python 3.9 on macos 14 (GitHub has recently been [rolling it out](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/)).

See: https://github.com/cogent3/cogent3/pull/1822#issuecomment-2074204974

As a temporary solution, so development can proceed, I've downgraded the CI runner from macos-latest to macos-13.