### PR TITLE
DEV: upgrade macos back to latest

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
Issue for setup-python on macos-14 has been resolved (https://github.com/actions/setup-python/issues/850#issuecomment-2077454891)!

The macos tests are now the fastest in the CI to run! 