### PR TITLE
DOC: Docstring examples for `app.translate`, `app.align`, and `app.dist`

### DIFF
--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -464,7 +464,7 @@ class progressive_align:
         --------
 
         Create an unaligned sequence collection of BRCA1 genes from 4 species,
-        and an app for alignment with nucleotide model ``model=HKY85``.
+        and an app for alignment with nucleotide model ``model="HKY85"``.
 
         >>> from cogent3 import make_unaligned_seqs, get_app
         >>> aln = make_unaligned_seqs({
@@ -684,12 +684,11 @@ class ic_score:
         --------
 
         Create a sample alignment and compute the Information Content alignment
-        quality score. By default, equally frequent motif probabilities are
-        specified with ``equifreq_mprobs=True``.
+        quality score. The default is equally frequent motif probabilities.
 
         >>> from cogent3 import make_aligned_seqs, get_app
         >>> aln = make_aligned_seqs({"s1": "AATTGA", "s2": "AGGTCC", "s3": "AGGATG", "s4": "AGGCGT"})
-        >>> app = get_app("ic_score", equifreq_mprobs=True)
+        >>> app = get_app("ic_score")
         >>> result = app(aln)
         >>> print(result)
         5.377443751081734

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -459,6 +459,35 @@ class progressive_align:
             if no guide tree, and model is for DNA / Codons, estimates pairwise
             distances using an approximation and JC69. Otherwise, estimates
             genetic distances from pairwise alignments (which is slower).
+
+        Examples
+        --------
+
+        Create an unaligned sequence collection of BRCA1 genes from 4 species,
+        and an app for alignment with nucleotide model ``model=HKY85``.
+
+        >>> from cogent3 import make_unaligned_seqs, get_app
+        >>> aln = make_unaligned_seqs({
+        ... "Human": "GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT",
+        ... "Bandicoot": "NACTCATTAATGCTTGAAACCAGCAGTTTATTGTCCAAC",
+        ... "Rhesus": "GCCAGCTCATTACAGCATGAGAACAGTTTGTTACTCACT",
+        ... "FlyingFox": "GCCAGCTCTTTACAGCATGAGAACAGTTTATTATACACT"
+        ... }, moltype="dna")
+        >>> app = get_app("progressive_align", model="HKY85")
+        >>> result = app(aln)
+        >>> print(result.to_pretty(name_order=['Human', 'Bandicoot', 'Rhesus', 'FlyingFox']))
+            Human    GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT...
+
+        Optionally, a pre-computed guide tree can be provided.
+
+        >>> newick = "(Bandicoot:0.4,FlyingFox:0.05,(Rhesus:0.06," "Human:0.0):0.04);"
+        >>> app_guided = get_app("progressive_align", model="HKY85", guide_tree=newick)
+        >>> result = app_guided(aln)
+        >>> print(result.to_pretty(name_order=['Human', 'Bandicoot', 'Rhesus', 'FlyingFox']))
+            Human    GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT
+        Bandicoot    NA.TCA.T.A.G.TTG.AACC.G...---......GTC..AC
+           Rhesus    ..........................---...G.........
+        FlyingFox    ........T.................---.......TA....
         """
         self._param_vals = {
             "codon": dict(omega=0.4, kappa=3),
@@ -650,6 +679,20 @@ class ic_score:
         ----------
         equifreq_mprobs : bool
             If true, specifies equally frequent motif probabilities.
+
+        Examples
+        --------
+
+        Create a sample alignment and compute the Information Content alignment
+        quality score. By default, equally frequent motif probabilities are
+        specified with ``equifreq_mprobs=True``.
+
+        >>> from cogent3 import make_aligned_seqs, get_app
+        >>> aln = make_aligned_seqs({"s1": "AATTGA", "s2": "AGGTCC", "s3": "AGGATG", "s4": "AGGCGT"})
+        >>> app = get_app("ic_score", equifreq_mprobs=True)
+        >>> result = app(aln)
+        >>> print(result)
+        5.377443751081734
         """
         self._equi_frequent = equifreq_mprobs
 
@@ -708,6 +751,32 @@ def cogent3_score(aln: AlignedSeqsType) -> float:
     The instance must have been aligned using cogent3 tree_align. In addition,
     if the alignment has been saved, it has must have been serialised
     using a format that preserves the score.
+
+    Examples
+    --------
+
+    Prepare an alignment of BRCA1 genes from 4 species. Create an unaligned
+    sequence collection, guide tree, and an app for alignment using cogent3
+    ``progressive_align()``.
+
+    >>> from cogent3 import make_unaligned_seqs, get_app
+    >>> aln = make_unaligned_seqs({
+    ... "Human": "GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT",
+    ... "Bandicoot": "NACTCATTAATGCTTGAAACCAGCAGTTTATTGTCCAAC",
+    ... "Rhesus": "GCCAGCTCATTACAGCATGAGAACAGTTTGTTACTCACT",
+    ... "FlyingFox": "GCCAGCTCTTTACAGCATGAGAACAGTTTATTATACACT"
+    ... }, moltype="dna")
+    >>> newick = "(Bandicoot:0.4,FlyingFox:0.05,(Rhesus:0.06," "Human:0.0):0.04);"
+    >>> aligner = get_app("progressive_align", model="HKY85")
+
+    Create a composable app that aligns the sequences and returns the
+    cogent3 log-likelihood alignment score.
+
+    >>> scorer = get_app("cogent3_score")
+    >>> app = aligner + score
+    >>> result = app(aln)
+    >>> print(result)
+    -130.47375615734916
     """
     if aln.num_seqs == 1 or len(aln) == 0:
         msg = "zero length" if len(aln) == 0 else "single sequence"
@@ -766,6 +835,27 @@ class sp_score:
         Notes
         -----
         see available_distances() for the list of available methods.
+
+        Examples
+        --------
+
+        Create a sample alignment and an app to calculate the Sum of Pairs
+        alignment score with ``calc="pdist"`` and no gap penalties.
+
+        >>> from cogent3 import make_aligned_seqs, get_app
+        >>> aln = make_aligned_seqs({"s1": "AAGAA-A", "s2": "-ATAATG", "s3": "C-TGG-G"})
+        >>> app = get_app("sp_score", calc="pdist", gap_extend=0, gap_insert=0)
+        >>> result = app(aln)
+        >>> print(result)
+        5.0
+
+        Penalise gap extensions with ``gap_extend=1`` and insertions with
+        ``gap_insert=2``.
+
+        >>> app_gap_penalty = get_app("sp_score", calc="pdist", gap_extend=1, gap_insert=2)
+        >>> result = app_gap_penalty(aln)
+        >>> print(result)
+        -13.0
         """
         self._insert = gap_insert
         self._extend = gap_extend

--- a/src/cogent3/app/dist.py
+++ b/src/cogent3/app/dist.py
@@ -165,6 +165,19 @@ def jaccard_dist(seq_coll: UnalignedSeqsType, k: int = 10) -> PairwiseDistanceTy
     -------
     PairwiseDistanceType
         Pairwise Jaccard distance between sequences in the collection.
+
+    Examples
+    --------
+
+    Create an sample sequence collection and an app that calculates the
+    pairwise Jaccard distance with kmer size ``k=2``.
+
+    >>> from cogent3 import make_unaligned_seqs, get_app
+    >>> seqs = make_unaligned_seqs({"s1": "ACGTA", "s2": "ACGTC"}, moltype="dna")
+    >>> app = get_app("jaccard_dist", k=2)
+    >>> result = app(seqs)
+    >>> print(result.to_dict())
+    {('s1', 's2'): 0.4, ('s2', 's1'): 0.4}
     """
 
     kmers = {
@@ -223,6 +236,22 @@ def approx_pdist(jaccard_dists: PairwiseDistanceType) -> PairwiseDistanceType:
     polynomial fit between Jaccard distance and p-distance. The coefficients
     were fitted using data from 106 DNA sequences of mammalian protein coding
     genes, with kmers of size k=10.
+
+    Examples
+    --------
+
+    Create a sample sequence collection and apps for calculating the Jaccard
+    distances, and an approximation of the p-distance.
+    >>> seqs = make_unaligned_seqs({"s1": "ACGTA", "s2": "ACGTC"}, moltype="dna")
+    >>> jaccard_dist = get_app("jaccard_dist", k=2)
+    >>> pdist = get_app("approx_pdist")
+
+    Create a composable app to return the p-distances.
+
+    >>> app = jaccard_dist + pdist
+    >>> result = app(seqs)
+    >>> print(result.to_dict())
+    {('s1', 's2'): 0.02597466474649073, ('s2', 's1'): 0.02597466474649073}
     """
     upper_indices = triu_indices(n=jaccard_dists.shape[0], k=1)
     result = deepcopy(jaccard_dists)  # so the original matrix not modified
@@ -253,6 +282,23 @@ def approx_jc69(
     Returns
     -------
     DistanceMatrix of pairwise JC69 distances
+
+    Examples
+    --------
+
+    Create a sample sequence collection and apps for calculating the Jaccard
+    distances, and an approximation of the pairwise JC69 distances.
+
+    >>> seqs = make_unaligned_seqs({"s1": "ACGTA", "s2": "ACGTC"}, moltype="dna")
+    >>> jaccard_dist = get_app("jaccard_dist", k=2)
+    >>> jc69 = get_app("approx_pdist")
+
+    Create a composable app to return the JC69 distances.
+
+    >>> app = jaccard_dist + jc69
+    >>> result = app(seqs)
+    >>> print(result.to_dict())
+    {('s1', 's2'): 0.5716050390351726, ('s2', 's1'): 0.5716050390351726}
     """
     upper_indices = triu_indices(n=pdists.shape[0], k=1)
     result = deepcopy(pdists)  # so the original matrix not modified

--- a/src/cogent3/app/dist.py
+++ b/src/cogent3/app/dist.py
@@ -242,6 +242,8 @@ def approx_pdist(jaccard_dists: PairwiseDistanceType) -> PairwiseDistanceType:
 
     Create a sample sequence collection and apps for calculating the Jaccard
     distances, and an approximation of the p-distance.
+
+    >>> from cogent3 import make_unaligned_seqs, get_app
     >>> seqs = make_unaligned_seqs({"s1": "ACGTA", "s2": "ACGTC"}, moltype="dna")
     >>> jaccard_dist = get_app("jaccard_dist", k=2)
     >>> pdist = get_app("approx_pdist")
@@ -289,9 +291,10 @@ def approx_jc69(
     Create a sample sequence collection and apps for calculating the Jaccard
     distances, and an approximation of the pairwise JC69 distances.
 
+    >>> from cogent3 import make_unaligned_seqs, get_app
     >>> seqs = make_unaligned_seqs({"s1": "ACGTA", "s2": "ACGTC"}, moltype="dna")
     >>> jaccard_dist = get_app("jaccard_dist", k=2)
-    >>> jc69 = get_app("approx_pdist")
+    >>> jc69 = get_app("approx_jc69")
 
     Create a composable app to return the JC69 distances.
 

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -1,15 +1,24 @@
 from collections import defaultdict
-from typing import Union
+from typing import Optional, Union
 
 from cogent3.core.alignment import SequenceCollection
-from cogent3.core.genetic_code import get_code
-from cogent3.core.moltype import get_moltype
+from cogent3.core.genetic_code import GeneticCode, get_code
+from cogent3.core.moltype import Alphabet, MolType, get_moltype
 
 from .composable import NotCompleted, define_app
 from .typing import SeqsCollectionType, SerialisableType
 
 
-def best_frame(seq, gc=1, allow_rc=False, require_stop=False):
+GeneticCodeTypes = Union[str, int, GeneticCode]
+MolTypes = Union[str, MolType]
+
+
+def best_frame(
+    seq: SeqsCollectionType,
+    gc: GeneticCodeTypes = 1,
+    allow_rc: bool = False,
+    require_stop: bool = False,
+):
     """returns reading frame start that has either no stops or a single
     terminal stop codon
 
@@ -21,7 +30,7 @@ def best_frame(seq, gc=1, allow_rc=False, require_stop=False):
         genetic code ID, name or instance
     allow_rc
         If False, forward strand considered only. If True, and
-          best frame on rc, it will be negative
+        best frame on rc, it will be negative
     require_stop
         a terminal stop must be present
 
@@ -73,16 +82,21 @@ def best_frame(seq, gc=1, allow_rc=False, require_stop=False):
     return frame
 
 
-def translate_frames(seq, moltype=None, gc=1, allow_rc=False):
+def translate_frames(
+    seq: SeqsCollectionType,
+    moltype: Optional[MolTypes] = None,
+    gc: GeneticCodeTypes = 1,
+    allow_rc: bool = False,
+):
     """translates a nucleic acid sequence
 
     Parameters
     ----------
     moltype
-        molecular type, must be either DNA or RNA
+        molecular type, must be either DNA or RNA. Can be string or instance
     gc
         identifer for a genetic code or a genetic code instance
-    allow_rc : bool
+    allow_rc
         includes frames sequence reverse complement
 
     Returns
@@ -102,7 +116,9 @@ def translate_frames(seq, moltype=None, gc=1, allow_rc=False):
     return translations
 
 
-def get_fourfold_degenerate_sets(gc, alphabet=None, as_indices=True):
+def get_fourfold_degenerate_sets(
+    gc: GeneticCodeTypes, alphabet: Optional[Alphabet] = None, as_indices: bool = True
+):
     """returns set() of codons that are 4-fold degenerate for genetic code gc
 
     Parameters
@@ -145,18 +161,25 @@ class select_translatable:
     frame. Sequences are truncated to modulo 3. seqs.info has a
     translation_errors entry."""
 
-    def __init__(self, moltype="dna", gc=1, allow_rc=False, trim_terminal_stop=True):
+    def __init__(
+        self,
+        moltype: MolTypes = "dna",
+        gc: GeneticCodeTypes = 1,
+        allow_rc: bool = False,
+        trim_terminal_stop: bool = True,
+    ):
         """
         Parameters
         ----------
-        moltype : str
-            molecular type, must be either DNA or RNA
+        moltype
+            molecular type, must be either DNA or RNA. Can be string or
+            instance
         gc
             identifier for a genetic code or a genetic code instance
-        allow_rc : bool
+        allow_rc
             If False, forward strand considered only. If True, and
-              best frame on rc, it will be negative
-        trim_terminal_stop : bool
+            best frame on rc, it will be negative
+        trim_terminal_stop
             exclude terminal stop codon from seqs
 
         Returns
@@ -219,15 +242,22 @@ class translate_seqs:
     """Translates nucleic acid sequences into protein sequences, assumes in
     correct reading frame."""
 
-    def __init__(self, moltype="dna", gc=1, allow_rc=False, trim_terminal_stop=True):
+    def __init__(
+        self,
+        moltype: MolTypes = "dna",
+        gc: GeneticCodeTypes = 1,
+        allow_rc: bool = False,
+        trim_terminal_stop: bool = True,
+    ):
         """
         Parameters
         ----------
-        moltype : str
-            molecular type, must be either DNA or RNA
+        moltype
+            molecular type, must be either DNA or RNA. Can be string or
+            instance
         gc
             identifier for a genetic code or a genetic code instance
-        trim_terminal_stop : bool
+        trim_terminal_stop
             exclude terminal stop codon from seqs
 
         Returns

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -175,7 +175,8 @@ class select_translatable:
             molecular type, must be either DNA or RNA. Can be string or
             instance
         gc
-            identifier for a genetic code or a genetic code instance
+            identifier for a genetic code or a genetic code instance.
+            see https://cogent3.org/doc/cookbook/what_codes.html
         allow_rc
             If False, forward strand considered only. If True, and
             best frame on rc, it will be negative
@@ -186,6 +187,29 @@ class select_translatable:
         -------
         A sequence collection. Sequences that could not be translated
         are excluded.
+
+        Examples
+        --------
+
+        Create a sample sequence collection and an app that returns the sequences
+        which are translatable.
+
+        >>> from cogent3 import make_unaligned_seqs, get_app
+        >>> aln = make_unaligned_seqs({
+        ...     "s1": "AATATAAATGCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTTCATAAAGTCATA",
+        ...     "s1_rc": "TATGACTTTATGAAGTAATAAACTGCTGTTCTCATGCTGTAATGAGCTGGCATTTATATT"
+        ... })
+        >>> app = get_app("select_translatable")
+        >>> result = app(aln)
+        >>> print(result.to_dict())
+        {'s1': 'AATATAAATGCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTTCATAAAGTCATA'}
+
+        Use ``allow_rc=True`` to consider the reading frame for reverse strands.
+
+        >>> app_rc = get_app("select_translatable", allow_rc=True)
+        >>> result = app_rc(aln)
+        >>> print(result.to_dict())
+        {'s1': 'AATATAAATGCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTTCATAAAGTCATA', 's1_rc': 'AATATAAATGCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTTCATAAAGTCATA'}
         """
         moltype = get_moltype(moltype)
         assert moltype.label.lower() in ("dna", "rna"), "Invalid moltype"
@@ -256,7 +280,8 @@ class translate_seqs:
             molecular type, must be either DNA or RNA. Can be string or
             instance
         gc
-            identifier for a genetic code or a genetic code instance
+            identifier for a genetic code or a genetic code instance.
+            see https://cogent3.org/doc/cookbook/what_codes.html
         trim_terminal_stop
             exclude terminal stop codon from seqs
 
@@ -264,6 +289,21 @@ class translate_seqs:
         -------
         A sequence collection. Sequences that could not be translated
         are excluded.
+
+        Examples
+        --------
+
+        Create a sample sequence collection and an app that translates nucleic
+        acid sequences into protein sequences. By default, sequences that end
+        with a stop codon are excluded with ``trim_terminal_stop=True``.
+
+        >>> from cogent3 import make_aligned_seqs, get_app
+        >>> aln = make_aligned_seqs({"s1": "ATGAGG", "s2": "ATGTAA"})
+        >>> app_translate = get_app("translate_seqs", trim_terminal_stop=True)
+        >>> result = app_translate(aln)
+        >>> print(result.to_pretty())
+        s1    MR
+        s2    .-
         """
         moltype = get_moltype(moltype)
         assert moltype.label.lower() in ("dna", "rna"), "Invalid moltype"


### PR DESCRIPTION
Added docstring examples for the apps used in the wrangling paper.

`app.translate`:
- `select_translatable`
- `translate_seqs`

`app.align`:
- `progressive_align`
- `ic_score`
- `cogent3_score`
- `sp_score`

`app.dist`:
- `jaccard_dist`
- `approx_pdist`
- `approx_jc69`

#1636 