### PR TITLE
TST: Port `SeqView` tests and ruff fixes

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -964,14 +964,14 @@ class MolType:
         """Returns True if sequence contains no items that are not in self."""
         try:
             return self.first_invalid(sequence) is None
-        except Exception:
+        except:
             return False
 
     def is_strict(self, sequence):
         """Returns True if sequence contains only items in self.alphabet."""
         try:
             return (len(sequence) == 0) or (self.first_non_strict(sequence) is None)
-        except Exception:
+        except:
             return False
 
     def valid_on_alphabet(self, sequence, alphabet=None):
@@ -1035,7 +1035,7 @@ class MolType:
         if method == "strip":
             try:
                 return sequence.__class__(self.strip_degenerate(sequence))
-            except Exception:
+            except:
                 ambi = self.degenerates
 
                 def not_ambiguous(x):

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -964,14 +964,14 @@ class MolType:
         """Returns True if sequence contains no items that are not in self."""
         try:
             return self.first_invalid(sequence) is None
-        except:
+        except Exception:
             return False
 
     def is_strict(self, sequence):
         """Returns True if sequence contains only items in self.alphabet."""
         try:
             return (len(sequence) == 0) or (self.first_non_strict(sequence) is None)
-        except:
+        except Exception:
             return False
 
     def valid_on_alphabet(self, sequence, alphabet=None):
@@ -1035,7 +1035,7 @@ class MolType:
         if method == "strip":
             try:
                 return sequence.__class__(self.strip_degenerate(sequence))
-            except:
+            except Exception:
                 ambi = self.degenerates
 
                 def not_ambiguous(x):

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -129,7 +129,7 @@ class SequenceI(object):
     def to_rich_dict(self, exclude_annotations=False):
         """returns {'name': name, 'seq': sequence, 'moltype': moltype.label}"""
         info = {} if self.info is None else self.info
-        if info.get("Refs", None) is not None and "Refs" in info:
+        if not info.get("Refs", None) is None and "Refs" in info:
             info.pop("Refs")
 
         info = info or None
@@ -488,8 +488,7 @@ class SequenceI(object):
         """
         if function is None:
             # use identity scoring function
-            def function(a, b):
-                return a != b
+            function = lambda a, b: a != b
 
         distance = 0
         for first, second in zip(self, other):

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -129,7 +129,7 @@ class SequenceI(object):
     def to_rich_dict(self, exclude_annotations=False):
         """returns {'name': name, 'seq': sequence, 'moltype': moltype.label}"""
         info = {} if self.info is None else self.info
-        if not info.get("Refs", None) is None and "Refs" in info:
+        if info.get("Refs", None) is not None and "Refs" in info:
             info.pop("Refs")
 
         info = info or None
@@ -488,7 +488,9 @@ class SequenceI(object):
         """
         if function is None:
             # use identity scoring function
-            function = lambda a, b: a != b
+            def function(a, b):
+                return a != b
+
         distance = 0
         for first, second in zip(self, other):
             distance += function(first, second)

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cogent3.core import new_moltype
+from cogent3.core import new_moltype, new_sequence
 
 
 @pytest.mark.parametrize("name", ("dna", "rna", "protein", "protein_with_stop", "text"))
@@ -22,3 +22,98 @@ def test_moltype_make_bytes_seq():
     seq = moltype.make_seq(name="s1", seq=raw)
     assert seq.moltype.name == name
     assert str(seq) == raw
+
+
+# From test_sequence.py
+def test_seqview_seqid():
+    sv = new_sequence.SeqView(seq="ACGGTGGGAC")
+    assert sv.seqid is None
+
+    sv = new_sequence.SeqView(seq="ACGGTGGGAC", seqid="seq1")
+    assert sv.seqid == "seq1"
+
+
+def test_seqview_rich_dict_round_trip_seqid():
+    sv = new_sequence.SeqView(seq="ACGGTGGGAC", seqid="seq1")
+    rd = sv.to_rich_dict()
+    assert rd["init_args"]["seqid"] == "seq1"
+
+    got = new_sequence.SeqView.from_rich_dict(rd)
+    assert got.seqid == "seq1"
+
+    sv = new_sequence.SeqView(seq="ACGGTGGGAC")
+    rd = sv.to_rich_dict()
+    assert rd["init_args"]["seqid"] is None
+
+    got = new_sequence.SeqView.from_rich_dict(rd)
+    assert got.seqid is None
+
+
+def test_seqview_slice_propagates_seqid():
+    sv = new_sequence.SeqView(seq="ACGGTGGGAC", seqid="seq1")
+    sliced_sv = sv[1:8:2]
+    assert sliced_sv.seqid == "seq1"
+
+    copied_sv = sliced_sv.copy(sliced=False)
+    assert copied_sv.seqid == "seq1"
+
+    copied_sliced_sv = sliced_sv.copy(sliced=True)
+    assert copied_sliced_sv.seqid == "seq1"
+
+
+def test_sequences_propogates_seqid():
+    # creating a name Sequence propagates the seqid to the SeqView.
+    seq = new_moltype.DNA.make_seq(seq="ACGGTGGGAC", name="seq1")
+    assert seq._seq.seqid == "seq1"
+
+    # renaming the Sequence doesnt change the seqid of the SeqView.
+    seq.name = "seq2"
+    assert seq.name == "seq2"
+    assert seq._seq.seqid == "seq1"
+
+
+def test_make_seq_assigns_to_seqview():
+    seq = new_moltype.DNA.make_seq(seq="ACGT", name="s1")
+    assert seq.name == seq._seq.seqid == "s1"
+
+
+def test_empty_seqview_translate_position():
+    sv = new_sequence.SeqView(seq="")
+    assert sv.absolute_position(0) == 0
+    assert sv.relative_position(0) == 0
+
+
+@pytest.mark.parametrize("start", (None, 0, 1, 10, -1, -10))
+@pytest.mark.parametrize("stop", (None, 10, 8, 1, 0, -1, -11))
+@pytest.mark.parametrize("step", (None, 1, 2, -1, -2))
+@pytest.mark.parametrize("length", (1, 8, 999))
+def test_seqview_seq_len_init(start, stop, step, length):
+    # seq_len is length of seq when None
+    seq_data = "A" * length
+    sv = new_sequence.SeqView(seq=seq_data, start=start, stop=stop, step=step)
+    expect = len(seq_data)
+    # Check property and slot
+    assert sv.seq_len == expect
+    assert sv._seq_len == expect
+
+
+@pytest.mark.parametrize("seq, seq_len", [("A", 0), ("", 1), ("A", 2)])
+def test_seqview_seq_len_mismatch(seq, seq_len):
+    # If provided, seq_len must match len(seq)
+    with pytest.raises(AssertionError):
+        new_sequence.SeqView(seq=seq, seq_len=seq_len)
+
+
+def test_seqview_copy_propagates_seq_len():
+    seq = "ACGGTGGGAC"
+    sv = new_sequence.SeqView(seq=seq)
+    copied = sv.copy()
+    assert copied.seq_len == len(seq)
+
+
+def test_seqview_seq_len_modified_seq():
+    seq = "ACGGTGGGAC"
+    sv = new_sequence.SeqView(seq=seq)
+
+    sv.seq = "ATGC"  # this should not modify seq_len
+    assert sv.seq_len == len(seq)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -895,14 +895,14 @@ class SequenceTests(TestCase):
         token = 'class="label"'
         seq = self.SEQ("AAAAA")
 
-        orig = [line for line in seq._repr_html_().splitlines() if token in line][0]
+        orig = [l for l in seq._repr_html_().splitlines() if token in l][0]
         orig_num = len(re.findall(r"\bA\b", orig))
         self.assertEqual(orig_num, 5)
 
         # using environment variable
         env_name = "COGENT3_ALIGNMENT_REPR_POLICY"
         os.environ[env_name] = "num_pos=2"
-        got = [line for line in seq._repr_html_().splitlines() if token in line][0]
+        got = [l for l in seq._repr_html_().splitlines() if token in l][0]
         got_num = len(re.findall(r"\bA\b", got))
         self.assertEqual(got_num, 2)
         os.environ.pop(env_name, None)
@@ -2658,7 +2658,7 @@ def test_coerce_to_seqview(cls):
     assert isinstance(got, SeqView)
 
 
-def test_sequences_propogates_seqid():
+def test_sequences_propogates_seqid(): # ported for Sequence
     # creating a name Aligned propagates the seqid to the SeqView.
     seq = Aligned(*Sequence("ACG--G--GAC", name="seq1").parse_out_gaps())
     assert seq.data._seq.seqid == "seq1"

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2627,7 +2627,8 @@ def test_copied_parent_coordinates(sliced, rev, start_stop):
 def test_parent_coordinates(rev):
     seq = DNA.make_seq("ACGGTGGGAC")
     seq = seq[1:1]
-    seq = seq.rc() if rev else seq
+    if rev:
+        seq = seq.rc()
     seq.name = "sliced"  # this assignment does not affect the
     # note that when a sequence has zero length, the parent seqid is None
     assert seq.parent_coordinates() == (None, 0, 0, 1)
@@ -2658,7 +2659,7 @@ def test_coerce_to_seqview(cls):
     assert isinstance(got, SeqView)
 
 
-def test_sequences_propogates_seqid(): # ported for Sequence
+def test_sequences_propogates_seqid():  # ported for Sequence
     # creating a name Aligned propagates the seqid to the SeqView.
     seq = Aligned(*Sequence("ACG--G--GAC", name="seq1").parse_out_gaps())
     assert seq.data._seq.seqid == "seq1"

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -895,14 +895,14 @@ class SequenceTests(TestCase):
         token = 'class="label"'
         seq = self.SEQ("AAAAA")
 
-        orig = [l for l in seq._repr_html_().splitlines() if token in l][0]
+        orig = [line for line in seq._repr_html_().splitlines() if token in line][0]
         orig_num = len(re.findall(r"\bA\b", orig))
         self.assertEqual(orig_num, 5)
 
         # using environment variable
         env_name = "COGENT3_ALIGNMENT_REPR_POLICY"
         os.environ[env_name] = "num_pos=2"
-        got = [l for l in seq._repr_html_().splitlines() if token in l][0]
+        got = [line for line in seq._repr_html_().splitlines() if token in line][0]
         got_num = len(re.findall(r"\bA\b", got))
         self.assertEqual(got_num, 2)
         os.environ.pop(env_name, None)
@@ -2596,6 +2596,7 @@ def test_gapped_by_map_segment_iter():
     moltype = get_moltype("dna")
     m, seq = moltype.make_seq("-TCC--AG").parse_out_gaps()
     g = list(seq.gapped_by_map_segment_iter(m, allow_gaps=True, recode_gaps=False))
+    assert g == ["-", "TCC", "--", "AG"]
 
 
 @pytest.mark.parametrize("rev", (False, True))
@@ -2651,10 +2652,10 @@ def test_seqview_rich_dict_round_trip_seqid():
 
     sv = SeqView(seq="ACGGTGGGAC")
     rd = sv.to_rich_dict()
-    assert rd["init_args"]["seqid"] == None
+    assert rd["init_args"]["seqid"] is None
 
     got = SeqView.from_rich_dict(rd)
-    assert got.seqid == None
+    assert got.seqid is None
 
 
 def test_seqview_slice_propagates_seqid():
@@ -2716,7 +2717,7 @@ def test_sequences_propogates_seqid():
     # creating a Sequence with an unnamed seqview does not name the SeqView.
     seq = Sequence(SeqView(seq="ACGGTGGGAC"), name="seq_name")
     assert seq.name == "seq_name"
-    assert seq._seq.seqid == None
+    assert seq._seq.seqid is None
 
 
 def test_make_seq_assigns_to_seqview():


### PR DESCRIPTION
Updated tests use e.g. `new_moltype.DNA.make_seq()` replacing `Sequence(...)`.