### PR TITLE
MAINT: remove profiling comment, seq_to_kmer_indices is faster with numba

### DIFF
--- a/src/cogent3/core/new_alphabet.py
+++ b/src/cogent3/core/new_alphabet.py
@@ -334,8 +334,6 @@ def index_to_coord(index: int, coeffs: numpy.ndarray):  # pragma: no cover
     return coord
 
 
-# todo: profile this against pure python,
-#  appears slower as a numba function!
 @numba.jit()
 def seq_to_kmer_indices(
     seq: numpy.ndarray,


### PR DESCRIPTION
Over a particular example using timeit, with numba takes 1.8 microseconds per loop; half numba 23.3 microseconds per loop; no numba 49.5 microseconds per loop. Results follow a similar pattern for much larger sequence lengths.