### PR TITLE
ENH: DataStoreDirectory.write now handles compression

### DIFF
--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -488,6 +488,7 @@ class DataStoreDirectory(DataStoreABC):
         sfx, cmp = get_format_suffixes(unique_id)
         if sfx != suffix:
             unique_id = f"{Path(unique_id).stem}.{suffix}"
+            sfx, cmp = get_format_suffixes(unique_id)
 
         unique_id = (
             unique_id.replace(self.suffix, suffix)
@@ -496,8 +497,9 @@ class DataStoreDirectory(DataStoreABC):
         )
         if suffix != "log" and unique_id in self:
             return None
-
-        with open_(self.source / subdir / unique_id, mode="w", newline="\n") as out:
+        newline = None if cmp else "\n"
+        mode = "wt" if cmp else "w"
+        with open_(self.source / subdir / unique_id, mode=mode, newline=newline) as out:
             out.write(data)
 
         if subdir == _LOG_TABLE:

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -731,3 +731,15 @@ def test_write_multiple_times_apply_to(app_dstore_in):
     orig_length = len(app.data_store)
     app.apply_to(dstore_in)
     assert len(app.data_store) == orig_length
+
+
+def test_directory_data_store_write_compressed(tmp_path):
+    from cogent3 import get_app, make_aligned_seqs, open_data_store
+
+    out = open_data_store(base_path=tmp_path / "demo", suffix="fa.gz", mode="w")
+    writer = get_app("write_seqs", data_store=out)
+    seqs = make_aligned_seqs(
+        dict(s1="CG--T", s2="CGTTT"), moltype="dna", info=dict(source="test")
+    )
+    got = writer(seqs)  # pylint: disable=not-callable
+    assert got, got


### PR DESCRIPTION
[FIXED] would fail with invalid newline character if a
    compression was indicated via the file suffix.