### PR TITLE
DEV: `SeqViewABC` and methods for translation on `SequenceCollection`, #1901

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1445,7 +1445,7 @@ class _SequenceCollectionBase:
         """returns copy of self as an alignment of RNA moltype seqs"""
         return self.to_moltype("rna")
 
-    def to_protein(self):  # ported
+    def to_protein(self):  # will not port
         """returns copy of self as an alignment of PROTEIN moltype seqs"""
         return self.to_moltype("protein")
 

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -158,8 +158,6 @@ class SeqsDataABC(ABC):
     """
 
     __slots__ = ()
-    alphabet: new_alpha.CharAlphabet
-    make_seq: OptCallable = None
 
     @abstractmethod
     def seq_lengths(self) -> dict[str, int]: ...
@@ -171,6 +169,8 @@ class SeqsDataABC(ABC):
     @property
     @abstractmethod
     def make_seq(self): ...
+
+    # refactor: docstring
 
     @make_seq.setter
     @abstractmethod

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -60,6 +60,8 @@ class SeqDataView(new_seq.SeqViewABC, new_seq.SliceRecordABC):
     data = {"seq1": "ACGT", "seq2": "GTTTGCA"}
     sd = SeqsData(data=data)
     sdv = sd.get_seq_view(seqid="seq1")
+    sdv.array_value
+    # array([3, 1, 2, 0], dtype=int8)
     """
 
     __slots__ = ("seqs", "start", "stop", "step", "_offset", "_seqid", "_seq_len")
@@ -113,6 +115,7 @@ class SeqDataView(new_seq.SeqViewABC, new_seq.SliceRecordABC):
 
     @property
     def str_value(self) -> str:
+        """returns the sequence as a string"""
         raw = self.seqs.get_seq_str(
             seqid=self.seqid, start=self.parent_start, stop=self.parent_stop
         )
@@ -120,6 +123,7 @@ class SeqDataView(new_seq.SeqViewABC, new_seq.SliceRecordABC):
 
     @property
     def array_value(self) -> numpy.ndarray:
+        """returns the sequence as a numpy array"""
         raw = self.seqs.get_seq_array(
             seqid=self.seqid, start=self.parent_start, stop=self.parent_stop
         )
@@ -127,12 +131,14 @@ class SeqDataView(new_seq.SeqViewABC, new_seq.SliceRecordABC):
 
     @property
     def bytes_value(self) -> bytes:
+        """returns the sequence as bytes"""
         raw = self.seqs.get_seq_bytes(
             seqid=self.seqid, start=self.parent_start, stop=self.parent_stop
         )
         return raw if self.step == 1 else raw[:: self.step]
 
     def __repr__(self) -> str:
+        # todo: add alphabet to the repr
         seq = f"{self[:10]!s}...{self[-5:]}" if len(self) > 15 else str(self)
         return (
             f"{self.__class__.__name__}(seq={seq}, start={self.start}, "
@@ -250,6 +256,7 @@ class SeqsData(SeqsDataABC):
 
     @make_seq.setter
     def make_seq(self, make_seq: Callable) -> None:
+        # refactor: add type hints for callable function
         self._make_seq = make_seq
 
     @property
@@ -257,6 +264,7 @@ class SeqsData(SeqsDataABC):
         return self._alphabet
 
     def seq_lengths(self) -> dict[str, int]:
+        """Returns lengths of sequences as dict of {name: length, ... }."""
         return {name: seq.shape[0] for name, seq in self._data.items()}
 
     def get_seq_array(
@@ -1973,9 +1981,9 @@ def _(seqs: dict) -> SupportsFeatures:
 @singledispatch
 def coerce_to_seqs_data_dict(
     data, label_to_name: OptCallable = None
-) -> dict[
-    str, PrimitiveSeqTypes
-]:  # refactor: type hint for callable should specificy input/return type
+) -> dict[str, PrimitiveSeqTypes]:
+    # refactor: type hint for callable should specificy input/return type
+    # refactor: handle conversion of SeqView to SeqDataView.
     raise NotImplementedError(
         f"coerce_to_seqs_data_dict not implemented for {type(data)}"
     )

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -37,6 +37,9 @@ from cogent3.util.misc import get_setting_from_environ, negate_condition
 
 DEFAULT_ANNOTATION_DB = BasicAnnotationDb
 
+OptInt = typing.Optional[int]
+OptStr = typing.Optional[str]
+OptCallable = typing.Optional[typing.Callable]
 PrimitiveSeqTypes = Union[str, bytes, numpy.ndarray]
 
 
@@ -66,11 +69,11 @@ class SeqDataView(new_seq.SeqViewABC, new_seq.SliceRecordABC):
         *,
         seqs: SeqsData,
         seq_len: int,
-        start: Optional[int] = None,
-        stop: Optional[int] = None,
-        step: Optional[int] = None,
+        start: OptInt = None,
+        stop: OptInt = None,
+        step: OptInt = None,
         offset: int = 0,
-        seqid: Optional[str] = None,
+        seqid: OptStr = None,
     ):  # refactor: need to deal with optional args type hints
         if step == 0:
             raise ValueError("step cannot be 0")
@@ -149,9 +152,7 @@ class SeqsDataABC(ABC):
     """
 
     alphabet: new_alpha.CharAlphabet
-    make_seq: Callable = (
-        None  # refactor: type hint for callable should specificy input/return type
-    )
+    make_seq: OptCallable = None
 
     @abstractmethod
     def seq_lengths(self) -> dict[str, int]: ...
@@ -174,17 +175,17 @@ class SeqsDataABC(ABC):
 
     @abstractmethod
     def get_seq_array(
-        self, *, seqid: str, start: int = None, stop: int = None
-    ) -> numpy.ndarray: ...  # refactor: need to deal with optional args type hints
+        self, *, seqid: str, start: OptInt = None, stop: OptInt = None
+    ) -> numpy.ndarray: ...
 
     @abstractmethod
     def get_seq_str(
-        self, *, seqid: str, start: int = None, stop: int = None
+        self, *, seqid: str, start: OptInt = None, stop: OptInt = None
     ) -> str: ...
 
     @abstractmethod
     def get_seq_bytes(
-        self, *, seqid: str, start: int = None, stop: int = None
+        self, *, seqid: str, start: OptInt = None, stop: OptInt = None
     ) -> bytes: ...
 
     @abstractmethod
@@ -220,7 +221,7 @@ class SeqsData(SeqsDataABC):
         *,
         data: dict[str, PrimitiveSeqTypes],
         alphabet: new_alpha.CharAlphabet,
-        make_seq: Callable = None,
+        make_seq: OptCallable = None,
     ):
         self._alphabet = alphabet
         self._make_seq = make_seq
@@ -258,17 +259,19 @@ class SeqsData(SeqsDataABC):
         return {name: seq.shape[0] for name, seq in self._data.items()}
 
     def get_seq_array(
-        self, *, seqid: str, start: int = None, stop: int = None
-    ) -> numpy.ndarray:  # refactor: need to deal with optional args type hints
+        self, *, seqid: str, start: OptInt = None, stop: OptInt = None
+    ) -> numpy.ndarray:
         return self._data[seqid][start:stop]
 
-    def get_seq_str(self, *, seqid: str, start: int = None, stop: int = None) -> str:
+    def get_seq_str(
+        self, *, seqid: str, start: OptInt = None, stop: OptInt = None
+    ) -> str:
         return self._alphabet.from_indices(
             self.get_seq_array(seqid=seqid, start=start, stop=stop)
         )
 
     def get_seq_bytes(
-        self, *, seqid: str, start: int = None, stop: int = None
+        self, *, seqid: str, start: OptInt = None, stop: OptInt = None
     ) -> bytes:
         return self.get_seq_str(seqid=seqid, start=start, stop=stop).encode("utf8")
 
@@ -361,7 +364,7 @@ class SequenceCollection:
         moltype: new_moltype.MolType,
         names: list[str] = None,
         info: Union[dict, InfoClass] = None,
-        source: str = None,
+        source: OptStr = None,
         annotation_db: SupportsFeatures = None,
     ):  # refactor: need to deal with optional args type hints
         self._seqs_data = seqs_data
@@ -860,7 +863,7 @@ class SequenceCollection:
         biotype: str,
         name: str,
         spans: list[tuple[int, int]],
-        parent_id: Optional[str] = None,
+        parent_id: OptStr = None,
         strand: str = "+",
     ) -> Feature:
         """
@@ -901,10 +904,10 @@ class SequenceCollection:
         self,
         *,
         seqid: Union[str, Iterator[str]] = None,
-        biotype: Optional[str] = None,
-        name: Optional[str] = None,
-        start: int = None,
-        stop: int = None,
+        biotype: OptStr = None,
+        name: OptStr = None,
+        start: OptInt = None,
+        stop: OptInt = None,
         allow_partial: bool = False,
     ) -> Iterator[Feature]:  # refactor: need to deal with optional args type hints
         """yields Feature instances
@@ -985,7 +988,7 @@ class SequenceCollection:
 
         return alignment_to_phylip(self.to_dict())
 
-    def write(self, filename: str, file_format: str = None, **kwargs):
+    def write(self, filename: str, file_format: OptStr = None, **kwargs):
         """Write the sequences to a file, preserving order of sequences.
 
         Parameters
@@ -1019,14 +1022,14 @@ class SequenceCollection:
 
     def dotplot(
         self,
-        name1: Optional[str] = None,
-        name2: Optional[str] = None,
+        name1: OptStr = None,
+        name2: OptStr = None,
         window: int = 20,
-        threshold: Optional[int] = None,
-        k: Optional[int] = None,
+        threshold: OptInt = None,
+        k: OptInt = None,
         min_gap: int = 0,
         width: int = 500,
-        title: Optional[str] = None,
+        title: OptStr = None,
         rc: bool = False,
         show_progress: bool = False,
     ):
@@ -1128,7 +1131,7 @@ class SequenceCollection:
     def apply_pssm(
         self,
         pssm: PSSM = None,
-        path: str = None,
+        path: OptStr = None,
         background: numpy.array = None,
         pseudocount: int = 0,
         names: list = None,
@@ -1471,7 +1474,7 @@ class SequenceCollection:
         )
         return counts.row_sum()
 
-    def pad_seqs(self, pad_length: int = None):
+    def pad_seqs(self, pad_length: OptInt = None):
         """Returns copy in which sequences are padded to same length.
 
         Parameters
@@ -1728,7 +1731,7 @@ class SequenceCollection:
         self,
         name_order: Optional[typing.Sequence[str]] = None,
         wrap: int = 60,
-        limit: Optional[int] = None,
+        limit: OptInt = None,
         colors: Optional[Mapping[str, str]] = None,
         font_size: int = 12,
         font_family: str = "Lucida Console",
@@ -1879,10 +1882,10 @@ class SequenceCollection:
 
     def set_repr_policy(
         self,
-        num_seqs: Optional[int] = None,
-        num_pos: Optional[int] = None,
-        ref_name: Optional[str] = None,
-        wrap: Optional[int] = None,
+        num_seqs: OptInt = None,
+        num_pos: OptInt = None,
+        ref_name: OptInt = None,
+        wrap: OptInt = None,
     ):
         """specify policy for repr(self)
 
@@ -1968,7 +1971,7 @@ def _(seqs: dict) -> SupportsFeatures:
 
 @singledispatch
 def coerce_to_seqs_data_dict(
-    data, label_to_name: Callable = None
+    data, label_to_name: OptCallable = None
 ) -> dict[
     str, PrimitiveSeqTypes
 ]:  # refactor: type hint for callable should specificy input/return type
@@ -1978,7 +1981,7 @@ def coerce_to_seqs_data_dict(
 
 
 @coerce_to_seqs_data_dict.register
-def _(data: dict, label_to_name: Callable = None) -> dict[str, PrimitiveSeqTypes]:
+def _(data: dict, label_to_name: OptCallable = None) -> dict[str, PrimitiveSeqTypes]:
     is_sequence = isinstance(next(iter(data.values()), None), new_seq.Sequence)
     return {
         (label_to_name(k) if label_to_name else k): (str(v) if is_sequence else v)
@@ -1987,14 +1990,14 @@ def _(data: dict, label_to_name: Callable = None) -> dict[str, PrimitiveSeqTypes
 
 
 @coerce_to_seqs_data_dict.register
-def _(data: list, label_to_name: Callable = None) -> dict[str, PrimitiveSeqTypes]:
+def _(data: list, label_to_name: OptCallable = None) -> dict[str, PrimitiveSeqTypes]:
     first = data[0]
     labelled_seqs = assign_names(first, data=data)
     return coerce_to_seqs_data_dict(labelled_seqs, label_to_name=label_to_name)
 
 
 @coerce_to_seqs_data_dict.register
-def _(data: set, label_to_name: Callable = None) -> dict[str, PrimitiveSeqTypes]:
+def _(data: set, label_to_name: OptCallable = None) -> dict[str, PrimitiveSeqTypes]:
     first = next(iter(data))
     labelled_seqs = assign_names(first, data=data)
     return coerce_to_seqs_data_dict(labelled_seqs, label_to_name=label_to_name)
@@ -2002,7 +2005,7 @@ def _(data: set, label_to_name: Callable = None) -> dict[str, PrimitiveSeqTypes]
 
 @coerce_to_seqs_data_dict.register
 def _(
-    data: SequenceCollection, label_to_name: Callable = None
+    data: SequenceCollection, label_to_name: OptCallable = None
 ) -> dict[str, PrimitiveSeqTypes]:
     return coerce_to_seqs_data_dict(
         data.to_dict(as_array=True), label_to_name=label_to_name
@@ -2039,7 +2042,7 @@ def make_unaligned_seqs(
     data: Union[dict[str, PrimitiveSeqTypes], SeqsData, list],
     *,
     moltype: Union[str, new_moltype.MolType],
-    label_to_name: Callable = None,
+    label_to_name: OptCallable = None,
     info: dict = None,
     source: Union[str, Path] = None,
     annotation_db: SupportsFeatures = None,
@@ -2098,7 +2101,7 @@ def _(
     data: SeqsDataABC,
     *,
     moltype: Union[str, new_moltype.MolType],
-    label_to_name: Callable = None,
+    label_to_name: OptCallable = None,
     info: dict = None,
     source: Union[str, Path] = None,
     annotation_db: SupportsFeatures = None,

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -716,7 +716,7 @@ class SequenceCollection:
         pep_moltype = pep.moltype
         seqs_data = SeqsData(
             data=translated,
-            alphabet=pep_moltype.degen_gapped,
+            alphabet=pep_moltype.degen_gapped_alphabet,
             make_seq=pep_moltype.make_seq,
         )
         return self.__class__(

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -74,7 +74,7 @@ class SeqDataView(new_seq.SeqViewABC, new_seq.SliceRecordABC):
         step: OptInt = None,
         offset: int = 0,
         seqid: OptStr = None,
-    ):  # refactor: need to deal with optional args type hints
+    ):
         if step == 0:
             raise ValueError("step cannot be 0")
         step = 1 if step is None else step
@@ -151,6 +151,7 @@ class SeqsDataABC(ABC):
     a SequenceCollection
     """
 
+    __slots__ = ()
     alphabet: new_alpha.CharAlphabet
     make_seq: OptCallable = None
 
@@ -210,7 +211,7 @@ class SeqsDataABC(ABC):
 
 
 class SeqsData(SeqsDataABC):
-    __slots__ = ("_data", "_alphabet", "_names", "_make_seq")
+    __slots__ = ("_data", "_alphabet", "_make_seq")
     # todo: kath
     # refactor: design
     # SeqsData needs new fields that record the offsets and possibly whether

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -353,7 +353,7 @@ class SeqsData(SeqsDataABC):
             sdv
             if self.make_seq is None
             else self.make_seq(seq=sdv.str_value, name=index)
-        )
+        )  # todo: kath, i think seq._seq = sdv if self.make_seq
 
     @__getitem__.register
     def _(self, index: int) -> Union[SeqDataView, new_seq.Sequence]:
@@ -710,7 +710,9 @@ class SequenceCollection:
             alphabet=pep_moltype.alphabet,
             make_seq=pep_moltype.make_seq,
         )
-        return self.__class__(seqs_data, info=self.info, source=self.source, **kwargs)
+        return self.__class__(
+            seqs_data=seqs_data, info=self.info, source=self.source, **kwargs
+        )
 
     def rc(self):
         """Returns the reverse complement of all sequences in the collection.
@@ -724,7 +726,7 @@ class SequenceCollection:
             data=rc_seqs, alphabet=self.moltype.alphabet, make_seq=self.moltype.make_seq
         )
         return self.__class__(
-            data=seqs_data,
+            seqs_data=seqs_data,
             name=self.name,
             info=self.info,
             moltype=self.moltype,

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1912,6 +1912,7 @@ class SliceRecordABC(ABC):
     seq_len refers to a Python typing.Sequence object, e.g. array, str, list.
     """
 
+    __slots__ = ()
     start: int
     stop: int
     step: int
@@ -2291,6 +2292,7 @@ class SliceRecordABC(ABC):
 
 class SeqViewABC(ABC):
 
+    __slots__ = ()
     seqid: str
 
     @property
@@ -2325,7 +2327,16 @@ class SeqViewABC(ABC):
 
 
 class SeqView(SeqViewABC, SliceRecordABC):
-    __slots__ = ("seq", "start", "stop", "step", "_offset", "_seqid", "_seq_len")
+    __slots__ = (
+        "seq",
+        "alphabet",
+        "start",
+        "stop",
+        "step",
+        "_offset",
+        "_seqid",
+        "_seq_len",
+    )
 
     def __init__(
         self,

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -103,9 +103,7 @@ class Sequence:
         """
         self.moltype = moltype
         self.name = name
-        # todo: kath, convert all usages of degen_gapped_alphabet to most_degen_alphabet
-        # when most_degen_alphabet merged in
-        self._seq = _coerce_to_seqview(seq, name, self.moltype.degen_gapped_alphabet)
+        self._seq = _coerce_to_seqview(seq, name, self.moltype.most_degen_alphabet())
         info = info or {}
         self.info = InfoClass(**info)
         self._repr_policy = dict(num_pos=60)
@@ -1089,7 +1087,7 @@ class Sequence:
 
         s = moltype.coerce_str(self._seq.value)
         moltype.verify_sequence(s, gaps_allowed=True, wildcards_allowed=True)
-        sv = SeqView(seq=s, alphabet=moltype.degen_gapped_alphabet)
+        sv = SeqView(seq=s, alphabet=moltype.most_degen_alphabet())
         new = moltype.make_seq(sv, name=self.name, info=self.info)
         new.annotation_db = self.annotation_db
         return new

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -103,6 +103,8 @@ class Sequence:
         """
         self.moltype = moltype
         self.name = name
+        # todo: kath, convert all usages of degen_gapped_alphabet to most_degen_alphabet
+        # when most_degen_alphabet merged in
         self._seq = _coerce_to_seqview(seq, name, self.moltype.degen_gapped_alphabet)
         info = info or {}
         self.info = InfoClass(**info)
@@ -2291,6 +2293,7 @@ class SliceRecordABC(ABC):
 
 
 class SeqViewABC(ABC):
+    # refactor: docstring
 
     __slots__ = ()
     seqid: str
@@ -2327,6 +2330,7 @@ class SeqViewABC(ABC):
 
 
 class SeqView(SeqViewABC, SliceRecordABC):
+    # refactor: docstring
     __slots__ = (
         "seq",
         "alphabet",
@@ -2393,9 +2397,6 @@ class SeqView(SeqViewABC, SliceRecordABC):
     @property
     def bytes_value(self):
         return self.str_value.encode("utf-8")
-
-    def __iter__(self):
-        return iter(self.str_value)
 
     def __repr__(self) -> str:
         seq = f"{self.seq[:10]}...{self.seq[-5:]}" if self.seq_len > 15 else self.seq
@@ -2471,7 +2472,9 @@ class RnaSequence(Sequence, NucleicAcidSequenceMixin):
 
 
 @singledispatch
-def _coerce_to_seqview(data, seqid, alphabet):
+def _coerce_to_seqview(data, seqid, alphabet) -> SeqViewABC:
+    # refactor:
+    # build a SeqsData instance to handle conversion of SeqView to SeqDataView
     from cogent3.core.alignment import Aligned
 
     if isinstance(data, Aligned):
@@ -2480,31 +2483,31 @@ def _coerce_to_seqview(data, seqid, alphabet):
 
 
 @_coerce_to_seqview.register
-def _(data: SeqViewABC, seqid, alphabet):
+def _(data: SeqViewABC, seqid, alphabet) -> SeqViewABC:
     return data
 
 
 @_coerce_to_seqview.register
-def _(data: Sequence, seqid, alphabet):
+def _(data: Sequence, seqid, alphabet) -> SeqViewABC:
     return _coerce_to_seqview(data._seq, seqid, alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: str, seqid, alphabet):
+def _(data: str, seqid, alphabet) -> SeqViewABC:
     return SeqView(seq=data, seqid=seqid, alphabet=alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: bytes, seqid, alphabet):
+def _(data: bytes, seqid, alphabet) -> SeqViewABC:
     data = data.decode("utf8")
     return SeqView(seq=data, seqid=seqid, alphabet=alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: tuple, seqid, alphabet):
+def _(data: tuple, seqid, alphabet) -> SeqViewABC:
     return _coerce_to_seqview("".join(data), seqid, alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: list, seqid, alphabet):
+def _(data: list, seqid, alphabet) -> SeqViewABC:
     return _coerce_to_seqview("".join(data), seqid, alphabet)

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -24,6 +24,7 @@ from random import shuffle
 from numpy import array, floating, integer, issubdtype
 
 from cogent3._version import __version__
+from cogent3.core import new_alphabet
 from cogent3.core.annotation import Feature
 from cogent3.core.annotation_db import (
     BasicAnnotationDb,
@@ -32,10 +33,8 @@ from cogent3.core.annotation_db import (
     SupportsFeatures,
     load_annotations,
 )
-from cogent3.core.genetic_code import get_code
 from cogent3.core.info import Info as InfoClass
 from cogent3.core.location import FeatureMap, IndelMap, LostSpan
-from cogent3.core.new_alphabet import AlphabetError
 from cogent3.format.fasta import alignment_to_fasta
 from cogent3.maths.stats.contingency import CategoryCounts
 from cogent3.maths.stats.number import CategoryCounter
@@ -104,7 +103,7 @@ class Sequence:
         """
         self.moltype = moltype
         self.name = name
-        self._seq = _coerce_to_seqview(seq, name)
+        self._seq = _coerce_to_seqview(seq, name, self.moltype.degen_gapped_alphabet)
         info = info or {}
         self.info = InfoClass(**info)
         self._repr_policy = dict(num_pos=60)
@@ -113,6 +112,12 @@ class Sequence:
 
     def __str__(self):
         return str(self._seq)
+
+    def __bytes__(self):
+        return bytes(self._seq)
+
+    def __array__(self):
+        return array(self._seq)
 
     def to_fasta(self, make_seqlabel=None, block_size=60):
         """Return string of self in FASTA format, no trailing newline
@@ -1081,7 +1086,7 @@ class Sequence:
 
         s = moltype.coerce_str(self._seq.value)
         moltype.verify_sequence(s, gaps_allowed=True, wildcards_allowed=True)
-        sv = SeqView(seq=s)
+        sv = SeqView(seq=s, alphabet=moltype.degen_gapped_alphabet)
         new = moltype.make_seq(sv, name=self.name, info=self.info)
         new.annotation_db = self.annotation_db
         return new
@@ -1678,7 +1683,7 @@ class NucleicAcidSequenceMixin:
             return gc.is_stop(end3)
 
         if strict:
-            raise AlphabetError(f"{self.name!r} length not divisible by 3")
+            raise new_alphabet.AlphabetError(f"{self.name!r} length not divisible by 3")
 
         return False
 
@@ -1772,12 +1777,12 @@ class NucleicAcidSequenceMixin:
         #  with stop. The genetic code should also do the translation off
         #  raw data, either an array of ints or a string. So this method
         #  should only deal with trimming terminal stops, modulo 3 etc...
-        from cogent3.core import new_moltype
+        from cogent3.core import new_genetic_code, new_moltype
 
         protein = new_moltype.get_moltype(
             "protein_with_stop" if include_stop else "protein"
         )
-        gc = get_code(gc)
+        gc = new_genetic_code.get_code(gc)
         codon_alphabet = gc.get_alphabet(include_stop=include_stop).with_gap_motif()
         moltype = self.moltype
         # translate the codons
@@ -1794,9 +1799,9 @@ class NucleicAcidSequenceMixin:
                 resolved = moltype.resolve_ambiguity(
                     orig_codon, alphabet=codon_alphabet
                 )
-            except AlphabetError:
+            except new_alphabet.AlphabetError:
                 if not incomplete_ok or "-" not in orig_codon:
-                    raise AlphabetError(
+                    raise new_alphabet.AlphabetError(
                         f"unresolvable codon {orig_codon!r} in {self.name}"
                     )
                 resolved = (orig_codon,)
@@ -1807,14 +1812,16 @@ class NucleicAcidSequenceMixin:
                 elif "-" in codon:
                     aa = "?"
                     if not incomplete_ok:
-                        raise AlphabetError(f"incomplete codon {codon} in {self.name}")
+                        raise new_alphabet.AlphabetError(
+                            f"incomplete codon {codon} in {self.name}"
+                        )
                 else:
                     aa = gc[codon]
                     if aa == "*" and not include_stop:
                         continue
                 trans.append(aa)
             if not trans:
-                raise AlphabetError(orig_codon)
+                raise new_alphabet.AlphabetError(orig_codon)
             aa = protein.what_ambiguity(trans)
             translation.append(aa)
 
@@ -1920,6 +1927,8 @@ class SliceRecordABC(ABC):
     @abstractmethod
     def copy(self): ...
 
+    # refactor: design
+    # can we remove the need for this method on the ABC and inheriting
     @property
     @abstractmethod
     def _zero_slice(self): ...
@@ -1996,12 +2005,11 @@ class SliceRecordABC(ABC):
         seq_index, _, _ = self._get_index(rel_index, include_boundary=include_boundary)
 
         offset = self.offset
-        if self.is_reversed:
-            abs_index = offset + self.seq_len + seq_index + 1
-        else:
-            abs_index = offset + seq_index
-
-        return abs_index
+        return (
+            offset + self.seq_len + seq_index + 1
+            if self.is_reversed
+            else offset + seq_index
+        )
 
     def relative_position(self, abs_index: int, stop: bool = False):
         """converts an index on the original "Python sequence" into an index
@@ -2281,13 +2289,49 @@ class SliceRecordABC(ABC):
         )
 
 
-class SeqView(SliceRecordABC):
+class SeqViewABC(ABC):
+
+    seqid: str
+
+    @property
+    def seqid(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def str_value(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def array_value(self) -> array: ...
+
+    @property
+    @abstractmethod
+    def bytes_value(self) -> bytes: ...
+
+    @abstractmethod
+    def copy(self, sliced: bool = False): ...
+
+    def __str__(self) -> str:
+        return self.str_value
+
+    def __array__(self, dtype=None):
+        arr = self.array_value
+        if dtype is not None:
+            arr = arr.astype(dtype)
+        return arr
+
+    def __bytes__(self):
+        return self.bytes_value
+
+
+class SeqView(SeqViewABC, SliceRecordABC):
     __slots__ = ("seq", "start", "stop", "step", "_offset", "_seqid", "_seq_len")
 
     def __init__(
         self,
         *,
         seq: str,
+        alphabet: new_alphabet.AlphabetABC,
         start: OptInt = None,
         stop: OptInt = None,
         step: OptInt = None,
@@ -2298,7 +2342,7 @@ class SeqView(SliceRecordABC):
         if step == 0:
             raise ValueError("step cannot be 0")
         step = 1 if step is None else step
-
+        self.alphabet = alphabet
         func = _input_vals_pos_step if step > 0 else _input_vals_neg_step
         start, stop, step = func(len(seq), start, stop, step)
         self.seq = seq
@@ -2314,7 +2358,7 @@ class SeqView(SliceRecordABC):
 
     @property
     def _zero_slice(self):
-        return self.__class__(seq="")
+        return self.__class__(seq="", alphabet=self.alphabet)
 
     @property
     def seqid(self) -> str:
@@ -2325,32 +2369,22 @@ class SeqView(SliceRecordABC):
         return self._seq_len
 
     def _get_init_kwargs(self):
-        return {"seq": self.seq, "seqid": self.seqid}
+        return {"seq": self.seq, "seqid": self.seqid, "alphabet": self.alphabet}
 
     @property
-    def value(self):
+    def str_value(self):
         return self.seq[self.start : self.stop : self.step]
 
-    def replace(self, old: str, new: str):
-        new_seq = self.seq.replace(old, new)
-        if len(old) == len(new):
-            return self.__class__(
-                seq=new_seq,
-                start=self.start,
-                stop=self.stop,
-                step=self.step,
-                offset=self.offset,
-                seqid=self.seqid,
-                seq_len=self.seq_len,
-            )
+    @property
+    def array_value(self):
+        return self.alphabet.to_indices(self.str_value)
 
-        return self.__class__(seq=new_seq)
+    @property
+    def bytes_value(self):
+        return self.str_value.encode("utf-8")
 
     def __iter__(self):
-        return iter(self.value)
-
-    def __str__(self) -> str:
-        return self.value
+        return iter(self.str_value)
 
     def __repr__(self) -> str:
         seq = f"{self.seq[:10]}...{self.seq[-5:]}" if self.seq_len > 15 else self.seq
@@ -2396,11 +2430,12 @@ class SeqView(SliceRecordABC):
         if not sliced:
             return self.__class__(
                 seq=self.seq,
+                seqid=self.seqid,
+                alphabet=self.alphabet,
                 start=self.start,
                 stop=self.stop,
                 step=self.step,
                 offset=self.offset,
-                seqid=self.seqid,
                 seq_len=self.seq_len,
             )
         return self.from_rich_dict(self.to_rich_dict())
@@ -2425,40 +2460,40 @@ class RnaSequence(Sequence, NucleicAcidSequenceMixin):
 
 
 @singledispatch
-def _coerce_to_seqview(data, seqid):
+def _coerce_to_seqview(data, seqid, alphabet):
     from cogent3.core.alignment import Aligned
 
     if isinstance(data, Aligned):
-        return _coerce_to_seqview(str(data), seqid)
+        return _coerce_to_seqview(str(data), seqid, alphabet)
     raise NotImplementedError(f"{type(data)}")
 
 
 @_coerce_to_seqview.register
-def _(data: SeqView, seqid):
+def _(data: SeqViewABC, seqid, alphabet):
     return data
 
 
 @_coerce_to_seqview.register
-def _(data: Sequence, seqid):
-    return _coerce_to_seqview(data._seq, seqid)
+def _(data: Sequence, seqid, alphabet):
+    return _coerce_to_seqview(data._seq, seqid, alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: str, seqid):
-    return SeqView(seq=data, seqid=seqid)
+def _(data: str, seqid, alphabet):
+    return SeqView(seq=data, seqid=seqid, alphabet=alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: bytes, seqid):
+def _(data: bytes, seqid, alphabet):
     data = data.decode("utf8")
-    return SeqView(seq=data, seqid=seqid)
+    return SeqView(seq=data, seqid=seqid, alphabet=alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: tuple, seqid):
-    return _coerce_to_seqview("".join(data), seqid)
+def _(data: tuple, seqid, alphabet):
+    return _coerce_to_seqview("".join(data), seqid, alphabet)
 
 
 @_coerce_to_seqview.register
-def _(data: list, seqid):
-    return _coerce_to_seqview("".join(data), seqid)
+def _(data: list, seqid, alphabet):
+    return _coerce_to_seqview("".join(data), seqid, alphabet)

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -554,6 +554,7 @@ class Sequence:
         Returns 0 if one sequence is empty.
         """
         # refactor: simplify
+        # refactor: array - make use of self._seq.array_value
         if not self or not other:
             return 0.0
 
@@ -2473,8 +2474,6 @@ class RnaSequence(Sequence, NucleicAcidSequenceMixin):
 
 @singledispatch
 def _coerce_to_seqview(data, seqid, alphabet) -> SeqViewABC:
-    # refactor:
-    # build a SeqsData instance to handle conversion of SeqView to SeqDataView
     from cogent3.core.alignment import Aligned
 
     if isinstance(data, Aligned):

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1915,12 +1915,11 @@ class SliceRecordABC(ABC):
     seq_len refers to a Python typing.Sequence object, e.g. array, str, list.
     """
 
-    __slots__ = ()
-    start: int
-    stop: int
-    step: int
-    seq_len: int
-    _offset: int
+    __slots__ = ("start", "stop", "step", "_offset")
+
+    @property
+    @abstractmethod
+    def seq_len(self) -> int: ...
 
     @abstractmethod
     def _get_init_kwargs(self) -> dict:
@@ -2297,7 +2296,6 @@ class SeqViewABC(ABC):
     # refactor: docstring
 
     __slots__ = ()
-    seqid: str
 
     @property
     def seqid(self) -> str: ...

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -522,7 +522,7 @@ class SequenceCollectionBaseTests(object):
         got = aln.degap()
         self.assertEqual(got.info.path, "blah")
 
-    def test_with_modified_termini(self):  # will not port for SequenceCollection
+    def test_with_modified_termini(self):  # will not port
         """SequenceCollection.with_modified_termini should code trailing gaps as ?"""
         aln = self.Class({"s1": "AATGR--", "s2": "-T-AG?-"}, moltype=DNA)
         self.assertEqual(

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -2074,7 +2074,7 @@ def test_to_dna_raises():
 
 
 @pytest.mark.parametrize("cls", (SequenceCollection, Alignment))
-def test_annotate_from_gff3(cls):  # will not port for SequenceCollection
+def test_annotate_from_gff3(cls):  # will not port
     """annotate_from_gff should work on data from gff3 files"""
     fasta_path = os.path.join("data/c_elegans_WS199_dna_shortened.fasta")
     gff3_path = os.path.join("data/c_elegans_WS199_shortened_gff.gff3")

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -522,7 +522,7 @@ class SequenceCollectionBaseTests(object):
         got = aln.degap()
         self.assertEqual(got.info.path, "blah")
 
-    def test_with_modified_termini(self):
+    def test_with_modified_termini(self):  # will not port for SequenceCollection
         """SequenceCollection.with_modified_termini should code trailing gaps as ?"""
         aln = self.Class({"s1": "AATGR--", "s2": "-T-AG?-"}, moltype=DNA)
         self.assertEqual(
@@ -2074,7 +2074,7 @@ def test_to_dna_raises():
 
 
 @pytest.mark.parametrize("cls", (SequenceCollection, Alignment))
-def test_annotate_from_gff3(cls):  # ported for SequenceCollection
+def test_annotate_from_gff3(cls):  # will not port for SequenceCollection
     """annotate_from_gff should work on data from gff3 files"""
     fasta_path = os.path.join("data/c_elegans_WS199_dna_shortened.fasta")
     gff3_path = os.path.join("data/c_elegans_WS199_shortened_gff.gff3")
@@ -2914,7 +2914,7 @@ def test_to_unaligned_seqs(data):
 
 @pytest.mark.parametrize("moltype", ("dna", "protein"))
 @pytest.mark.parametrize("cls", (SequenceCollection, Alignment, ArrayAlignment))
-def test_same_moltype(cls, moltype):
+def test_same_moltype(cls, moltype):  # ported for SequenceCollection
     moltype = get_moltype(moltype)
     data = dict(s1="ACGTT", s2="ACCTT")
     seqs = cls(data, moltype=moltype)
@@ -2923,7 +2923,7 @@ def test_same_moltype(cls, moltype):
 
 
 @pytest.mark.parametrize("cls", (SequenceCollection, Alignment, ArrayAlignment))
-def test_add(cls):
+def test_add(cls):  # will not port for SequenceCollection
     """__add__ should concatenate sequence data, by name"""
     align1 = cls({"a": "AAAA", "b": "TTTT", "c": "CCCC"})
     align2 = cls({"a": "GGGG", "b": "----", "c": "NNNN"})
@@ -3185,7 +3185,7 @@ def test_aln_from_fasta_parser(cls):
     "d", ({"a": "AAAAA", "b": "BBBBB"}, {"a": b"AAAAA", "b": b"BBBBB"})
 )
 @pytest.mark.parametrize("cls", (Alignment, ArrayAlignment, SequenceCollection))
-def test_init_dict(cls, d):
+def test_init_dict(cls, d):  # will not port for SequenceCollection
     """SequenceCollection init from dict should work as expected"""
     # from bytes strings
     a = cls(d, names=["a", "b"])

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -1305,11 +1305,11 @@ def test_sequence_collection_get_identical_sets_ragged_raises(ragged):
         _ = ragged.get_identical_sets()
 
 
-def dna_2_rna(seq):
-    return seq.replace("T", "U")
+def rev(seq):
+    return seq[::-1]
 
 
-@pytest.mark.parametrize("transform", [dna_2_rna, lambda x: x, None])
+@pytest.mark.parametrize("transform", [rev, lambda x: x, None])
 def test_sequence_collection_get_similar(transform):
     data = {
         "a": "AAAAAAAAAA",  # target
@@ -1682,7 +1682,7 @@ def test_sequence_collection_copy_annotations_incompat_type_fails(seqcoll_db, se
 
 
 @pytest.mark.parametrize("moltype", ("dna", "protein"))
-def test_same_moltype(moltype):
+def test_sequence_collection_to_moltype_same_moltype(moltype):
     data = dict(s1="ACGTT", s2="ACCTT")
     seqs = new_aln.make_unaligned_seqs(data, moltype=moltype)
     got = seqs.to_moltype(moltype=moltype)
@@ -1725,13 +1725,6 @@ def test_sequence_collection_to_moltype_annotation_db():
     seqs.annotation_db = db
     dna = seqs.to_moltype("dna")
     assert len(dna.annotation_db) == 3
-
-
-def test_sequence_collection_to_moltype_same_moltype():
-    data = {"seq1": "ACGTACGTA", "seq2": "ACCGAA---", "seq3": "ACGTACGTT"}
-    seqs = new_aln.make_unaligned_seqs(data, moltype="dna")
-    to_same_seqs = seqs.to_moltype("dna")
-    assert to_same_seqs is seqs
 
 
 def test_sequence_collection_to_dna():

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -151,7 +151,7 @@ def test_seqs_data_default_attributes(dna_sd: new_aln.SeqsData):
 
 def test_seqs_data_view_zero_step_raises(dna_sd):
     with pytest.raises(ValueError):
-        new_aln.SeqDataView(seqs=dna_sd, step=0, seq_len=4)
+        new_aln.SeqDataView(seq=dna_sd, step=0, seq_len=4)
 
 
 @pytest.mark.parametrize("seqid", ["seq1", "seq2"])
@@ -200,7 +200,7 @@ def test_seqs_data_get_seq_view(str_seqs_dict, alpha, seqid):
     seq_len = len(seq)
     got = sd.get_seq_view(seqid)
     assert isinstance(got, new_aln.SeqDataView)
-    assert got.seqs == sd
+    assert got.seq == sd
     assert got.stop == seq_len
     assert got.seqid == seqid
     assert got.seq_len == seq_len
@@ -275,7 +275,7 @@ def test_seqs_data_make_seq_setget(dna_sd):
 @pytest.mark.parametrize("seq", ("seq1", "seq2"))
 def test_seqs_data_getitem_str_1(dna_sd, seq):
     got = dna_sd[seq]
-    assert got.seqs == dna_sd
+    assert got.seq == dna_sd
     assert got.seqid == seq
 
 
@@ -283,7 +283,7 @@ def test_seqs_data_getitem_str_1(dna_sd, seq):
 def test_seqs_data_getitem_int(str_seqs_dict, alpha, idx):
     sd = new_aln.SeqsData(data=str_seqs_dict, alphabet=alpha)
     got = sd[idx]
-    assert got.seqs == sd
+    assert got.seq == sd
     assert got.seqid == list(str_seqs_dict)[idx]
 
 
@@ -293,7 +293,7 @@ def test_seqs_data_getitem_str(
     seqid,
 ):
     got = dna_sd[seqid]
-    assert got.seqs == dna_sd
+    assert got.seq == dna_sd
     assert got.seqid == seqid
 
 
@@ -373,7 +373,7 @@ def test_seqs_data_to_alphabet_invalid():
     ],
 )
 def test_seq_data_view_slice_returns_self(seq1: str, index: slice):
-    sdv = new_aln.SeqDataView(seqs=seq1, seqid="seq1", seq_len=len(seq1))
+    sdv = new_aln.SeqDataView(seq=seq1, seqid="seq1", seq_len=len(seq1))
     got = sdv[index]
     assert isinstance(got, new_aln.SeqDataView)
 
@@ -453,7 +453,7 @@ def test_get_aligned_view(aligned_dict, seqid):
     ad = new_aln.AlignedData.from_gapped_seqs(aligned_dict)
     got = ad.get_aligned_view(seqid)
     assert isinstance(got, new_aln.AlignedDataView)
-    assert got.seqs == ad
+    assert got.seq == ad
     assert got.stop == ad.align_len
     assert got.seq_len == ad.align_len
 

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import re
 
-from tempfile import TemporaryDirectory
 from warnings import catch_warnings, filterwarnings
 
 import numpy
@@ -2054,16 +2053,15 @@ def test_sequence_collection_get_seq_entropy():
 
 
 @pytest.mark.xfail(reason="todo: kath, design of serialisation is unresolved")
-def test_sequence_collection_write_to_json():
+def test_sequence_collection_write_to_json(tmp_path):
     # test writing to json file
     data = {"a": "AAAA", "b": "TTTT", "c": "CCCC"}
     aln = new_aln.make_unaligned_seqs(data, moltype="dna")
-    with TemporaryDirectory(".") as dirname:
-        path = str(pathlib.Path(dirname) / "sample.json")
-        aln.write(path)
-        with open_(path) as fn:
-            got = json.loads(fn.read())
-            assert got == aln.to_rich_dict()
+    path = str(tmp_path / "sample.json")
+    aln.write(path)
+    with open_(path) as fn:
+        got = json.loads(fn.read())
+        assert got == aln.to_rich_dict()
 
 
 @pytest.mark.parametrize("moltype", ("dna", "rna"))

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -1682,6 +1682,14 @@ def test_sequence_collection_copy_annotations_incompat_type_fails(seqcoll_db, se
         seqcoll_db.copy_annotations(seqs)
 
 
+@pytest.mark.parametrize("moltype", ("dna", "protein"))
+def test_same_moltype(moltype):
+    data = dict(s1="ACGTT", s2="ACCTT")
+    seqs = new_aln.make_unaligned_seqs(data, moltype=moltype)
+    got = seqs.to_moltype(moltype=moltype)
+    assert got is seqs
+
+
 def test_sequence_collection_to_moltype_with_gaps():
     """correctly convert to specified moltype"""
     data = {"seq1": "ACGTACGTA", "seq2": "ACCGAA---", "seq3": "ACGTACGTT"}


### PR DESCRIPTION
in this PR: 

#### NEW
- add `SeqViewABC`
- `SeqView` inherits from `SeqViewABC` and now requires `alphabet` as init arg

#### DEV:
- REMOVED `replace` method from `SeqView` -- wont add back unless things break 
- methods for `translation` (pending refactoring of `Sequence.translate`)
- methods for `reverse_complement`
- increased test coverage 
- refactor targets