### PR TITLE
ENH: add new_type arguments for top-level function, fixes #1924

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -78,24 +78,33 @@ __numba_logger = logging.getLogger("numba")
 __numba_logger.setLevel(logging.WARNING)
 
 
-def make_seq(seq, name=None, moltype=None):
+def make_seq(seq, name: str = None, moltype=None, new_type: bool = False):
     """
     Parameters
     ----------
-    seq : str
+    seq
         raw string to be converted to sequence object
-    name : str
+    name
         sequence name
     moltype
         name of a moltype or moltype instance
+    new_type
+        if True, returns a new type Sequence (cogent3.core.new_sequence.Sequence).
+        The default will be changed to True in 2024.12. Support for the old
+        style will be removed as of 2025.6.
 
     Returns
     -------
     returns a sequence object
     """
     moltype = moltype or "text"
-    moltype = get_moltype(moltype)
-    seq = moltype.make_seq(seq, name=name)
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        from cogent3.core import new_moltype
+
+        moltype = new_moltype.get_moltype(moltype)
+    else:
+        moltype = get_moltype(moltype)
+    seq = moltype.make_seq(seq=seq, name=name)
     return seq
 
 
@@ -138,15 +147,18 @@ def make_unaligned_seqs(
         origins of this data, defaults to 'unknown'. Converted to a string
         and added to info["source"].
     new_type
-        if True, the returned SequenceCollection will be of the new type.
-        The default will be changed to True in 2024.12. Support for the old
-        style will be removed as of 2025.6.
+        if True, the returned SequenceCollection will be of the new type,
+        (cogent3.core.new_sequence.SequenceCollection). The default will be
+        changed to True in 2024.12. Support for the old style will be removed
+        as of 2025.6.
     **kw
         other keyword arguments passed to SequenceCollection
     """
-    if new_type and moltype is None:
-        raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-    elif new_type:
+
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        if moltype is None:
+            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
+
         from cogent3.core import new_alignment
 
         return new_alignment.make_unaligned_seqs(
@@ -233,9 +245,11 @@ def _load_files_to_unaligned_seqs(
         )
         for fn in ui.series(file_names)
     ]
-    if new_type and moltype is None:
-        raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-    elif new_type:
+
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        if moltype is None:
+            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
+
         from cogent3.core import new_alignment
 
         return new_alignment.make_unaligned_seqs(
@@ -297,7 +311,7 @@ def load_seq(
     info : dict
         a dict from which to make an info object
     new_type
-        if True, the returned Sequence will be of the new type.
+        if True, returns a new type Sequence (cogent3.core.new_sequence.Sequence)
         The default will be changed to True in 2024.12. Support for the old
         style will be removed as of 2025.6.
     **kw
@@ -323,9 +337,11 @@ def load_seq(
     data = _load_seqs(file_format, filename, format, kw, parser_kw)
     name, seq = data[0]
     name = label_to_name(name) if label_to_name else name
-    if new_type and moltype is None:
-        raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-    elif new_type:
+
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        if moltype is None:
+            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
+
         from cogent3.core import new_moltype
 
         moltype = new_moltype.get_moltype(moltype)
@@ -372,9 +388,10 @@ def load_unaligned_seqs(
     info
         a dict from which to make an info object
     new_type
-        if True, the returned SequenceCollection will be of the new type.
-        The default will be changed to True in 2024.12. Support for the old
-        style will be removed as of 2025.6.
+        if True, the returned SequenceCollection will be of the new type,
+        (cogent3.core.new_sequence.SequenceCollection). The default will be
+        changed to True in 2024.12. Support for the old style will be removed
+        as of 2025.6.
 
     **kw
         other keyword arguments passed to SequenceCollection, or show_progress.
@@ -405,9 +422,11 @@ def load_unaligned_seqs(
         return load_from_json(filename, (SequenceCollection,))
 
     data = _load_seqs(file_format, filename, format, kw, parser_kw)
-    if new_type and moltype is None:
-        raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-    elif new_type:
+
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        if moltype is None:
+            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
+
         from cogent3.core import new_alignment
 
         return new_alignment.make_unaligned_seqs(

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -78,7 +78,9 @@ __numba_logger = logging.getLogger("numba")
 __numba_logger.setLevel(logging.WARNING)
 
 
-def make_seq(seq, name: str = None, moltype=None, new_type: bool = False):
+def make_seq(
+    seq, name: str = None, moltype=None, new_type: bool = False
+):  # refactor: type hinting, need to capture optional args and the return type
     """
     Parameters
     ----------
@@ -246,26 +248,13 @@ def _load_files_to_unaligned_seqs(
         for fn in ui.series(file_names)
     ]
 
-    if new_type or "COGENT3_NEW_TYPE" in os.environ:
-        if moltype is None:
-            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-
-        from cogent3.core import new_alignment
-
-        return new_alignment.make_unaligned_seqs(
-            data=seqs,
-            moltype=moltype,
-            label_to_name=label_to_name,
-            source=path,
-            info=info,
-        )
-
     return make_unaligned_seqs(
         seqs,
         label_to_name=label_to_name,
         moltype=moltype,
         source=path,
         info=info,
+        new_type=new_type,
     )
 
 
@@ -338,16 +327,7 @@ def load_seq(
     name, seq = data[0]
     name = label_to_name(name) if label_to_name else name
 
-    if new_type or "COGENT3_NEW_TYPE" in os.environ:
-        if moltype is None:
-            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-
-        from cogent3.core import new_moltype
-
-        moltype = new_moltype.get_moltype(moltype)
-        result = moltype.make_seq(seq=seq, name=name)
-    else:
-        result = make_seq(seq, name, moltype=moltype)
+    result = make_seq(seq, name, moltype=moltype, new_type=new_type)
     result.info.update(info)
 
     if getattr(seq, "annotation_db", None):
@@ -423,27 +403,13 @@ def load_unaligned_seqs(
 
     data = _load_seqs(file_format, filename, format, kw, parser_kw)
 
-    if new_type or "COGENT3_NEW_TYPE" in os.environ:
-        if moltype is None:
-            raise ValueError("Argument 'moltype' is required when 'new_type=True'")
-
-        from cogent3.core import new_alignment
-
-        return new_alignment.make_unaligned_seqs(
-            data,
-            moltype=moltype,
-            label_to_name=label_to_name,
-            info=info,
-            source=filename,
-            **kw,
-        )
-
     return make_unaligned_seqs(
         data,
         label_to_name=label_to_name,
         moltype=moltype,
         source=filename,
         info=info,
+        new_type=new_type,
         **kw,
     )
 

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -5,6 +5,7 @@ NOTE: * is used to denote termination (as per NCBI standard).
 NOTE: Although the genetic code objects convert DNA to RNA and vice
 versa, lists of codons that they produce will be provided in DNA format.
 """
+import os
 import re
 
 from itertools import product
@@ -523,7 +524,7 @@ for key, value in list(GeneticCodes.items()):
 DEFAULT = GeneticCodes[1]
 
 
-def get_code(code_id=1):
+def get_code(code_id=1, new_type=False):
     """returns the genetic code
 
     Parameters
@@ -531,7 +532,16 @@ def get_code(code_id=1):
     code_id
         genetic code identifier, name, number or string(number), defaults to
         standard genetic code
+    new_type
+        if True, the returned genetic code object will be the new type.
+        The default will be changed to True in 2024.12. Support for the old
+        style will be removed as of 2025.6.
     """
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        from cogent3.core.new_genetic_code import get_code as new_get_code
+
+        return new_get_code(code_id=code_id)
+
     code_id = code_id or 1
     if isinstance(code_id, GeneticCode):
         return code_id

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -13,6 +13,7 @@ types and the MolType can be made after the objects are created.
 
 import itertools
 import json
+import os
 import re
 import typing
 
@@ -1517,8 +1518,23 @@ def _make_moltype_dict():
 moltypes = _make_moltype_dict()
 
 
-def get_moltype(name):
-    """returns the moltype with the matching name attribute"""
+def get_moltype(name, new_type: bool = False):
+    """returns the moltype with the matching name attribute
+
+    Parameters
+    ----------
+    name
+        the name of the moltype
+    new_type
+        if True, returns new type Moltype (cogent3.core.new_moltype.MolType).
+        The default will be changed to True in 2024.12. Support for the old
+        style will be removed as of 2025.6.
+    """
+    if new_type or "COGENT3_NEW_TYPE" in os.environ:
+        from cogent3.core.new_moltype import get_moltype as new_get_moltype
+
+        return new_get_moltype(name=name)
+
     if isinstance(name, MolType):
         return name
     name = name.lower()

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -521,7 +521,7 @@ class MolType:
                 f"{seq[:4]!r} not valid for moltype {self.name!r}"
             )
 
-        return self.complement(seq.encode("utf8"), validate=False)
+        return self.complement(seq.encode("utf8"), validate=False).decode("utf8")
 
     @complement.register
     def _(self, seq: bytes, validate: bool = True) -> str:
@@ -529,7 +529,7 @@ class MolType:
             raise new_alphabet.AlphabetError(
                 f"{seq[:4]!r} not valid for moltype {self.name!r}"
             )
-        return self._complement(seq).decode("utf8")
+        return self._complement(seq)
 
     @complement.register
     def _(self, seq: numpy.ndarray, validate: bool = True) -> str:
@@ -538,8 +538,10 @@ class MolType:
                 f"{seq[:4]!r} not valid for moltype {self.name!r}"
             )
 
-        return self.complement(
-            self.degen_gapped_alphabet.array_to_bytes(seq), validate=False
+        return self.degen_gapped_alphabet.to_indices(
+            self.complement(
+                self.degen_gapped_alphabet.array_to_bytes(seq), validate=False
+            )
         )
 
     def rc(self, seq: str, validate: bool = True) -> str:

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -119,10 +119,18 @@ class Sequence:
         return result
 
     def __bytes__(self):
-        return bytes(self._seq)
+        result = bytes(self._seq)
+        if self._seq.is_reversed:
+            with contextlib.suppress(TypeError):
+                result = self.moltype.complement(result)
+        return result
 
     def __array__(self):
-        return array(self._seq)
+        result = array(self._seq)
+        if self._seq.is_reversed:
+            with contextlib.suppress(TypeError):
+                result = self.moltype.complement(result)
+        return result
 
     def to_fasta(self, make_seqlabel=None, block_size=60):
         """Return string of self in FASTA format, no trailing newline
@@ -2383,7 +2391,8 @@ class SeqView(SeqViewABC, SliceRecordABC):
             f"seqid={self.seqid!r}, seq_len={self.seq_len})"
         )
 
-    def to_rich_dict(self):
+    def to_rich_dict(self) -> dict[str, str | dict[str, str]]:
+        """returns a json serialisable dict"""
         # get the current state
         data = {"type": get_object_provenance(self), "version": __version__}
         data["init_args"] = self._get_init_kwargs()

--- a/tests/test_core/test_new_moltype.py
+++ b/tests/test_core/test_new_moltype.py
@@ -72,14 +72,23 @@ def test_str_moltype():
 
 
 @pytest.mark.parametrize(
-    "seq", ("ACCCG", b"ACCCG", numpy.array([2, 1, 1, 1, 3], dtype=numpy.uint8))
+    "seq, data_type",
+    (
+        ("ACCCG", str),
+        (b"ACCCG", bytes),
+        (numpy.array([2, 1, 1, 1, 3], dtype=numpy.uint8), numpy.ndarray),
+    ),
 )
 @pytest.mark.parametrize("name", ("dna", "rna"))
-def test_complement(name, seq):
-    dna = new_moltype.get_moltype(name)
+def test_complement(name, seq, data_type):
+    moltype = new_moltype.get_moltype(name)
     expect = "TGGGC" if name == "dna" else "UGGGC"
-    got = dna.complement(seq)
-    assert got == expect
+    got = moltype.complement(seq)
+    assert (
+        got == make_typed(expect, data_type, moltype)
+        if data_type is not numpy.ndarray
+        else numpy.array_equal(got, make_typed(expect, data_type, moltype))
+    )
 
 
 def make_typed(seq, data_type, moltype):

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -852,7 +852,6 @@ def test_sequence_str_bytes_array():
     )
 
 
-@pytest.mark.xfail(reason="remove when Sequence.__str__ complements sequence")
 @pytest.mark.parametrize("seq,rc", (("ATGTTT", False), ("AAACAT", True)))
 def test_translation(seq, rc):
     seq = new_moltype.DNA.make_seq(seq=seq)


### PR DESCRIPTION
DEV: `__bytes/array__` now complement reversed seqs - this took some changes to `Moltype.complement`, @GavinHuttley if you would prefer that the responsibility of converting the result of complement into input type is handled in the `__bytes/array__` methods let me know and I can change it 🫡