### PR TITLE
DEV: raise not implemented error on top level stringified type hint

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -153,6 +153,21 @@ def _get_raw_hints(main_func, min_params):
     if depth > 2:
         raise TypeError(msg.format("return_type", return_type, depth))
 
+    if isinstance(first_param_type, str):
+        msg = (
+            "Apps do not yet support string type hints "
+            "(such as those caused by __future__ annotations). "
+            f"Bad type hint: {first_param_type}"
+        )
+        raise NotImplementedError(msg)
+    if isinstance(return_type, str):
+        msg = (
+            "Apps do not yet support string type hints "
+            "(such as those caused by __future__ annotations). "
+            f"Bad type hint: {return_type}"
+        )
+        raise NotImplementedError(msg)
+
     return first_param_type, return_type
 
 

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -1129,3 +1129,17 @@ def test_copies_doc_from_func():
 
     assert delme2.__doc__ == "my docstring"
     assert delme2.__init__.__doc__.split() == ["Notes", "-----", "body"]
+
+
+def test_bad_wrap():
+    def foo(a: "str") -> int:
+        return int(a)
+
+    with pytest.raises(NotImplementedError):
+        define_app(foo)
+
+    def bar(a: str) -> "int":
+        return int(a)
+
+    with pytest.raises(NotImplementedError):
+        define_app(bar)


### PR DESCRIPTION
Not a fix to #1897, though raises an error when it detects a top-level stringified type hint for either the input or output of an app.

By top-level, I mean it doesn't check nested type hints - i.e. patterns like `typing.Union["int","str"]`. To do so would break the current behaviour of `cogent3.app.typing.get_constraint_names`. It would be better to properly resolve the issue instead.

It will detect the problem-causing `from __future__ import annotations` pattern and raise a `NotImplementedError` for now.