### PR TITLE
ENH: add strip methods to moltype

### DIFF
--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -835,7 +835,7 @@ class MolType:
         # how can we reliably strip the gap character when it will be a different
         # index depending on the alphabet used to encode the sequence?
         # here I assume that degen_alphabet was used (as that is used in the str/bytes dispatches)
-        # but this is not guaranteed if the input is already numpy array. 
+        # but this is not guaranteed if the input is already numpy array.
         # given degen_gapped_alphabet is typically used for conversion elsewhere in the code
         # should we assume that instead?
         return seq[seq < len(self.degen_alphabet)]

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -821,7 +821,7 @@ class MolType:
 
     @strip_bad.register
     def _(self, seq: str) -> str:
-        return self._strip_bad(seq.encode("utf8")).decode("utf8")
+        return self.strip_bad(seq.encode("utf8")).decode("utf8")
 
     @functools.singledispatchmethod
     def strip_bad_and_gaps(self, seq: StrORBytes) -> StrORBytes:

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -922,6 +922,26 @@ class MolType:
     def _(self, seq: str) -> int:
         return self.count_degenerate(seq.encode("utf8"))
 
+    @functools.singledispatchmethod
+    def count_variants(self, seq: StrORBytes) -> int:
+        """Counts number of possible sequences matching the sequence, given
+        any ambiguous characters in the sequence.
+
+        Notes
+        -----
+        Uses self.ambiguitues to decide how many possibilities there are at
+        each position in the sequence and calculates the permutations.
+        """
+        raise TypeError(f"{type(seq)} not supported")
+
+    @count_variants.register
+    def _(self, seq: bytes) -> int:
+        return self.count_variants(seq.decode("utf8"))
+
+    @count_variants.register
+    def _(self, seq: str) -> int:
+        return numpy.prod([len(self.ambiguities.get(c, c)) for c in seq])
+
     def strand_symmetric_motifs(
         self, motif_length: int = 1
     ) -> set[tuple[str, str]]:  # refactor: docstring

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -890,6 +890,22 @@ class MolType:
             self.random_disambiguate(self.degen_gapped_alphabet.array_to_bytes(seq))
         )
 
+    @functools.singledispatchmethod
+    def count_gaps(self, seq: StrORBytes) -> int:
+        """returns the number of gap characters in a sequence"""
+        raise TypeError(f"{type(seq)} not supported")
+
+    def _count_gaps(self, seq: numpy.ndarray) -> int:
+        return numpy.sum(seq == self.degen_gapped_alphabet.gap_index)
+
+    @count_gaps.register
+    def _(self, seq: bytes) -> int:
+        return self._count_gaps(self.degen_gapped_alphabet.to_indices(seq))
+
+    @count_gaps.register
+    def _(self, seq: str) -> int:
+        return self.count_gaps(seq.encode("utf8"))
+
     def strand_symmetric_motifs(
         self, motif_length: int = 1
     ) -> set[tuple[str, str]]:  # refactor: docstring

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -806,26 +806,25 @@ class MolType:
         )
 
     @functools.singledispatchmethod
-    def strip_bad(self, seq: StrORBytesORArray) -> StrORBytesORArray:
+    def strip_bad(self, seq: StrORBytes) -> StrORBytes:
         """Removes any symbols not in the alphabet."""
         raise TypeError(f"{type(seq)} not supported")
 
-    @strip_bad.register
-    def _(self, seq: numpy.ndarray) -> numpy.ndarray:
+    def _strip_bad(self, seq: numpy.ndarray) -> numpy.ndarray:
         return seq[seq < len(self.degen_gapped_alphabet)]
 
     @strip_bad.register
     def _(self, seq: bytes) -> bytes:
         return self.degen_gapped_alphabet.array_to_bytes(
-            self.strip_bad(self.degen_gapped_alphabet.to_indices(seq))
+            self._strip_bad(self.degen_gapped_alphabet.to_indices(seq))
         )
 
     @strip_bad.register
     def _(self, seq: str) -> str:
-        return self.strip_bad(seq.encode("utf8")).decode("utf8")
+        return self._strip_bad(seq.encode("utf8")).decode("utf8")
 
     @functools.singledispatchmethod
-    def strip_bad_and_gaps(self, seq: StrORBytesORArray) -> StrORBytesORArray:
+    def strip_bad_and_gaps(self, seq: StrORBytes) -> StrORBytes:
         """Removes any symbols not in the alphabet, and any gaps."""
         raise TypeError(f"{type(seq)} not supported")
 

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -906,6 +906,22 @@ class MolType:
     def _(self, seq: str) -> int:
         return self.count_gaps(seq.encode("utf8"))
 
+    @functools.singledispatchmethod
+    def count_degenerate(self, seq: StrORBytes) -> int:
+        """returns the number of degenerate characters in a sequence"""
+        raise TypeError(f"{type(seq)} not supported")
+
+    def _count_degenerate(self, seq: numpy.ndarray) -> int:
+        return numpy.sum(seq >= self.degen_gapped_alphabet.gap_index)
+
+    @count_degenerate.register
+    def _(self, seq: bytes) -> int:
+        return self._count_degenerate(self.degen_gapped_alphabet.to_indices(seq))
+
+    @count_degenerate.register
+    def _(self, seq: str) -> int:
+        return self.count_degenerate(seq.encode("utf8"))
+
     def strand_symmetric_motifs(
         self, motif_length: int = 1
     ) -> set[tuple[str, str]]:  # refactor: docstring

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -383,13 +383,18 @@ class Sequence:
     def disambiguate(self, method="strip"):
         """Returns a non-degenerate sequence from a degenerate one.
 
-        method can be 'strip' (deletes any characters not in monomers or gaps)
-        or 'random'(assigns the possibilities at random, using equal
-        frequencies).
+        Parameters
+        ----------
+        seq
+            the sequence to be disambiguated
+        method
+            how to disambiguate the sequence, one of "strip", "random"
+            strip: deletes any characters not in monomers or gaps
+            random: assigns the possibilities at random, using equal frequencies
         """
         return self.__class__(
             moltype=self.moltype,
-            seq=self.moltype.disambiguate(self, method),
+            seq=self.moltype.disambiguate(str(self), method),
             info=self.info,
         )
 

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1910,10 +1910,6 @@ class DnaSequence(Sequence, NucleicAcidSequenceMixin):
 
     # constructed by DNA moltype
 
-    def _seq_filter(self, seq):
-        """Converts U to T."""
-        return seq.replace("u", "t").replace("U", "T")
-
 
 @register_deserialiser(get_object_provenance(DnaSequence))
 def deserialise_dna_sequence(data) -> DnaSequence:
@@ -1924,10 +1920,6 @@ class RnaSequence(Sequence, NucleicAcidSequenceMixin):
     """Holds the standard RNA sequence."""
 
     # constructed by RNA moltype
-
-    def _seq_filter(self, seq):
-        """Converts T to U."""
-        return seq.replace("t", "u").replace("T", "U")
 
 
 @register_deserialiser(get_object_provenance(RnaSequence))

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -372,11 +372,11 @@ class Sequence:
         """Returns True if sequence contains degenerate characters."""
         return self.moltype.is_degenerate(str(self))
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """Returns True if sequence contains no items absent from alphabet."""
         return self.moltype.is_valid(self)
 
-    def is_strict(self):
+    def is_strict(self) -> bool:
         """Returns True if sequence contains only monomers."""
         return self.moltype.alphabet.is_valid(array(self))
 
@@ -417,25 +417,31 @@ class Sequence:
         """Returns vector of True or False according to which pos are gaps."""
         return self.moltype.gap_vector(self)
 
-    def gap_maps(self):
-        """Returns dicts mapping between gapped and ungapped positions."""
-        return self.moltype.gap_maps(self)
-
-    def count_gaps(self):
+    def count_gaps(self) -> int:
         """Counts the gaps in the specified sequence."""
-        return self.moltype.count_gaps(self)
+        return self.moltype.count_gaps(bytes(self))
 
-    def count_degenerate(self):
-        """Counts the degenerate bases in the specified sequence."""
-        return self.moltype.count_degenerate(self)
+    def count_degenerate(self) -> int:
+        """Counts the degenerate bases in the specified sequence.
 
-    def possibilities(self):
-        """Counts number of possible sequences matching the sequence.
-
-        Uses self.degenerates to decide how many possibilities there are at
-        each position in the sequence.
+        Notes
+        -----
+        gap and missing characters are counted as degenerate.
         """
-        return self.moltype.possibilities(self)
+        # design: refactor
+        # should gap and missing characters be counted as degenerate?
+        return self.moltype.count_degenerate(bytes(self))
+
+    def count_variants(self):
+        """Counts number of possible sequences matching the sequence, given
+        any ambiguous characters in the sequence.
+
+        Notes
+        -----
+        Uses self.ambiguitues to decide how many possibilities there are at
+        each position in the sequence and calculates the permutations.
+        """
+        return self.moltype.count_variants(str(self))
 
     def mw(self, method="random", delta=None):  # refactor: type hint
         """Returns the molecular weight of (one strand of) the sequence.

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -329,15 +329,12 @@ class Sequence:
         """Removes degenerate bases by stripping them out of the sequence."""
         return self.__class__(
             moltype=self.moltype,
-            seq=self.moltype.strip_degenerate(str(self)),
+            seq=self.moltype.strip_degenerate(bytes(self)),
             info=self.info,
         )
 
     def strip_bad(self):
         """Removes any symbols not in the alphabet."""
-        # refactor: design
-        # previous implementation did NOT strip X from DNA even though its not in the alphabet
-        # do we want to keep that behavior?
         return self.__class__(
             moltype=self.moltype, seq=self.moltype.strip_bad(str(self)), info=self.info
         )
@@ -359,7 +356,7 @@ class Sequence:
 
         If char is not supplied, tests whether self is gaps only.
         """
-        # refactor design
+        # refactor design - possibly delete method
         # only works on a single literal that's a gap, not on a sequence.
         # i.e, seq.is_gap('-') would return True, but seq.is_gap("--") would return False
         # possibly, this behavior should change?
@@ -402,7 +399,7 @@ class Sequence:
         """Deletes all gap characters from sequence."""
         result = self.__class__(
             moltype=self.moltype,
-            seq=self.moltype.degap(str(self)),
+            seq=self.moltype.degap(bytes(self)),
             name=self.name,
             info=self.info,
         )
@@ -1129,6 +1126,9 @@ class Sequence:
         -----
         This method cannot convert between nucleic acids and proteins. Use
         get_translation() for that.
+
+        When applied to a sequence in a SequenceCollection, the resulting
+        sequence will no longer be part of the collection.
         """
         from cogent3.core import new_moltype
 
@@ -1711,7 +1711,9 @@ class NucleicAcidSequenceMixin:
         will return list of keys.
         """
         return self.__class__(
-            moltype=self.moltype, seq=self.moltype.complement(str(self)), info=self.info
+            moltype=self.moltype,
+            seq=self.moltype.complement(bytes(self)),
+            info=self.info,
         )
 
     def reverse_complement(self):

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1160,7 +1160,7 @@ class Sequence:
                 f"moltype={moltype.label} is not valid for this data"
             )
         sv = SeqView(seq=seq, alphabet=moltype.most_degen_alphabet())
-        new = moltype.make_seq(seq=sv, name=self.name, info=self.info, check_seq=False)
+        new = self.__class__(moltype=moltype, seq=sv, name=self.name, info=self.info)
         new.annotation_db = self.annotation_db
         return new
 

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1144,26 +1144,13 @@ class Sequence:
             # converting between dna and rna
             seq = (
                 moltype.most_degen_alphabet()
-                .array_to_bytes(self._seq.array_value)
+                .array_to_bytes(array(self))
                 .decode("utf-8")
             )
 
         else:
-            old = self.moltype.most_degen_alphabet().as_bytes()
-            new = moltype.most_degen_alphabet().as_bytes()
-            convert_old_to_bytes = new_alphabet.array_to_bytes(old)
-            convert_bytes_to_new = new_alphabet.bytes_to_array(
-                new, dtype=new_alphabet.get_array_type(len(new))
-            )
-
-            as_new_alpha = convert_bytes_to_new(
-                convert_old_to_bytes(self._seq.array_value)
-            )
-            seq = (
-                moltype.most_degen_alphabet()
-                .array_to_bytes(as_new_alpha)
-                .decode("utf-8")
-            )
+            # assume converting between ASCII/BYTES and nucleic acid
+            seq = str(self)
 
         if not moltype.most_degen_alphabet().is_valid(seq):
             raise ValueError(

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -315,19 +315,19 @@ class SequenceI(object):
         """Returns True if sequence contains only monomers."""
         return self.moltype.is_strict(self)
 
-    def first_gap(self):
+    def first_gap(self):  # will not port
         """Returns the index of the first gap in the sequence, or None."""
         return self.moltype.first_gap(self)
 
-    def first_degenerate(self):
+    def first_degenerate(self):  # will not port
         """Returns the index of first degenerate symbol in sequence, or None."""
         return self.moltype.first_degenerate(self)
 
-    def first_invalid(self):
+    def first_invalid(self):  # will not port
         """Returns the index of first invalid symbol in sequence, or None."""
         return self.moltype.first_invalid(self)
 
-    def first_non_strict(self):
+    def first_non_strict(self):  # will not port
         """Returns the index of first non-strict symbol in sequence, or None."""
         return self.moltype.first_non_strict(self)
 

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -486,7 +486,7 @@ class MolTypeTests(TestCase):
         self.assertEqual(s("ACGUcgAUGUGCAUcaguX"), 18)
         self.assertEqual(s("ACGUcgAUGUGCAUcaguX-38243829"), 18)
 
-    def test_disambiguate(self):
+    def test_disambiguate(self):  # ported
         """MolType disambiguate should remove degenerate bases"""
         d = RnaMolType.disambiguate
         self.assertEqual(d(""), "")
@@ -599,7 +599,7 @@ class MolTypeTests(TestCase):
         self.assertEqual(c("!@#$!@#$!@#$"), 12)
         self.assertEqual(c("cguua!cgcuagua@cguasguadc#"), 3)
 
-    def test_count_degenerate(self):
+    def test_count_degenerate(self):  # ported
         """MolType count_degenerate should return correct degen base count"""
         d = RnaMolType.count_degenerate
         self.assertEqual(d(""), 0)
@@ -608,7 +608,7 @@ class MolTypeTests(TestCase):
         self.assertEqual(d("NRY"), 3)
         self.assertEqual(d("ACGUAVCUAGCAUNUCAGUCAGyUACGUCAGS"), 4)
 
-    def test_possibilites(self):
+    def test_possibilites(self):  # ported
         """MolType possibilities should return correct # possible sequences"""
         p = RnaMolType.possibilities
         self.assertEqual(p(""), 1)

--- a/tests/test_core/test_new_moltype.py
+++ b/tests/test_core/test_new_moltype.py
@@ -480,7 +480,7 @@ def test_disambiguate_random_str():
         if i in new_moltype.RNA.ambiguities:
             assert j in new_moltype.RNA.ambiguities[i]
 
-    assert new_moltype.RNA.is_degenerate(t) == False
+    assert not new_moltype.RNA.is_degenerate(t)
     with pytest.raises(NotImplementedError):
         d(s, method="xyz")
 

--- a/tests/test_core/test_new_moltype.py
+++ b/tests/test_core/test_new_moltype.py
@@ -484,3 +484,35 @@ def test_disambiguate_random_str():
     with pytest.raises(NotImplementedError):
         d(s, method="xyz")
 
+
+@pytest.mark.parametrize("data_type", (str, bytes))
+@pytest.mark.parametrize(
+    "data, expect",
+    (("---CGAUGCAU---ACGHC---ACGUCAGU---", 12), ("", 0), ("ACGU", 0), ("-", 1)),
+)
+def test_count_gaps(data, expect, data_type):
+    seq = make_typed(data, data_type, new_moltype.RNA)
+    got = new_moltype.RNA.count_gaps(seq)
+    assert got == expect
+
+
+def test_count_degenerate():
+    """MolType count_degenerate should return correct degen base count"""
+    d = new_moltype.RNA.count_degenerate
+    assert d("") == 0
+    assert d("GACUGCAUGCAUCGUACGUCAGUACCGA") == 0
+    assert d("N") == 1
+    assert d("NRY") == 3
+    assert d("ACGUAVCUAGCAUNUCAGUCAGyUACGUCAGS") == 4
+
+
+def test_count_variants():
+    """MolType count_variants should return correct # possible sequences"""
+    p = new_moltype.RNA.count_variants
+    assert p("") == 1
+    assert p("ACGUGCAUCAGUCGUGCAU") == 1
+    assert p("N") == 4
+    assert p("R") == 2
+    assert p("H") == 3
+    assert p("NRH") == 24
+    assert p("AUGCNGUCAG-AURGAUC--GAUHCGAUACGWS") == 96

--- a/tests/test_core/test_new_moltype.py
+++ b/tests/test_core/test_new_moltype.py
@@ -401,7 +401,7 @@ def test_strip_degenerate(data_type):
     )
 
 
-@pytest.mark.parametrize("data_type", (str, bytes, numpy.ndarray))
+@pytest.mark.parametrize("data_type", (str, bytes))
 def test_strip_bad(data_type):
     """removes characters that are not in the alphabet"""
 
@@ -409,25 +409,19 @@ def test_strip_bad(data_type):
     seq = make_typed("TCGA-Q?NRYWSKMBDHV", data_type, new_moltype.DNA)
     got = new_moltype.DNA.strip_bad(seq)
     expect = make_typed("TCGA-?NRYWSKMBDHV", data_type, new_moltype.DNA)
-    assert (
-        numpy.array_equal(got, expect) if data_type is numpy.ndarray else got == expect
-    )
+    assert got == expect
 
     # Protein - J and * not in Protein alphabet/ambiguities
     seq = make_typed("ASTBJZ*-X", data_type, new_moltype.PROTEIN)
     got = new_moltype.PROTEIN.strip_bad(seq)
     expect = make_typed("ASTBZ-X", data_type, new_moltype.PROTEIN)
-    assert (
-        numpy.array_equal(got, expect) if data_type is numpy.ndarray else got == expect
-    )
+    assert got == expect
 
     # Protein with stop - J  not in Protein alphabet/ambiguities
     seq = make_typed("ASTBJZ*-X", data_type, new_moltype.PROTEIN_WITH_STOP)
     got = new_moltype.PROTEIN_WITH_STOP.strip_bad(seq)
     expect = make_typed("ASTBZ*-X", data_type, new_moltype.PROTEIN_WITH_STOP)
-    assert (
-        numpy.array_equal(got, expect) if data_type is numpy.ndarray else got == expect
-    )
+    assert got == expect
 
 
 @pytest.mark.parametrize("data_type", (str, bytes))

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -378,32 +378,6 @@ def test_sequence_gap_vector():
     )
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'gap_maps'"
-)
-def test_gap_maps():
-    """Sequence.gap_maps should return dicts mapping gapped/ungapped pos"""
-    empty = ""
-    no_gaps = "AAA"
-    all_gaps = "---"
-    start_gaps = "--ABC"
-    end_gaps = "AB---"
-    mid_gaps = "--A--B-CD---"
-
-    def gm(x):
-        return new_moltype.RNA.make_seq(seq=x).gap_maps()
-
-    assert gm(empty) == ({}, {})
-    assert gm(no_gaps) == ({0: 0, 1: 1, 2: 2}, {0: 0, 1: 1, 2: 2})
-    assert gm(all_gaps) == ({}, {})
-    assert gm(start_gaps) == ({0: 2, 1: 3, 2: 4}, {2: 0, 3: 1, 4: 2})
-    assert gm(end_gaps) == ({0: 0, 1: 1}, {0: 0, 1: 1})
-    assert gm(mid_gaps) == ({0: 2, 1: 5, 2: 7, 3: 8}, {2: 0, 5: 1, 7: 2, 8: 3})
-
-
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'count_gaps'"
-)
 def test_count_gaps():
     """Sequence.count_gaps should return correct gap count"""
     assert new_moltype.RNA.make_seq(seq="").count_gaps() == 0
@@ -417,9 +391,6 @@ def test_count_gaps():
     )
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'count_degenerate'"
-)
 def test_count_degenerate():
     """Sequence.count_degenerate should return correct degen base count"""
     assert new_moltype.RNA.make_seq(seq="").count_degenerate() == 0
@@ -428,31 +399,28 @@ def test_count_degenerate():
         == 0
     )
     assert new_moltype.RNA.make_seq(seq="N").count_degenerate() == 1
-    assert new_moltype.PROT.make_seq(seq="N").count_degenerate() == 0
+    assert new_moltype.PROTEIN.make_seq(seq="N").count_degenerate() == 0
     assert new_moltype.RNA.make_seq(seq="NRY").count_degenerate() == 3
     assert (
         new_moltype.RNA.make_seq(
-            seq="ACGUAVCUAGCAUNUCAGUCAGyUACGUCAGS"
+            seq="ACGUAVCUAGCAUNUCAGUCAGYUACGUCAGS"
         ).count_degenerate()
         == 4
     )
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'possibilities'"
-)
-def test_possibilites():
-    """Sequence possibilities should return correct # possible sequences"""
-    assert new_moltype.RNA.make_seq(seq="").possibilities() == 1
-    assert new_moltype.RNA.make_seq(seq="ACGUGCAU").possibilities() == 1
-    assert new_moltype.RNA.make_seq(seq="N").possibilities() == 4
-    assert new_moltype.RNA.make_seq(seq="R").possibilities() == 2
-    assert new_moltype.RNA.make_seq(seq="H").possibilities() == 3
-    assert new_moltype.RNA.make_seq(seq="nRh").possibilities() == 24
+def test_sequence_count_variants():
+    """Sequence count_variants should return correct # possible sequences"""
+    assert new_moltype.RNA.make_seq(seq="").count_variants() == 1
+    assert new_moltype.RNA.make_seq(seq="ACGUGCAU").count_variants() == 1
+    assert new_moltype.RNA.make_seq(seq="N").count_variants() == 4
+    assert new_moltype.RNA.make_seq(seq="R").count_variants() == 2
+    assert new_moltype.RNA.make_seq(seq="H").count_variants() == 3
+    assert new_moltype.RNA.make_seq(seq="NRH").count_variants() == 24
     assert (
         new_moltype.RNA.make_seq(
             seq="AUGCNGUCAG-AURGAUC--GAUHCGAUACGWS"
-        ).possibilities()
+        ).count_variants()
         == 96
     )
 

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -336,13 +336,13 @@ def test_sequence_disambiguate():
 def test_sequence_degap():
     """Sequence degap should remove all gaps from sequence"""
     # doesn't preserve case
-    new_moltype.RNA.make_seq(seq="").degap() == ""
-    new_moltype.RNA.make_seq(seq="GUCAGUC").degap() == "GUCAGUC"
-    new_moltype.RNA.make_seq(seq="----------------").degap() == ""
-    new_moltype.RNA.make_seq(seq="GCUAUACG-").degap() == "GCUAUACG"
-    new_moltype.RNA.make_seq(seq="-CUAGUCA").degap() == "CUAGUCA"
-    new_moltype.RNA.make_seq(seq="---A---C---U----G---").degap() == "ACUG"
-    new_moltype.RNA.make_seq(seq="?A-").degap() == "A"
+    assert new_moltype.RNA.make_seq(seq="").degap() == ""
+    assert new_moltype.RNA.make_seq(seq="GUCAGUC").degap() == "GUCAGUC"
+    assert new_moltype.RNA.make_seq(seq="----------------").degap() == ""
+    assert new_moltype.RNA.make_seq(seq="GCUAUACG-").degap() == "GCUAUACG"
+    assert new_moltype.RNA.make_seq(seq="-CUAGUCA").degap() == "CUAGUCA"
+    assert new_moltype.RNA.make_seq(seq="---A---C---U----G---").degap() == "ACUG"
+    assert new_moltype.RNA.make_seq(seq="?A-").degap() == "A"
 
 
 @pytest.mark.xfail(
@@ -494,7 +494,7 @@ def test_can_match():
 )
 def test_can_mismatch():
     """Sequence can_mismatch should return True on any possible mismatch"""
-    assert not new_moltype.RNA.make_seq("").can_mismatch("")
+    assert not new_moltype.RNA.make_seq(seq="").can_mismatch("")
     assert new_moltype.RNA.make_seq(seq="N").can_mismatch("N")
     assert new_moltype.RNA.make_seq(seq="R").can_mismatch("R")
     assert new_moltype.RNA.make_seq(seq="N").can_mismatch("r")

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -305,9 +305,6 @@ def test_sequence_is_strict():
     assert not new_moltype.RNA.make_seq(seq="CAGUCGAUCA-").is_strict()
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'disambiguate'"
-)
 def test_sequence_disambiguate():
     """Sequence disambiguate should remove degenerate bases
 
@@ -325,8 +322,8 @@ def test_sequence_disambiguate():
     t = s.disambiguate("random")
     u = s.disambiguate("random")
     for i, j in zip(str(s), str(t)):
-        if i in s.moltype.degenerates:
-            assert j in s.moltype.degenerates[i]
+        if i in s.moltype.ambiguities:
+            assert j in s.moltype.ambiguities[i]
         else:
             assert i == j
     assert t != u

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -54,7 +54,7 @@ class SequenceTests(TestCase):
     DNA = DnaSequence
     PROT = ProteinSequence
 
-    def test_init_empty(self):
+    def test_init_empty(self):  # will not port
         """Sequence and subclasses should init correctly."""
         # NOTE: ModelSequences can't be initialized empty because it screws up
         # the dimensions of the array, and not worth special-casing.
@@ -65,18 +65,18 @@ class SequenceTests(TestCase):
         r = self.RNA()
         assert r.moltype is RNA
 
-    def test_init_data(self):
+    def test_init_data(self):  # will not port
         """Sequence init with data should set data in correct location"""
         r = self.RNA("ucagg")
         # no longer preserves case
         self.assertEqual(r, "UCAGG")
 
-    def test_init_from_bytes(self):
+    def test_init_from_bytes(self):  # will not port
         """correctly convert bytes to str"""
         s = self.SEQ(b"ACGT")
         self.assertEqual(s, "ACGT")
 
-    def test_init_other_seq(self):
+    def test_init_other_seq(self):  # will not port
         """Sequence init with other seq should preserve name and info."""
         r = self.RNA("UCAGG", name="x", info={"z": 3})
         s = Sequence(r)
@@ -84,7 +84,7 @@ class SequenceTests(TestCase):
         self.assertEqual(s.name, "x")
         self.assertEqual(s.info.z, 3)
 
-    def test_copy(self):
+    def test_copy(self):  # ported
         """correctly returns a copy version of self"""
         s = Sequence("TTTTTTTTTTAAAA", name="test_copy")
         annot1 = s.add_feature(biotype="exon", name="annot1", spans=[(0, 10)])
@@ -106,31 +106,31 @@ class SequenceTests(TestCase):
         self.assertEqual(annot1_slice, got1_slice)
         self.assertEqual(annot2_slice, got2_slice)
 
-    def test_compare_to_string(self):
+    def test_compare_to_string(self):  # ported
         """Sequence should compare equal to same string."""
         r = self.RNA("UCC")
         self.assertEqual(r, "UCC")
 
-    def test_slice(self):
+    def test_slice(self):  # ported
         """Sequence slicing should work as expected"""
         r = self.RNA("UCAGG")
         self.assertEqual(r[0], "U")
         self.assertEqual(r[-1], "G")
         self.assertEqual(r[1:3], "CA")
 
-    def test_to_dna(self):
+    def test_to_dna(self):  # ported
         """Returns copy of self as DNA."""
         r = self.RNA("UCA")
         self.assertEqual(str(r), "UCA")
         self.assertEqual(str(r.to_dna()), "TCA")
 
-    def test_to_rna(self):
+    def test_to_rna(self):  # ported
         """Returns copy of self as RNA."""
         r = self.DNA("TCA")
         self.assertEqual(str(r), "TCA")
         self.assertEqual(str(r.to_rna()), "UCA")
 
-    def test_to_fasta(self):
+    def test_to_fasta(self):  # ported
         """Sequence to_fasta() should return Fasta-format string"""
         even = "TCAGAT"
         odd = even + "AAA"
@@ -143,12 +143,14 @@ class SequenceTests(TestCase):
         # check that changing the linewrap again works
         self.assertEqual(even_dna.to_fasta(block_size=4), ">even\nTCAG\nAT\n")
 
-    def test_serialize(self):
+    def test_serialize(self):  # ported
         """Sequence should be serializable"""
         r = self.RNA("ugagg")
         assert dumps(r)
 
-    def test_sequence_to_moltype(self):
+    def test_sequence_to_moltype(
+        self,
+    ):  # ported however not supporting coercing to a different moltype if invalid
         """correctly convert to specified moltype"""
         s = Sequence("TTTTTTTTTTAAAA", name="test1")
         s.add_feature(biotype="exon", name="fred", spans=[(0, 10)])
@@ -166,13 +168,13 @@ class SequenceTests(TestCase):
         with self.assertRaises(ValueError):
             s.to_moltype("")
 
-    def test_strip_degenerate(self):
+    def test_strip_degenerate(self):  # ported
         """Sequence strip_degenerate should remove any degenerate bases"""
         self.assertEqual(self.RNA("UCAG-").strip_degenerate(), "UCAG-")
         self.assertEqual(self.RNA("NRYSW").strip_degenerate(), "")
         self.assertEqual(self.RNA("USNG").strip_degenerate(), "UG")
 
-    def test_strip_bad(self):
+    def test_strip_bad(self):  # ported
         """Sequence strip_bad should remove any non-base, non-gap chars"""
         # have to turn off check to get bad data in; no longer preserves case
         self.assertEqual(
@@ -184,7 +186,7 @@ class SequenceTests(TestCase):
             self.RNA("aaaxggg---!ccc", check=False).strip_bad(), "AAAGGG---CCC"
         )
 
-    def test_strip_bad_and_gaps(self):
+    def test_strip_bad_and_gaps(self):  # ported
         """Sequence strip_bad_and_gaps should remove gaps and bad chars"""
         # have to turn off check to get bad data in; no longer preserves case
         self.assertEqual(
@@ -198,21 +200,21 @@ class SequenceTests(TestCase):
             self.RNA("aaa ggg ---!ccc", check=False).strip_bad_and_gaps(), "AAAGGGCCC"
         )
 
-    def test_shuffle(self):
+    def test_shuffle(self):  # ported
         """Sequence shuffle should return new random sequence w/ same monomers"""
         r = self.RNA("UUUUCCCCAAAAGGGG")
         s = r.shuffle()
         self.assertFalse(r == s)
         self.assertCountEqual(r, s)
 
-    def test_complement(self):
+    def test_complement(self):  # ported
         """Sequence complement should correctly complement sequence"""
         self.assertEqual(self.RNA("UAUCG-NR").complement(), "AUAGC-NY")
         self.assertEqual(self.DNA("TATCG-NR").complement(), "ATAGC-NY")
         self.assertEqual(self.DNA("").complement(), "")
         self.assertRaises(TypeError, self.PROT("ACD").complement)
 
-    def test_rc(self):
+    def test_rc(self):  # ported although not support coercing to upper case
         """Sequence rc should correctly reverse-complement sequence"""
         # no longer preserves case!
         self.assertEqual(self.RNA("UauCG-NR").rc(), "YN-CGAUA")
@@ -221,7 +223,7 @@ class SequenceTests(TestCase):
         self.assertEqual(self.RNA("A").rc(), "U")
         self.assertRaises(TypeError, self.PROT("ACD").rc)
 
-    def test_contains(self):
+    def test_contains(self):  # ported
         """Sequence contains should return correct result"""
         r = self.RNA("UCA")
         assert "U" in r
@@ -229,12 +231,12 @@ class SequenceTests(TestCase):
         assert "X" not in r
         assert "G" not in r
 
-    def test_iter(self):
+    def test_iter(self):  # ported
         """Sequence iter should iterate over sequence"""
         p = self.PROT("QWE")
         self.assertEqual(list(p), ["Q", "W", "E"])
 
-    def test_is_gapped(self):
+    def test_is_gapped(self):  # ported although not support coercing to upper case
         """Sequence is_gapped should return True if gaps in seq"""
         assert not self.RNA("").is_gapped()
         assert not self.RNA("ACGUCAGUACGUCAGNRCGAUcaguaguacYRNRYRN").is_gapped()
@@ -244,7 +246,7 @@ class SequenceTests(TestCase):
         assert self.RNA("CA--CGUAUGCA-----g").is_gapped()
         assert self.RNA("CAGU-").is_gapped()
 
-    def test_is_gap(self):
+    def test_is_gap(self):  # ported although not support coercing to upper case
         """Sequence is_gap should return True if char is a valid gap char"""
         r = self.RNA("ACGUCAGUACGUCAGNRCGAUcaguaguacYRNRYRN")
         for char in "qwertyuiopasdfghjklzxcvbnmQWERTYUIOASDFGHJKLZXCVBNM":
@@ -259,7 +261,7 @@ class SequenceTests(TestCase):
         assert self.RNA("").is_gap()
         assert self.RNA("----------").is_gap()
 
-    def test_is_degenerate(self):
+    def test_is_degenerate(self):  # ported although not support coercing to upper case
         """Sequence is_degenerate should return True if degen symbol in seq"""
         assert not self.RNA("").is_degenerate()
         assert not self.RNA("UACGCUACAUGuacgucaguGCUAGCUA---ACGUCAG").is_degenerate()
@@ -269,14 +271,14 @@ class SequenceTests(TestCase):
         assert self.RNA("GCAUguagcucgUCAGUCAGUACgUgcasCUAG").is_degenerate()
         assert self.RNA("ACGYAUGCUGYWWNMNuwbycwuybcwbwub").is_degenerate()
 
-    def test_is_strict(self):
+    def test_is_strict(self):  # ported although not support coercing to upper case
         """Sequence is_strict should return True if all symbols in Monomers"""
         assert self.RNA("").is_strict()
         assert self.PROT("A").is_strict()
         assert self.RNA("UAGCACUgcaugcauGCAUGACuacguACAUG").is_strict()
         assert not self.RNA("CAGUCGAUCA-cgaucagUCGAUGAC").is_strict()
 
-    def test_first_gap(self):
+    def test_first_gap(self):  # will not port
         """Sequence first_gap should return index of first gap symbol, or None"""
         self.assertEqual(self.RNA("").first_gap(), None)
         self.assertEqual(self.RNA("a").first_gap(), None)
@@ -285,7 +287,7 @@ class SequenceTests(TestCase):
         self.assertEqual(self.RNA("b-ac").first_gap(), 1)
         self.assertEqual(self.RNA("abcd-").first_gap(), 4)
 
-    def test_first_degenerate(self):
+    def test_first_degenerate(self):  # will not port
         """Sequence first_degenerate should return index of first degen symbol"""
         self.assertEqual(self.RNA("").first_degenerate(), None)
         self.assertEqual(self.RNA("a").first_degenerate(), None)
@@ -294,7 +296,7 @@ class SequenceTests(TestCase):
         self.assertEqual(self.RNA("CUGguagvAUG").first_degenerate(), 7)
         self.assertEqual(self.RNA("ACUGCUAacgud").first_degenerate(), 11)
 
-    def test_first_non_strict(self):
+    def test_first_non_strict(self):  # will not port
         """Sequence first_non_strict should return index of first non-strict symbol"""
         self.assertEqual(self.RNA("").first_non_strict(), None)
         self.assertEqual(self.RNA("A").first_non_strict(), None)
@@ -303,7 +305,7 @@ class SequenceTests(TestCase):
         self.assertEqual(self.RNA("-").first_non_strict(), 0)
         self.assertEqual(self.RNA("ACGUcgAUGUGCAUcagu-").first_non_strict(), 18)
 
-    def test_disambiguate(self):
+    def test_disambiguate(self):  # ported
         """Sequence disambiguate should remove degenerate bases"""
         self.assertEqual(self.RNA("").disambiguate(), "")
         self.assertEqual(
@@ -323,7 +325,7 @@ class SequenceTests(TestCase):
         self.assertFalse(t == u)
         self.assertEqual(len(s), len(t))
 
-    def test_degap(self):
+    def test_degap(self):  # ported
         """Sequence degap should remove all gaps from sequence"""
         # doesn't preserve case
         self.assertEqual(self.RNA("").degap(), "")
@@ -336,7 +338,7 @@ class SequenceTests(TestCase):
         self.assertEqual(self.RNA("---a---c---u----g---").degap(), "ACUG")
         self.assertEqual(self.RNA("?a-").degap(), "A")
 
-    def test_gap_indices(self):
+    def test_gap_indices(self):  # ported
         """Sequence gap_indices should return correct gap positions"""
         self.assertEqual(self.RNA("").gap_indices(), [])
         self.assertEqual(self.RNA("ACUGUCAGUACGHSDKCUCDNNS").gap_indices(), [])
@@ -348,7 +350,7 @@ class SequenceTests(TestCase):
             [0, 1, 2, 11, 12, 13, 19, 20, 21, 30, 31, 32],
         )
 
-    def test_gap_vector(self):
+    def test_gap_vector(self):  # ported
         """Sequence gap_vector should return correct gap positions"""
 
         def g(x):
@@ -369,7 +371,7 @@ class SequenceTests(TestCase):
             list(map(bool, list(map(int, "111000000001110000011100000000111")))),
         )
 
-    def test_gap_maps(self):
+    def test_gap_maps(self):  # ported
         """Sequence gap_maps should return dicts mapping gapped/ungapped pos"""
         empty = ""
         no_gaps = "aaa"
@@ -390,7 +392,7 @@ class SequenceTests(TestCase):
             gm(mid_gaps), ({0: 2, 1: 5, 2: 7, 3: 8}, {2: 0, 5: 1, 7: 2, 8: 3})
         )
 
-    def test_count_gaps(self):
+    def test_count_gaps(self):  # ported
         """Sequence count_gaps should return correct gap count"""
         self.assertEqual(self.RNA("").count_gaps(), 0)
         self.assertEqual(self.RNA("ACUGUCAGUACGHSDKCUCDNNS").count_gaps(), 0)
@@ -399,7 +401,7 @@ class SequenceTests(TestCase):
         self.assertEqual(self.RNA("UACHASADS-").count_gaps(), 1)
         self.assertEqual(self.RNA("---CGAUgCAU---ACGHc---ACGUCAGU---").count_gaps(), 12)
 
-    def test_count_degenerate(self):
+    def test_count_degenerate(self):  # ported
         """Sequence count_degenerate should return correct degen base count"""
         self.assertEqual(self.RNA("").count_degenerate(), 0)
         self.assertEqual(self.RNA("GACUGCAUGCAUCGUACGUCAGUACCGA").count_degenerate(), 0)
@@ -410,7 +412,7 @@ class SequenceTests(TestCase):
             self.RNA("ACGUAVCUAGCAUNUCAGUCAGyUACGUCAGS").count_degenerate(), 4
         )
 
-    def test_possibilites(self):
+    def test_possibilites(self):  # ported
         """Sequence possibilities should return correct # possible sequences"""
         self.assertEqual(self.RNA("").possibilities(), 1)
         self.assertEqual(self.RNA("ACGUgcaucagUCGuGCAU").possibilities(), 1)
@@ -422,7 +424,7 @@ class SequenceTests(TestCase):
             self.RNA("AUGCnGUCAg-aurGauc--gauhcgauacgws").possibilities(), 96
         )
 
-    def test_mw(self):
+    def test_mw(self):  # ported
         """Sequence MW should return correct molecular weight"""
         self.assertEqual(self.PROT("").mw(), 0)
         self.assertEqual(self.RNA("").mw(), 0)
@@ -432,7 +434,7 @@ class SequenceTests(TestCase):
         assert_allclose(self.RNA("AAA").mw(), 1001.59)
         assert_allclose(self.RNA("AAACCCA").mw(), 2182.37)
 
-    def test_can_match(self):
+    def test_can_match(self):  # ported
         """Sequence can_match should return True if all positions can match"""
         assert self.RNA("").can_match("")
         assert self.RNA("UCAG").can_match("UCAG")
@@ -445,7 +447,7 @@ class SequenceTests(TestCase):
         assert self.RNA("UCAG").can_match("YYRR")
         assert self.RNA("UCAG").can_match("KMWS")
 
-    def test_can_mismatch(self):
+    def test_can_mismatch(self):  # ported
         """Sequence can_mismatch should return True on any possible mismatch"""
         assert not self.RNA("").can_mismatch("")
         assert self.RNA("N").can_mismatch("N")
@@ -751,7 +753,7 @@ class SequenceTests(TestCase):
         self.assertEqual(dna.strip_degenerate(), raw_no_ambigs)
         self.assertEqual(dna.strip_bad_and_gaps(), raw_ungapped)
 
-    def test_replace(self):
+    def test_replace(self):  # will not port
         """replace should convert oldchars to new returning same class"""
         seq = self.SEQ("ACC--GT")
         got = seq.replace("-", "N")


### PR DESCRIPTION
- add `strip_degenerate`, `strip_bad`, `strip_bad_and_gaps`, `disambiguate` to `Moltype` -- addresses #1932
- add `count_variants`, `count_gaps`, `count_degenerate` to `Moltype` -- addresses #1938
- remove replace from sequences -- fixes #1921 
- port Sequence tests