### PR TITLE
TST: Port Sequence unittest classes

### DIFF
--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -802,6 +802,11 @@ class Sequence:
                 )
         other_seq = str(other)
 
+        if not self.moltype.most_degen_alphabet().is_valid(str(other)):
+            raise new_alphabet.AlphabetError(
+                f"Invalid sequence characters in other for moltype={self.moltype.label}"
+            )
+
         # If two sequences with the same name are being added together the name should not be None
         if type(other) == type(self):
             name = self.name if self.name == other.name else None

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -189,7 +189,7 @@ def test_add_bad():
     mt = new_moltype.DNA
     seq1 = mt.make_seq(seq="AAA")
     with pytest.raises(new_alphabet.AlphabetError):
-        f"{seq1}s8d3j%31 s-']"
+        _ = f"{seq1}s8d3j%31 s-']"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -172,6 +172,7 @@ def test_sequence_strip_degenerate(seq, expect):
     """Sequence strip_degenerate should remove any degenerate bases"""
     seq = new_moltype.RNA.make_seq(seq=seq)
     got = seq.strip_degenerate()
+    assert got == expect
 
 
 def test_add():
@@ -309,9 +310,6 @@ def test_sequence_is_gapped():
     assert new_moltype.RNA.make_seq(seq="CAGU-").is_gapped()
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'count_gaps'"
-)
 def test_sequence_is_gap():
     """Sequence is_gap should return True if char is a valid gap char"""
     r = new_moltype.RNA.make_seq(seq="ACGUCAGUACGUCAGNRCGAUYRNRYRN")
@@ -1642,25 +1640,17 @@ def test_annotate_gff_nested_features(DATA_DIR):
     assert tuple(str(ex.get_slice()) for ex in exons) == exon_seqs
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'coerce_str'"
-)
 def test_to_moltype_dna():
     """to_moltype("dna") ensures conversion from T to U"""
     seq = new_moltype.DNA.make_seq(seq="AAAAGGGGTTT", name="seq1")
     rna = seq.to_moltype("rna")
-
     assert "T" not in rna
 
 
-@pytest.mark.xfail(
-    reason="AttributeError: 'MolType' object has no attribute 'coerce_str'"
-)
 def test_to_moltype_rna():
     """to_moltype("rna") ensures conversion from U to T"""
     seq = new_moltype.RNA.make_seq(seq="AAAAGGGGUUU", name="seq1")
     rna = seq.to_moltype("dna")
-
     assert "U" not in rna
 
 

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -184,12 +184,11 @@ def test_add():
     assert got.moltype == mt
 
 
-@pytest.mark.xfail(reason="No error when adding sequences")
 def test_add_bad():
     mt = new_moltype.DNA
     seq1 = mt.make_seq(seq="AAA")
     with pytest.raises(new_alphabet.AlphabetError):
-        _ = f"{seq1}s8d3j%31 s-']"
+        _ = seq1 + "s8d3j%31 s-']"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -961,7 +961,7 @@ class SequenceTests(TestCase):
 class SequenceSubclassTests(TestCase):
     SequenceClass = Sequence
 
-    def test_DnaSequence(self):
+    def test_DnaSequence(self):  # ported
         """DnaSequence should behave as expected"""
         x = DnaSequence("tcag")
         # note: no longer preserves case
@@ -974,13 +974,13 @@ class SequenceSubclassTests(TestCase):
         self.assertRaises(AlphabetError, x.__add__, "z")
         self.assertEqual(DnaSequence("TTTAc").rc(), "GTAAA")
 
-    def test_get_type(self):
+    def test_get_type(self):  # ported
         """returns moltype label"""
         for moltype in ("text", "dna", "bytes"):
             seq = get_moltype(moltype).make_seq("ARCGT")
             self.assertEqual(seq.get_type(), moltype)
 
-    def test_resolved_ambiguities(self):
+    def test_resolved_ambiguities(self):  # ported
         seq = get_moltype("dna").make_seq("ARC")
         got = seq.resolved_ambiguities()
         self.assertEqual(got, [("A",), ("A", "G"), ("C",)])
@@ -989,7 +989,9 @@ class SequenceSubclassTests(TestCase):
         got = seq.resolved_ambiguities()
         self.assertEqual(got, [("A",), ("G",), ("C",)])
 
-    def test_iter_kmers(self):
+    def test_iter_kmers(
+        self,
+    ):  # ported tests for Generator and empty orig, dupes of test_get_kmers...()
         """correctly yield all k-mers"""
         from typing import Generator
 
@@ -1008,7 +1010,7 @@ class SequenceSubclassTests(TestCase):
         got = list(r.iter_kmers(k=1))
         self.assertEqual(got, [])
 
-    def test_iter_kmers_handles_invalid(self):
+    def test_iter_kmers_handles_invalid(self):  # ported
         """raise exceptions on invalid input to iter_kmers"""
         orig = "TCAGGA"
         r = self.SequenceClass(orig)
@@ -1016,7 +1018,7 @@ class SequenceSubclassTests(TestCase):
             with self.assertRaises(ValueError):
                 _ = list(r.iter_kmers(k))
 
-    def test_get_kmers(self):
+    def test_get_kmers(self):  # not porting, dupes of test_get_kmers..()
         """returns a list of k-mers"""
         orig = "TCAGGA"
         r = self.SequenceClass(orig)
@@ -1028,12 +1030,12 @@ class SequenceSubclassTests(TestCase):
 
 
 # TODO move methods of this class onto the single class that inherits from it!
-class ModelSequenceTests(object):
+class ModelSequenceTests(object):  # ported
     """base class for tests of specific ArraySequence objects."""
 
     SequenceClass = None  # override in derived classes
 
-    def test_to_fasta(self):
+    def test_to_fasta(self):  # ported
         """Sequence to_fasta() should return Fasta-format string"""
         even = "TCAGAT"
         odd = even + "AAA"
@@ -1046,13 +1048,15 @@ class ModelSequenceTests(object):
         # check that changing the linewrap again works
         self.assertEqual(even_dna.to_fasta(block_size=4), ">even\nTCAG\nAT\n")
 
-    def test_to_phylip(self):
+    def test_to_phylip(self):  # ported
         """Sequence to_phylip() should return one-line phylip string"""
         s = self.SequenceClass("ACG", name="xyz")
         self.assertEqual(s.to_phylip(), "xyz" + " " * 27 + "ACG")
 
 
-class DnaSequenceTests(ModelSequenceTests, TestCase):
+class DnaSequenceTests(
+    ModelSequenceTests, TestCase
+):  # not porting: not supporting ArraySeqs
     class SequenceClass(ArrayNucleicAcidSequence):
         alphabet = DNA.alphabets.base
 
@@ -1068,7 +1072,9 @@ class DnaSequenceTests(ModelSequenceTests, TestCase):
         self.assertEqual(str(r), orig)
 
 
-class CodonSequenceTests(SequenceTests, TestCase):
+class CodonSequenceTests(
+    SequenceTests, TestCase
+):  # not porting: not supporting ArraySeqs
     class SequenceClass(ArrayCodonSequence):
         alphabet = DNA.alphabets.base**3
 
@@ -1084,7 +1090,7 @@ class CodonSequenceTests(SequenceTests, TestCase):
         self.assertEqual(str(r), orig)
 
 
-class DnaSequenceGapTests(TestCase):
+class DnaSequenceGapTests(TestCase):  # not porting: not supporting ArraySeqs
     """Tests of gapped DNA sequences."""
 
     class SequenceClass(ArrayNucleicAcidSequence):
@@ -1128,7 +1134,7 @@ class DnaSequenceGapTests(TestCase):
         self.assertEqual(got.name, "blah")
 
 
-class SequenceIntegrationTests(TestCase):
+class SequenceIntegrationTests(TestCase):  # not porting: not supporting ArraySeqs
     """Should be able to convert regular to model sequences, and back"""
 
     def test_regular_to_model(self):
@@ -1180,7 +1186,7 @@ class SequenceIntegrationTests(TestCase):
         self.assertEqual(str(r.to_dna()), "TTTCGT")
 
 
-class ModelSequenceTests(SequenceTests):
+class ModelSequenceTests(SequenceTests):  # not porting: not supporting ArraySeqs
     """Tests of the ArraySequence class's inheritance of SequenceI."""
 
     SEQ = ArraySequence


### PR DESCRIPTION
- 3 new xfails
- 3 xpasses removed
- @KatherineCaley could you check if any old ArraySeq-related tests in the following classes should be ported? If not, I think it's the last of the Sequence tests!
    - DnaSequenceTests
    - CodonSequenceTests
    - DnaSequenceGapTests
    - SequenceIntegrationTests
    - ModelSequenceSequenceTests

