### PR TITLE
DEV: preps and documentation of new_type 

### DIFF
--- a/changelog.d/20240716_142129_u6096186_seq_collections_refactor.md
+++ b/changelog.d/20240716_142129_u6096186_seq_collections_refactor.md
@@ -11,7 +11,16 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### ENH
 
-- Introduced alpha versions of the new implementations of core objects: `Sequence`, `SequenceCollection`, `MolType`, `GeneticCode`, and `Alphabet`. These "new-style" objects enhance performance by supporting the access of the underlying data in various formats (i.e., numpy arrays, bytes or strings). The "new-style" objects can be accessed by setting the `new_type=True` argument in top-level functions (`make_seq`, `load_seq`, `make_unaligned_seqs`, `get_moltype`, `get_code`). These are not yet the default as they are not fully integrated into the existing code, however, we encourage experimentation in cases where integration with old objects is NOT required and look forward to any feedback!
+- Introduced alpha versions of new implementations of core objects: `Sequence`,
+  `SequenceCollection`, `MolType`, `GeneticCode`, and `Alphabet`. These
+  "new-style" objects enhance performance by supporting the access of the
+  underlying data in various formats (i.e. numpy arrays, bytes or strings). The
+  "new-style" objects can be accessed by setting the `new_type=True` argument
+  in top-level functions (`make_seq`, `load_seq`, `make_unaligned_seqs`,
+  `get_moltype`, `get_code`). These are not yet the default and are not fully
+  integrated into the existing code, however, we encourage experimentation in
+  cases where integration with old objects is NOT required and look forward to
+  any feedback!
 
 <!--
 ### BUG

--- a/changelog.d/20240716_142129_u6096186_seq_collections_refactor.md
+++ b/changelog.d/20240716_142129_u6096186_seq_collections_refactor.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+
+### Contributors
+
+- katherine caley (@KatherineCaley) 
+- fred jaya (@fredjaya) 
+- gavin huttley (@GavinHuttley)
+
+
+### ENH
+
+- Introduced alpha versions of the new implementations of core objects: `Sequence`, `SequenceCollection`, `MolType`, `GeneticCode`, and `Alphabet`. These "new-style" objects enhance performance by supporting the access of the underlying data in various formats (i.e., numpy arrays, bytes or strings). The "new-style" objects can be accessed by setting the `new_type=True` argument in top-level functions (`make_seq`, `load_seq`, `make_unaligned_seqs`, `get_moltype`, `get_code`). These are not yet the default as they are not fully integrated into the existing code, however, we encourage experimentation in cases where integration with old objects is NOT required and look forward to any feedback!
+
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/changelog.d/20240716_142129_u6096186_seq_collections_refactor.md
+++ b/changelog.d/20240716_142129_u6096186_seq_collections_refactor.md
@@ -3,14 +3,11 @@ A new scriv changelog fragment.
 
 Uncomment the section that is right (remove the HTML comment wrapper).
 -->
-
-
 ### Contributors
 
-- katherine caley (@KatherineCaley) 
-- fred jaya (@fredjaya) 
+- katherine caley (@KatherineCaley)
+- fred jaya (@fredjaya)
 - gavin huttley (@GavinHuttley)
-
 
 ### ENH
 

--- a/doc/cookbook/alignments.rst
+++ b/doc/cookbook/alignments.rst
@@ -12,7 +12,7 @@ Sequence Collections and Alignments
 
    We are pleased to announce an alpha release of our new ``SequenceCollection`` API. This version can be accessed by specifying the argument ``new_type=True`` in the ``load_unaligned_seqs()`` or ``make_unaligned_seqs()`` functions. The new API is designed for increased efficiency, offering access to the underlying data in multiple formats, including numpy arrays, strings, and bytes (via ``array(seqs)``, ``str(seqs)`` and ``bytes(seqs)`` respectively). 
 
-   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+   Please be aware that this alpha release has not been fully integrated with the library. Users are encouraged to explore its capabilities but should proceed with caution!
 
 For loading collections of unaligned or aligned sequences see :ref:`load-seqs`.
 

--- a/doc/cookbook/alignments.rst
+++ b/doc/cookbook/alignments.rst
@@ -8,6 +8,12 @@ Sequence Collections and Alignments
 
 .. authors, Gavin Huttley, Kristian Rother, Patrick Yannul, Tom Elliott, Jan Kosinski
 
+.. note:: **Alpha Release of the New SequenceCollection API**
+
+   We are pleased to announce an alpha release of our new ``SequenceCollection`` API. This version can be accessed by specifying the argument ``new_type=True`` in the ``load_unaligned_seqs()`` or ``make_unaligned_seqs()`` functions. The new API is designed for increased efficiency, offering access to the underlying data in multiple formats, including numpy arrays, strings, and bytes (via ``array(seqs)``, ``str(seqs)`` and ``bytes(seqs)`` respectively). 
+
+   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+
 For loading collections of unaligned or aligned sequences see :ref:`load-seqs`.
 
 What's the difference between ``Alignment`` and ``ArrayAlignment``?

--- a/doc/cookbook/genetic_code.rst
+++ b/doc/cookbook/genetic_code.rst
@@ -7,7 +7,7 @@ Using genetic codes
 
    We are pleased to announce an alpha release of our new ``GeneticCode`` API. This version can be accessed by specifying the argument ``new_type=True`` in the ``get_code()`` function. 
    
-   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+   Please be aware that this alpha release has not been fully integrated with the library. Users are encouraged to explore its capabilities but should proceed with caution!
 
 Selecting codes in methods that support them
 """"""""""""""""""""""""""""""""""""""""""""

--- a/doc/cookbook/genetic_code.rst
+++ b/doc/cookbook/genetic_code.rst
@@ -3,6 +3,12 @@
 Using genetic codes
 ^^^^^^^^^^^^^^^^^^^
 
+.. note:: **Alpha Release of the New GeneticCode API**
+
+   We are pleased to announce an alpha release of our new ``GeneticCode`` API. This version can be accessed by specifying the argument ``new_type=True`` in the ``get_code()`` function. 
+   
+   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+
 Selecting codes in methods that support them
 """"""""""""""""""""""""""""""""""""""""""""
 

--- a/doc/cookbook/loading_sequences.rst
+++ b/doc/cookbook/loading_sequences.rst
@@ -12,7 +12,7 @@ Loading a sequence from a file
 
    We are pleased to announce an alpha release of our new ``Sequence`` API! This version can be accessed by specifying the argument ``new_type=True`` in the ``load_seq()`` or ``make_seq()`` functions. The new API is designed for increased efficiency, offering access to the underlying data in multiple formats, including numpy arrays, strings, and bytes (via ``array(seq)``, ``str(seq)`` and ``bytes(seq)`` respectively). 
 
-   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+   Please be aware that this alpha release has not been fully integrated with the library. Users are encouraged to explore its capabilities but should proceed with caution!
 
 It's also possible to load a sequence from a :ref:`url <load_url>`.
 

--- a/doc/cookbook/loading_sequences.rst
+++ b/doc/cookbook/loading_sequences.rst
@@ -8,6 +8,12 @@
 Loading a sequence from a file
 ------------------------------
 
+.. note:: **Alpha Release of the New Sequence API**
+
+   We are pleased to announce an alpha release of our new ``Sequence`` API! This version can be accessed by specifying the argument ``new_type=True`` in the ``load_seq()`` or ``make_seq()`` functions. The new API is designed for increased efficiency, offering access to the underlying data in multiple formats, including numpy arrays, strings, and bytes (via ``array(seq)``, ``str(seq)`` and ``bytes(seq)`` respectively). 
+
+   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+
 It's also possible to load a sequence from a :ref:`url <load_url>`.
 
 .. jupyter-execute::

--- a/doc/cookbook/moltypes.rst
+++ b/doc/cookbook/moltypes.rst
@@ -7,6 +7,12 @@
 Molecular types
 ***************
 
+.. note:: **Alpha Release of the New MolType API**
+
+   We are pleased to announce an alpha release of our new ``MolType`` API. This version can be accessed by specifying the argument ``new_type=True`` in the ``get_moltype()`` function. 
+   
+   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+
 The ``MolType`` object provides services for resolving ambiguities, or providing the correct ambiguity for recoding. It also maintains the mappings between different kinds of alphabets, sequences and alignments.
 
 If your analysis involves handling ambiguous states, or translation via a genetic code, it's critical to specify the appropriate moltype.

--- a/doc/cookbook/moltypes.rst
+++ b/doc/cookbook/moltypes.rst
@@ -10,8 +10,8 @@ Molecular types
 .. note:: **Alpha Release of the New MolType API**
 
    We are pleased to announce an alpha release of our new ``MolType`` API. This version can be accessed by specifying the argument ``new_type=True`` in the ``get_moltype()`` function. 
-   
-   Please be aware that this alpha release has not been fully integrated with the entire library. Users are encouraged to explore its capabilities but should proceed with caution!
+
+   Please be aware that this alpha release has not been fully integrated with the library. Users are encouraged to explore its capabilities but should proceed with caution!
 
 The ``MolType`` object provides services for resolving ambiguities, or providing the correct ambiguity for recoding. It also maintains the mappings between different kinds of alphabets, sequences and alignments.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,8 @@ exclude = ["doc/*.html"]
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "internet: marks tests that require internet access  (deselect with '-m \"not internet\"')"
+    "internet: marks tests that require internet access  (deselect with '-m \"not internet\"')",
+    "discontinued: mark tests as discontinued (deselect with '-m \"not discontinued\"')",
     ]
 testpaths = "tests"
 addopts = ["--strict-config"]

--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple
 
-from cogent3 import get_app, get_model
+from cogent3 import get_app, get_model, make_unaligned_seqs
 from cogent3.core.alignment import ArrayAlignment, SequenceCollection
 from cogent3.core.tree import TreeNode
 from cogent3.evolve.distance import EstimateDistances
@@ -69,10 +69,10 @@ def tree_align(
 
     num_states = len(model.alphabet)
 
-    if isinstance(seqs, SequenceCollection):
-        seqs = seqs.to_moltype(moltype)
+    if isinstance(seqs, dict):
+        seqs = make_unaligned_seqs(seqs, moltype=moltype)
     else:
-        seqs = SequenceCollection(data=seqs, moltype=moltype)
+        seqs = seqs.to_moltype(moltype)
 
     if tree is not None:
         fix_lengths = get_app("scale_branches", scalar=1.0)

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -524,7 +524,7 @@ for key, value in list(GeneticCodes.items()):
 DEFAULT = GeneticCodes[1]
 
 
-def get_code(code_id=1, new_type=False):
+def get_code(code_id: int = 1, new_type: bool = False):
     """returns the genetic code
 
     Parameters

--- a/src/cogent3/core/new_alphabet.py
+++ b/src/cogent3/core/new_alphabet.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 import numba
 import numpy
 
+from cogent3.util import warning as c3warn
 from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.misc import get_object_provenance
 
@@ -301,6 +302,15 @@ class CharAlphabet(tuple, AlphabetABC, MonomerAlphabetABC):
         # this is enforced by consistent_words(length=1) in the constructor
         return 1
 
+    @c3warn.deprecated_callable(
+        version="2025.6",
+        reason="Replaced by .motif_len",
+        is_discontinued=True,
+    )
+    def get_motif_len(self) -> int:
+        # added to maintain compatibility with the old API
+        return self.motif_len
+
     @functools.singledispatchmethod
     def to_indices(self, seq: StrORBytesORArray) -> numpy.ndarray:
         raise TypeError(f"{type(seq)} is invalid")
@@ -427,6 +437,14 @@ class CharAlphabet(tuple, AlphabetABC, MonomerAlphabetABC):
     def from_rich_dict(cls, data: dict) -> "CharAlphabet":
         """returns an instance from a serialised dictionary"""
         return cls(data["chars"], gap=data["gap"], missing=data["missing"])
+
+    @c3warn.deprecated_callable(
+        version="2025.6",
+        reason="Replaced by get_kmer_alphabet",
+        is_discontinued=True,
+    )
+    def get_word_alphabet(self, k: int, include_gap: bool = True) -> "KmerAlphabet":
+        return self.get_kmer_alphabet(k, include_gap=include_gap)
 
 
 @register_deserialiser(get_object_provenance(CharAlphabet))

--- a/src/cogent3/core/new_genetic_code.py
+++ b/src/cogent3/core/new_genetic_code.py
@@ -469,6 +469,12 @@ def get_code(code_id: StrORInt = 1) -> GeneticCode:
         genetic code identifier, name, number or string(number), defaults to
         standard genetic code
     """
+    # refactor: hack
+    # added for compatibility with previous API, should be removed when
+    # support for old style is dropped
+    if code_id is None:
+        code_id = 1
+
     with contextlib.suppress((ValueError, TypeError)):
         code_id = int(code_id)
 

--- a/src/cogent3/core/new_genetic_code.py
+++ b/src/cogent3/core/new_genetic_code.py
@@ -469,7 +469,7 @@ def get_code(code_id: StrORInt = 1) -> GeneticCode:
         genetic code identifier, name, number or string(number), defaults to
         standard genetic code
     """
-    # refactor: hack
+    # refactor: simplify
     # added for compatibility with previous API, should be removed when
     # support for old style is dropped
     if code_id is None:

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -543,9 +543,12 @@ class MolType:
 
         return any(alpha == alphabet for alpha in self.iter_alphabets())
 
-    def make_seq(
-        self, *, seq: str, name: OptStr = None, check_seq=True, **kwargs
-    ):  # refactor: docstring
+    def make_seq(self, *, seq: str, name: OptStr = None, check_seq=True, **kwargs):
+        # refactor: docstring
+        # refactor: design
+        # for Sequence and SeqView object, a consistency check with moltype/alphabet
+        # should be performed
+
         if check_seq:
             assert self.is_valid(
                 seq
@@ -1137,6 +1140,11 @@ def get_moltype(name: typing.Union[str, MolType]) -> MolType:
     """returns the moltype with the matching name attribute"""
     if isinstance(name, MolType):
         return name
+    # refactor: simplify
+    # intoduced to check whether we have a old-style moltype object,
+    # remove when support for the old-style moltype objects is removed
+    if hasattr(name, "label"):
+        name = name.label
     name = name.lower()
     if name not in _moltypes:
         raise ValueError(f"unknown moltype {name!r}")

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -72,6 +72,7 @@ from cogent3.util.transform import for_seq, per_shortest
 
 
 ARRAY_TYPE = type(array(1))
+DEFAULT_ANNOTATION_DB = BasicAnnotationDb
 
 # standard distance functions: left  because generally useful
 frac_same = for_seq(f=eq, aggregator=sum, normalizer=per_shortest)
@@ -837,7 +838,7 @@ class Sequence(SequenceI):
         self.info = info
 
         self._repr_policy = dict(num_pos=60)
-        self._annotation_db = BasicAnnotationDb()
+        self._annotation_db = DEFAULT_ANNOTATION_DB()
         self.annotation_offset = annotation_offset
 
     @property

--- a/src/cogent3/draw/dotplot.py
+++ b/src/cogent3/draw/dotplot.py
@@ -59,7 +59,7 @@ def _convert_input(seq, moltype):
     seq = (
         moltype.make_seq(seq=str(seq), name=seq.name)
         if hasattr(seq, "moltype")
-        else moltype.make_seq(seq)
+        else moltype.make_seq(seq=seq)
     )
 
     gap_map, seq = seq.parse_out_gaps()

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -54,7 +54,13 @@ def get_moltype_index_array(moltype, invalid=-9):
     canonical_chars = list(moltype)
     # maximum ordinal for an allowed character, this defines the length of
     # the required numpy array
-    max_ord = max(list(map(ord, list(moltype.All.keys()))))
+    # refactor: hack
+    from cogent3.core.new_moltype import MolType as new_MolType
+
+    if isinstance(moltype, new_MolType):
+        max_ord = max(list(map(ord, list(moltype.most_degen_alphabet()))))
+    else:
+        max_ord = max(list(map(ord, list(moltype.All.keys()))))
     char_to_index = zeros(max_ord + 1, int32)
     # all non canonical_chars are ``invalid''
     char_to_index.fill(invalid)

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -54,7 +54,9 @@ def get_moltype_index_array(moltype, invalid=-9):
     canonical_chars = list(moltype)
     # maximum ordinal for an allowed character, this defines the length of
     # the required numpy array
-    # refactor: hack
+    # refactor: simplify
+    # added for compatibility with both new and old moltypes - should be removed
+    # when old moltype is removed
     from cogent3.core.new_moltype import MolType as new_MolType
 
     if isinstance(moltype, new_MolType):

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -237,7 +237,9 @@ def make_likelihood_tree_leaf(sequence, alphabet, seq_name):
 
     counts = numpy.array(counts, float)
 
-    # refactor: hack
+    # refactor: simplify
+    # added for compatibility between old and new style sequences/moltype/alphabets
+    # should be simplified when old style is removed
     from cogent3.core.alphabet import Alphabet, CharAlphabet
     from cogent3.core.new_sequence import Sequence
 

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -3,6 +3,9 @@ Each leaf holds a sequence.  Used by a likelihood function."""
 
 import numpy
 
+from cogent3.core.alphabet import AlphabetError
+from cogent3.core.new_alphabet import AlphabetError as new_AlphabetError
+
 from . import likelihood_tree_numba as likelihood_tree
 
 
@@ -234,12 +237,30 @@ def make_likelihood_tree_leaf(sequence, alphabet, seq_name):
 
     counts = numpy.array(counts, float)
 
+    # refactor: hack
+    from cogent3.core.alphabet import Alphabet, CharAlphabet
+    from cogent3.core.new_sequence import Sequence
+
+    if isinstance(sequence, Sequence):
+        # we can rely on getting the moltype from the sequence
+        moltype = sequence.moltype
+    elif isinstance(alphabet, (CharAlphabet, Alphabet)):
+        # we can rely on getting the moltype from the alphabet
+        moltype = alphabet.moltype
+    else:
+        # the combination of new old style sequence and new alphabet
+        # means we cannot reliably source the moltype.
+        try:
+            moltype = sequence.moltype
+        except AttributeError as e:
+            raise ValueError(
+                "Cannot determine moltype from sequence or alphabet"
+            ) from e
+
     # Convert list of unique motifs to array of unique profiles
     try:
-        likelihoods = get_matched_array(
-            alphabet, alphabet.moltype, uniq_motifs, dtype=float
-        )
-    except alphabet.AlphabetError as detail:
+        likelihoods = get_matched_array(alphabet, moltype, uniq_motifs, dtype=float)
+    except (AlphabetError, new_AlphabetError) as detail:
         motif = str(detail)
         posn = list(sequence2).index(motif) * motif_len
         raise ValueError(

--- a/src/cogent3/evolve/parameter_controller.py
+++ b/src/cogent3/evolve/parameter_controller.py
@@ -568,11 +568,18 @@ class SequenceLikelihoodFunction(_LikelihoodParameterController):
 
     def set_sequences(self, seqs, locus=None):
         from cogent3.core.alignment import SequenceCollection
+        from cogent3.core.new_alignment import (
+            SequenceCollection as new_SequenceCollection,
+        )
 
         leaves = {}
 
+        # refactor: simplify
+        # can be simplified once we drop support for old sequence objects
         if isinstance(seqs, SequenceCollection):
             seqs = seqs.named_seqs
+        if isinstance(seqs, new_SequenceCollection):
+            seqs = {name: seqs.seqs[name] for name in seqs.names}
 
         for name, seq in list(seqs.items()):
             # if has uniq, probably already a likelihood tree leaf obj already

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -644,7 +644,7 @@ def RichGenbankParser(
         info = Info(genbank_record=info)
         try:
             seq = rec_moltype.make_seq(
-                rec["sequence"].upper(), info=info, name=rec["locus"]
+                seq=rec["sequence"].upper(), info=info, name=rec["locus"]
             )
         except KeyError:
             if "contig" in rec:

--- a/tests/benchmark_aligning.py
+++ b/tests/benchmark_aligning.py
@@ -15,8 +15,8 @@ def _s2i(s):
 def test(r=1, **kw):
     S = make_dna_scoring_dict(10, -1, -8)
 
-    seq2 = DNA.make_seq("AAAATGCTTA" * r)
-    seq1 = DNA.make_seq("AATTTTGCTG" * r)
+    seq2 = DNA.make_seq(seq="AAAATGCTTA" * r)
+    seq1 = DNA.make_seq(seq="AATTTTGCTG" * r)
 
     t0 = time.clock()
     try:

--- a/tests/test_align/test_compare.py
+++ b/tests/test_align/test_compare.py
@@ -51,8 +51,8 @@ def smallseq():
 
 
 def test_find_matched_k_eq_1():
-    s1 = make_seq("TGATGTAAGGTAGTT", name="1")
-    s2 = make_seq("CTGGAAGGGT", name="2")
+    s1 = make_seq(seq="TGATGTAAGGTAGTT", name="1")
+    s2 = make_seq(seq="CTGGAAGGGT", name="2")
     expect = _brute_force(s1, s2, window=5, threshold=3)
     sk = SeqKmers(s1, k=1, canonical=set("ACGT"))
     got = find_matched_paths(seq_kmers=sk, seq1=s1, seq2=s2, window=5, threshold=3)
@@ -129,7 +129,7 @@ def test_segment_adjacent():
 
 def test_segment_rc():
     """should correctly transform for reverse complemented sequence"""
-    seq = make_seq("AACCCTTTTT", moltype="dna")
+    seq = make_seq(seq="AACCCTTTTT", moltype="dna")
     c = segment(2, 5)
     assert seq[c.start : c.end] == "CCC"
     r = c.for_rc(len(seq))
@@ -144,7 +144,7 @@ def test_get_segments():
 
 
 def test_kmer_one(smallseq):
-    seq = make_seq(smallseq, name="seq1")
+    seq = make_seq(seq=smallseq, name="seq1")
     kmers = {Kmer(e, seq.name, i) for i, e in enumerate(seq.iter_kmers(k=2))}
     assert kmers == {smallseq[i : i + 2] for i in range(len(smallseq) - 1)}
 
@@ -171,7 +171,7 @@ def test_kmer_one(smallseq):
 
 
 def test_seqkmers_1seq(smallseq):
-    seq1 = make_seq(smallseq, name="seq1", moltype="dna")
+    seq1 = make_seq(seq=smallseq, name="seq1", moltype="dna")
     sk = SeqKmers(seq1, 1, canonical=set(seq1.moltype))
     assert sk.num_seqs == 1
     # iter k-mers skips single occurrence in seq1
@@ -182,7 +182,7 @@ def test_seqkmers_1seq(smallseq):
 @pytest.mark.parametrize("k,expect", [(1, 3), (2, 5), (7, 0)])
 def test_seqkmers_1seq_degenerate(k, expect):
     # k-mers with degenerate characters are not stored
-    seq1 = make_seq("NCCGGTT", name="seq1", moltype="dna")
+    seq1 = make_seq(seq="NCCGGTT", name="seq1", moltype="dna")
     sk = SeqKmers(seq1, k, canonical=set(seq1.moltype))
     assert len(sk.kmers) == expect
     assert "N" not in sk.kmers
@@ -191,8 +191,8 @@ def test_seqkmers_1seq_degenerate(k, expect):
 
 
 def test_seqkmers_2seqs(smallseq):
-    seq1 = make_seq(smallseq, name="seq1", moltype="dna")
-    seq2 = make_seq(smallseq[1:], name="seq2", moltype="dna")
+    seq1 = make_seq(seq=smallseq, name="seq1", moltype="dna")
+    seq2 = make_seq(seq=smallseq[1:], name="seq2", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set(seq1.moltype))
     sk.add_seq(seq2)
     # the k-mer indices for "AC" should not have an entry for seq2, but should
@@ -207,7 +207,7 @@ def test_seqkmers_2seqs(smallseq):
 def test_seqkmers_1seq_iter_matched_indices():
     from itertools import product
 
-    seq1 = make_seq("", name="seq1", moltype="dna")
+    seq1 = make_seq(seq="", name="seq1", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set("ACGT"))
     kmer = Kmer("AA", "seq1", 0)
     kmer.add_location("seq1", 1)
@@ -224,7 +224,7 @@ def test_seqkmers_1seq_iter_matched_indices():
 def test_seqkmers_2seq_iter_matched_indices():
     from itertools import product
 
-    seq1 = make_seq("", name="seq1", moltype="dna")
+    seq1 = make_seq(seq="", name="seq1", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set("ACGT"))
     sk.num_seqs += 1
     sk.other_name = "seq2"
@@ -240,8 +240,8 @@ def test_seqkmers_2seq_iter_matched_indices():
 
 
 def test_seqkmers_2seqs_dropseq(smallseq):
-    seq1 = make_seq(smallseq, name="seq1", moltype="dna")
-    seq2 = make_seq(smallseq[1:], name="seq2", moltype="dna")
+    seq1 = make_seq(seq=smallseq, name="seq1", moltype="dna")
+    seq2 = make_seq(seq=smallseq[1:], name="seq2", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set(seq1.moltype))
     sk.add_seq(seq2)
     assert sk.ref_name == seq1.name
@@ -255,8 +255,8 @@ def test_seqkmers_2seqs_dropseq(smallseq):
 
 
 def test_dropseq_default(smallseq):
-    seq1 = make_seq(smallseq, name="seq1", moltype="dna")
-    seq2 = make_seq(smallseq[1:], name="seq2", moltype="dna")
+    seq1 = make_seq(seq=smallseq, name="seq1", moltype="dna")
+    seq2 = make_seq(seq=smallseq[1:], name="seq2", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set(seq1.moltype))
     sk.add_seq(seq2)
     sk.drop_seq()
@@ -264,7 +264,7 @@ def test_dropseq_default(smallseq):
 
 
 def test_one_seq_dropseq(smallseq):
-    seq1 = make_seq(smallseq, name="seq1", moltype="dna")
+    seq1 = make_seq(seq=smallseq, name="seq1", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set(seq1.moltype))
     assert sk.other_name is None
     assert sk.num_seqs == 1
@@ -274,8 +274,8 @@ def test_one_seq_dropseq(smallseq):
 
 
 def test_seqkmers_iter_matching_kmers(smallseq):
-    seq1 = make_seq(smallseq, name="seq1", moltype="dna")
-    seq2 = make_seq(smallseq[1:], name="seq2", moltype="dna")
+    seq1 = make_seq(seq=smallseq, name="seq1", moltype="dna")
+    seq2 = make_seq(seq=smallseq[1:], name="seq2", moltype="dna")
     sk = SeqKmers(seq1, 2, canonical=set(seq1.moltype))
     sk.add_seq(seq2)
     for kmer in sk.iter_matching_kmers():
@@ -295,12 +295,12 @@ def test_matchedpaths():
 
 @pytest.fixture
 def aseq1():
-    return make_seq("ATACGT", name="seq1", moltype="dna")
+    return make_seq(seq="ATACGT", name="seq1", moltype="dna")
 
 
 @pytest.fixture
 def aseq2():
-    return make_seq("AGTTTACGTTTGACGTAA", name="seq2", moltype="dna")
+    return make_seq(seq="AGTTTACGTTTGACGTAA", name="seq2", moltype="dna")
 
 
 def test_bruteforce(aseq1, aseq2):
@@ -375,7 +375,7 @@ def test_find_matched_paths_moltype(aseq1, aseq2, moltype):
 
 
 def test_find_matched_with_rc():
-    s = make_seq("CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
+    s = make_seq(seq="CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
     r = s.rc()
     r.name = "rc1"
     k = _calc_seed_size(4, 4)
@@ -391,8 +391,8 @@ def test_find_matched_with_rc():
 
 
 def test_find_matched_with_small_seed():
-    s1 = make_seq("CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
-    s2 = make_seq("GGTCTATCCGACTGCAGTGGTGTG", moltype="dna", name="s2")
+    s1 = make_seq(seq="CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
+    s2 = make_seq(seq="GGTCTATCCGACTGCAGTGGTGTG", moltype="dna", name="s2")
     k = 2
     expect = _brute_force(s1, s2, 4, 4)
     sk = SeqKmers(s1, k=k, canonical="ACGT")
@@ -402,7 +402,7 @@ def test_find_matched_with_small_seed():
 
 @pytest.mark.parametrize("w,t", [(4, 4), (3, 3)])
 def test_find_matched_1seq(w, t):
-    s = make_seq("CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
+    s = make_seq(seq="CACACCACTGCAGTCGGATAGACC", moltype="dna", name="s1")
     expect = _brute_force(s, s, w, t)
     sk = SeqKmers(s, k=w, canonical=set("ACGT"))
     got = find_matched_paths(seq_kmers=sk, seq1=s, window=w, threshold=t)

--- a/tests/test_app/test_align.py
+++ b/tests/test_app/test_align.py
@@ -86,7 +86,7 @@ def make_pairwise(data, refseq_name, moltype="dna", array_align=False):
 
 
 def make_aligned(gaps_lengths, seq, name="seq1"):
-    seq = seq.moltype.make_seq(seq, name=name)
+    seq = seq.moltype.make_seq(seq=seq, name=name)
     return Aligned(gap_coords_to_map(gaps_lengths, len(seq)), seq)
 
 
@@ -155,7 +155,7 @@ class RefalignmentTests(TestCase):
     def test_gap_union(self):
         """correctly identifies the union of all gaps"""
         # fails if not all sequences same
-        seq = DNA.make_seq("AACCCGTT")
+        seq = DNA.make_seq(seq="AACCCGTT")
         all_gaps = dict([(0, 3), (2, 1), (5, 3), (6, 3)])
         make_aligned(all_gaps, seq)
         gap_sets = [
@@ -178,7 +178,7 @@ class RefalignmentTests(TestCase):
 
     def test_gap_difference(self):
         """correctly identifies the difference in gaps"""
-        seq = DNA.make_seq("AACCCGTT")
+        seq = DNA.make_seq(seq="AACCCGTT")
         dict([(0, 3), (2, 1), (5, 3), (6, 3)])
         gap_sets = [
             dict([(5, 1), (6, 3)]),
@@ -563,7 +563,7 @@ def test_sp_score_exclude_gap():
     data = {"s1": "AAGAA-A", "s2": "-ATAATG", "s3": "C-TGG-G"}
     # prop unchanged s1-s2, s1-s3
     expect = sum([6 * 3 / 6, 0, 5 * 2 / 5])
-    aln = make_aligned_seqs(data, moltype="dna")
+    aln = make_aligned_seqs(data, moltype="dna", array_align=False)
     got = app.main(aln)
     assert_allclose(got, expect)
 

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -534,7 +534,7 @@ def test_get_data_source_seqcoll(klass):
 
     value = klass("some/path.txt")
     obj = make_unaligned_seqs(
-        data=dict(seq1="ACGG"), info=dict(source=value, random_key=1234)
+        data=dict(seq1="ACGG"), moltype="dna", info=dict(source=value, random_key=1234)
     )
     got = get_data_source(obj)
     assert got == "path.txt"

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -12,7 +12,7 @@ import pytest
 
 from numpy.testing import assert_allclose
 
-from cogent3 import DNA, get_app, open_data_store
+from cogent3 import get_app, get_moltype, open_data_store
 from cogent3.app import io as io_app
 from cogent3.app.composable import NotCompleted, source_proxy
 from cogent3.app.data_store import (
@@ -29,6 +29,9 @@ from cogent3.maths.util import safe_log
 from cogent3.parse.sequence import PARSERS
 from cogent3.util.deserialise import deserialise_object
 from cogent3.util.table import Table
+
+
+DNA = get_moltype("dna")
 
 
 @pytest.fixture(scope="function")
@@ -431,7 +434,7 @@ def test_pickled_compress_roundtrip(data):
     deserialised = io_app.decompress() + io_app.unpickle_it() + io_app.from_primitive()
     s = serialised(data)
     d = deserialised(s)
-    assert d == data
+    assert d.label == data.label
 
 
 # todo test objects where there is no unique_id provided, or inferrable,
@@ -528,7 +531,9 @@ def seqs():
     from cogent3 import make_unaligned_seqs
 
     return make_unaligned_seqs(
-        data=dict(a="ACGG", b="GGC"), info=dict(source="dummy/blah.1.2.fa")
+        data=dict(a="ACGG", b="GGC"),
+        moltype="dna",
+        info=dict(source="dummy/blah.1.2.fa"),
     )
 
 

--- a/tests/test_app/test_translate.py
+++ b/tests/test_app/test_translate.py
@@ -18,7 +18,7 @@ class TestTranslatable(TestCase):
     def test_best_frame(self):
         """correctly identify best frame with/without allowing rc"""
         make_seq = DNA.make_seq
-        seq = make_seq("ATGCTAACATAAA", name="fake1")
+        seq = make_seq(seq="ATGCTAACATAAA", name="fake1")
         f = best_frame(seq)
         self.assertEqual(f, 1)
         f = best_frame(seq, require_stop=True)
@@ -26,14 +26,15 @@ class TestTranslatable(TestCase):
 
         # a challenging seq, translatable in 1 and 3 frames, ending on stop in
         # frame 1. Should return frame 1 irrespective of require_stop
-        seq = make_seq("ATGTTACGGACGATGCTGAAGTCGAAGATCCACCGCGCCACGGTGACCTGCTGA")
+        seq = make_seq(seq="ATGTTACGGACGATGCTGAAGTCGAAGATCCACCGCGCCACGGTGACCTGCTGA")
         f = best_frame(seq)
         self.assertEqual(f, 1)
 
         # a rc seq
         f = best_frame(seq)
         seq = make_seq(
-            "AATATAAATGCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTTCATAAAGTCATA", name="fake2"
+            seq="AATATAAATGCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTTCATAAAGTCATA",
+            name="fake2",
         )
         f = best_frame(seq, allow_rc=True)
         self.assertEqual(f, 1)
@@ -70,7 +71,7 @@ class TestTranslatable(TestCase):
 
     def test_translate_frames(self):
         """returns translated sequences"""
-        seq = DNA.make_seq("ATGCTGACATAAA", name="fake1")
+        seq = DNA.make_seq(seq="ATGCTGACATAAA", name="fake1")
         tr = translate_frames(seq)
         self.assertEqual(tr, ["MLT*", "C*HK", "ADI"])
         # with the bacterial nuclear and plant plastid code
@@ -82,7 +83,7 @@ class TestTranslate(TestCase):
     def test_translate_seqcoll(self):
         """correctly translate a sequence collection"""
         seqs = dict(a="ATGAGG", b="ATGTAA")
-        seqs = make_unaligned_seqs(seqs)
+        seqs = make_unaligned_seqs(seqs, moltype="dna")
         # trim terminal stops
         translater = translate_seqs()
         aa = translater(seqs)

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -47,9 +47,6 @@ from cogent3.parse.fasta import MinimalFastaParser
 from cogent3.util.misc import get_object_provenance
 
 
-# refactor: hack
-# use get_moltype for all moltype instances to ensure new_type is set correctly
-# if we are relying on an enviroment variable.
 DNA = get_moltype("dna")
 RNA = get_moltype("rna")
 PROTEIN = get_moltype("protein")
@@ -2156,10 +2153,10 @@ def test_seqcoll_query(seqcoll_db):
 
 
 def test_align_get_features():
-    #                0123456789   the positions
+    #                    0123456789   the positions
     seq1 = make_seq(seq="ACG--ACCGT", moltype="dna", name="seq1")
     seq2 = make_seq(seq="ACGGGCCCGT", moltype="dna", name="seq2")
-    #                  *****      the CDS feature
+    #                      *****      the CDS feature
     seq2.add_feature(biotype="CDS", name="fake01", spans=[(2, 7)], strand="+")
     aln = make_aligned_seqs(data=[seq1, seq2], array_align=False)
     feat = list(aln.get_features(biotype="CDS"))[0]

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -40,11 +40,21 @@ from cogent3.core.alignment import (
 )
 from cogent3.core.alphabet import AlphabetError
 from cogent3.core.annotation_db import GffAnnotationDb
-from cogent3.core.moltype import AB, ASCII, BYTES, DNA, PROTEIN, RNA
-from cogent3.core.sequence import ArraySequence, RnaSequence, Sequence, SeqView
+from cogent3.core.moltype import AB
+from cogent3.core.sequence import ArraySequence, Sequence, SeqView
 from cogent3.maths.util import safe_p_log_p
 from cogent3.parse.fasta import MinimalFastaParser
 from cogent3.util.misc import get_object_provenance
+
+
+# refactor: hack
+# use get_moltype for all moltype instances to ensure new_type is set correctly
+# if we are relying on an enviroment variable.
+DNA = get_moltype("dna")
+RNA = get_moltype("rna")
+PROTEIN = get_moltype("protein")
+ASCII = get_moltype("text")
+BYTES = get_moltype("bytes")
 
 
 class SequenceCollectionBaseTests(object):
@@ -72,9 +82,9 @@ class SequenceCollectionBaseTests(object):
         self.gaps = self.Class({"a": "AAAAAAA", "b": "A--A-AA", "c": "AA-----"})
         self.gaps_rna = self.Class(
             {
-                "a": RnaSequence("AAAAAAA"),
-                "b": RnaSequence("A--A-AA"),
-                "c": RnaSequence("AA-----"),
+                "a": RNA.make_seq(seq="AAAAAAA"),
+                "b": RNA.make_seq(seq="A--A-AA"),
+                "c": RNA.make_seq(seq="AA-----"),
             }
         )
         self.unordered = self.Class({"a": "AAAAA", "b": "BBBBB"})
@@ -86,27 +96,33 @@ class SequenceCollectionBaseTests(object):
         )
         self.many = self.Class(
             {
-                "a": RnaSequence("UCAGUCAGUU"),
-                "b": RnaSequence("UCCGUCAAUU"),
-                "c": RnaSequence("ACCAUCAGUC"),
-                "d": RnaSequence("UCAAUCGGUU"),
-                "e": RnaSequence("UUGGUUGGGU"),
-                "f": RnaSequence("CCGGGCGGCC"),
-                "g": RnaSequence("UCAACCGGAA"),
+                "a": RNA.make_seq(seq="UCAGUCAGUU"),
+                "b": RNA.make_seq(seq="UCCGUCAAUU"),
+                "c": RNA.make_seq(seq="ACCAUCAGUC"),
+                "d": RNA.make_seq(seq="UCAAUCGGUU"),
+                "e": RNA.make_seq(seq="UUGGUUGGGU"),
+                "f": RNA.make_seq(seq="CCGGGCGGCC"),
+                "g": RNA.make_seq(seq="UCAACCGGAA"),
             }
         )
         # Additional SequenceCollections for tests added 6/4/04 by Jeremy
         # Widmann
-        self.sequences = self.Class(list(map(RnaSequence, ["UCAG", "UCAG", "UCAG"])))
+        self.sequences = self.Class(
+            [
+                RNA.make_seq(seq="UCAG"),
+                RNA.make_seq(seq="UCAG"),
+                RNA.make_seq(seq="UCAG"),
+            ]
+        )
         # Additional SequenceCollection for tests added 1/30/06 by Cathy
         # Lozupone
         self.omitSeqsTemplate_aln = self.Class(
             {
-                "s1": RnaSequence("UC-----CU---C"),
-                "s2": RnaSequence("UC------U---C"),
-                "s3": RnaSequence("UUCCUUCUU-UUC"),
-                "s4": RnaSequence("UU-UUUU-UUUUC"),
-                "s5": RnaSequence("-------------"),
+                "s1": RNA.make_seq(seq="UC-----CU---C"),
+                "s2": RNA.make_seq(seq="UC------U---C"),
+                "s3": RNA.make_seq(seq="UUCCUUCUU-UUC"),
+                "s4": RNA.make_seq(seq="UU-UUUU-UUUUC"),
+                "s5": RNA.make_seq(seq="-------------"),
             }
         )
 
@@ -531,9 +547,9 @@ class SequenceCollectionBaseTests(object):
 
     def test_make_gap_filter(self):
         """make_gap_filter returns f(seq) -> True if aligned ok w/ query"""
-        s1 = RnaSequence("UC-----CU---C")
-        s3 = RnaSequence("UUCCUUCUU-UUC")
-        s4 = RnaSequence("UU-UUUU-UUUUC")
+        s1 = RNA.make_seq(seq="UC-----CU---C")
+        s3 = RNA.make_seq(seq="UUCCUUCUU-UUC")
+        s4 = RNA.make_seq(seq="UU-UUUU-UUUUC")
         # check that the behavior is ok for gap runs
         f1 = make_gap_filter(s1, 0.9, 5)
         f3 = make_gap_filter(s3, 0.9, 5)
@@ -626,7 +642,7 @@ class SequenceCollectionBaseTests(object):
         raw_seq = "---??-??TC-GGCG-GCA-G-GC-?-C-TAN-GCGC-CCTC-AGGA?-???-??--"
         raw_ungapped = re.sub("[-?]", "", raw_seq)
         re.sub("[N?]+", "", raw_seq)
-        dna = DNA.make_seq(raw_seq)
+        dna = DNA.make_seq(seq=raw_seq)
 
         aln = self.Class(data=[("a", dna), ("b", dna)])
         expect = self.Class(data=[("a", raw_ungapped), ("b", raw_ungapped)]).to_fasta()
@@ -890,7 +906,7 @@ class SequenceCollectionTests(SequenceCollectionBaseTests, TestCase):
     def test_info_source(self):  # ported
         """info.source exists if load seqs given a filename"""
         path = pathlib.Path("data/brca1.fasta")
-        seqs = load_unaligned_seqs(path)
+        seqs = load_unaligned_seqs(path, moltype="dna")
         self.assertEqual(seqs.info.source, str(path))
 
     def test_apply_pssm2(self):  # ported
@@ -905,8 +921,8 @@ class SequenceCollectionTests(SequenceCollectionBaseTests, TestCase):
 
     def test_construction(self):  # ported
         """correctly construct from list of sequences of length 2"""
-        seq1 = make_seq("AC", name="seq1")
-        seq2 = make_seq("AC", name="seq2")
+        seq1 = make_seq(seq="AC", name="seq1")
+        seq2 = make_seq(seq="AC", name="seq2")
         coll = SequenceCollection(data=[seq1, seq2])
 
 
@@ -1389,10 +1405,10 @@ class AlignmentBaseTests(SequenceCollectionBaseTests):
             ]
         )
 
-        s1 = DNA.make_seq("TCAGAG", name="s1")
-        s2 = DNA.make_seq("CCACAC", name="s2")
-        s3 = DNA.make_seq("AGATAT", name="s3")
-        s4 = DNA.make_seq("G-ACCC", name="s4")
+        s1 = DNA.make_seq(seq="TCAGAG", name="s1")
+        s2 = DNA.make_seq(seq="CCACAC", name="s2")
+        s3 = DNA.make_seq(seq="AGATAT", name="s3")
+        s4 = DNA.make_seq(seq="G-ACCC", name="s4")
         aln = self.Class([s1, s2, s3], moltype=DNA)
         obs = aln.counts_per_pos()
         assert_equal(obs.array, exp)
@@ -1717,9 +1733,10 @@ class AlignmentTests(AlignmentBaseTests, TestCase):
 
     def test_to_moltype_annotations(self):
         """correctly convert to specified moltype with proper sequence annotations"""
-        s1 = Sequence("TTTTTTAAAA", name="test_seq1")
-        s2 = Sequence("AAAATTTTTT", name="test_seq2")
-        s3 = Sequence("AATTTTTAAA", name="test_seq3")
+
+        s1 = Sequence(seq="TTTTTTAAAA", name="test_seq1")
+        s2 = Sequence(seq="AAAATTTTTT", name="test_seq2")
+        s3 = Sequence(seq="AATTTTTAAA", name="test_seq3")
         s1.add_feature(biotype="exon", name="fred", spans=[(0, 6)])
         s2.add_feature(biotype="exon", name="fred", spans=[(4, 10)])
         s3.add_feature(biotype="exon", name="fred", spans=[(2, 7)])
@@ -1736,9 +1753,9 @@ class AlignmentTests(AlignmentBaseTests, TestCase):
 
     def test_construction(self):
         """correctly construct from list of sequences of length 2"""
-        seq1 = make_seq("AC-", name="seq1")
+        seq1 = make_seq(seq="AC-", name="seq1")
         seq1 = Aligned(*seq1.parse_out_gaps())
-        seq2 = make_seq("ACG", name="seq2")
+        seq2 = make_seq(seq="ACG", name="seq2")
         seq2 = Aligned(*seq2.parse_out_gaps())
         coll = self.Class(data=[seq1, seq2])
 
@@ -1751,7 +1768,7 @@ class ArrayAlignmentSpecificTests(TestCase):
         self.a2 = ArrayAlignment(["ABC", "DEF"], names=["x", "y"])
         seqs = []
         for s in ["abaa", "abbb"]:
-            seqs.append(AB.make_seq(s, preserve_case=True))
+            seqs.append(AB.make_seq(seq=s, preserve_case=True))
         self.a = ArrayAlignment(seqs, moltype=AB)
         self.b = Alignment(["ABC", "DEF"])
         self.c = SequenceCollection(["ABC", "DEF"])
@@ -1864,7 +1881,7 @@ class ArrayAlignmentSpecificTests(TestCase):
         assert_allclose(f, e)
         seqs = []
         for s in ["-GAT", "ACCT", "GAGT"]:
-            seqs.append(make_seq(s, moltype="dna"))
+            seqs.append(make_seq(seq=s, moltype="dna"))
         a = ArrayAlignment(seqs)
         f = a.entropy_per_pos(allow_gap=True)
         e = array([1.584962500721156, 1.584962500721156, 1.584962500721156, 0])
@@ -1872,7 +1889,7 @@ class ArrayAlignmentSpecificTests(TestCase):
 
         seqs = []
         for s in ["-RAT", "ACCT", "GTGT"]:
-            seqs.append(make_seq(s, moltype="dna"))
+            seqs.append(make_seq(seq=s, moltype="dna"))
         a = ArrayAlignment(seqs)
 
         # "-RAT"
@@ -1911,10 +1928,10 @@ class IntegrationTests(TestCase):
 
     def setUp(self):
         """Intialize some standard sequences"""
-        self.r1 = RNA.make_seq("AAA", name="x")
-        self.r2 = RNA.make_seq("CCC", name="y")
-        self.m1 = RNA.make_array_seq("AAA", name="xx")
-        self.m2 = RNA.make_array_seq("CCC", name="yy")
+        self.r1 = RNA.make_seq(seq="AAA", name="x")
+        self.r2 = RNA.make_seq(seq="CCC", name="y")
+        self.m1 = RNA.make_array_seq(seq="AAA", name="xx")
+        self.m2 = RNA.make_array_seq(seq="CCC", name="yy")
 
     def test_model_to_model(self):
         """Model seq should work with dense alignment"""
@@ -1992,7 +2009,7 @@ class IntegrationTests(TestCase):
 def test_featuremap_slice_aligned(raw_seq, coords):
     from cogent3.core.location import FeatureMap, Span
 
-    im, seq = DNA.make_seq(raw_seq).parse_out_gaps()
+    im, seq = DNA.make_seq(seq=raw_seq).parse_out_gaps()
     ia = Aligned(im, seq)
     length = len(raw_seq)
     fmap = FeatureMap(spans=[Span(s, e) for s, e in coords], parent_length=length)
@@ -2040,14 +2057,33 @@ def test_to_type(cls):
 
 
 @pytest.mark.parametrize(
-    "moltype,array_align",
-    tuple(itertools.product(["rna", "dna", "protein"], [True, False])),
+    "moltype",
+    ["rna", "dna", "protein"],
 )
-def test_upac_consensus_allow_gaps(moltype, array_align):
+def test_upac_consensus_allow_gaps(moltype):
     aln = make_aligned_seqs(
         data={"s1": "ACGG", "s2": "ACGG", "s3": "-CGG"},
         moltype=moltype,
-        array_align=array_align,
+        array_align=False,
+    )
+    # default behaviour
+    iupac = aln.iupac_consensus()
+    assert iupac == "?CGG"
+
+    # allow_gaps
+    iupac = aln.iupac_consensus(allow_gap=False)
+    assert iupac == "ACGG"
+
+
+@pytest.mark.parametrize(
+    "moltype",
+    ["rna", "dna", "protein"],
+)
+def test_upac_consensus_allow_gaps_array_alignment(moltype):
+    aln = make_aligned_seqs(
+        data={"s1": "ACGG", "s2": "ACGG", "s3": "-CGG"},
+        moltype=moltype,
+        array_align=False,
     )
     # default behaviour
     iupac = aln.iupac_consensus()
@@ -2059,7 +2095,7 @@ def test_upac_consensus_allow_gaps(moltype, array_align):
 
 
 def test_rc_iter():
-    dna = DNA.make_seq("ACG", name="seq1")
+    dna = DNA.make_seq(seq="ACG", name="seq1")
     rc = dna.rc()
 
     got = [x for x in rc]
@@ -2068,7 +2104,7 @@ def test_rc_iter():
 
 
 def test_to_dna_raises():
-    seq = make_seq("ETV", moltype="protein")
+    seq = make_seq(seq="ETV", moltype="protein")
     with pytest.raises(AlphabetError):
         seq.to_moltype("dna")
 
@@ -2121,8 +2157,8 @@ def test_seqcoll_query(seqcoll_db):
 
 def test_align_get_features():
     #                0123456789   the positions
-    seq1 = make_seq("ACG--ACCGT", moltype="dna", name="seq1")
-    seq2 = make_seq("ACGGGCCCGT", moltype="dna", name="seq2")
+    seq1 = make_seq(seq="ACG--ACCGT", moltype="dna", name="seq1")
+    seq2 = make_seq(seq="ACGGGCCCGT", moltype="dna", name="seq2")
     #                  *****      the CDS feature
     seq2.add_feature(biotype="CDS", name="fake01", spans=[(2, 7)], strand="+")
     aln = make_aligned_seqs(data=[seq1, seq2], array_align=False)
@@ -2137,7 +2173,7 @@ def test_align_get_features():
 @pytest.mark.parametrize("cls", (SequenceCollection, Alignment))
 def test_init_annotated_seqs(cls):  # ported for SequenceCollection
     """correctly construct from list with annotated seq"""
-    seq = make_seq("GCCAGGGGGGAAAG-GGAGAA", name="seq1")
+    seq = make_seq(seq="GCCAGGGGGGAAAG-GGAGAA", name="seq1")
     _ = seq.add_feature(biotype="exon", name="name", spans=[(4, 10)])
     coll = cls(data=[seq])
     features = list(coll.get_features(biotype="exon"))
@@ -2235,7 +2271,7 @@ def _make_seq(name):
     cds = (15, 25)
     utr = (12, 15)
     # name is required for creating annotations
-    seq = DNA.make_seq(raw_seq, name=name)
+    seq = DNA.make_seq(seq=raw_seq, name=name)
     seq.add_feature(biotype="CDS", name="CDS", spans=[cds])
     seq.add_feature(biotype="5'UTR", name="5' UTR", spans=[utr])
     return seq
@@ -2297,7 +2333,7 @@ def test_copy_annotations_incompat_type_fails(seqcoll_db, gb_db):  # ported
 
 
 def test_aligned_deepcopy_sliced():
-    a = Aligned(*DNA.make_seq("GCAAGGCGCCAA").parse_out_gaps())
+    a = Aligned(*DNA.make_seq(seq="GCAAGGCGCCAA").parse_out_gaps())
     sliced = a[2:3]
     sl_cp = sliced.deepcopy(sliced=True)
     assert str(sl_cp) == str(sliced)
@@ -2364,14 +2400,60 @@ def test_seq_rename_preserves_annotations(cls):
     assert len(list(new.get_features(seqid="seq1")))
 
 
-@pytest.mark.parametrize(
-    "cls",
-    (SequenceCollection, ArrayAlignment),
-)
-def test_to_rich_dict_not_alignment(cls):  # ported for SequenceCollection
+def test_to_rich_dict_not_alignment():  # ported
     """to_rich_dict produces correct dict"""
     data = {"seq1": "ACGG", "seq2": "CGCA", "seq3": "CCG-"}
-    aln = cls(data, moltype="dna")
+    aln = SequenceCollection(data, moltype="dna")
+    try:
+        seq_type = get_object_provenance(aln.seqs[0].data)
+    except AttributeError:
+        seq_type = get_object_provenance(aln.seqs[0])
+
+    got = aln.to_rich_dict()
+
+    data = {k: SeqView(seq=s, seqid=k).to_rich_dict() for k, s in data.items()}
+
+    expect = {
+        "seqs": {
+            "seq1": {
+                "name": "seq1",
+                "seq": data["seq1"],
+                "info": None,
+                "type": seq_type,
+                "moltype": aln.moltype.label,
+                "version": __version__,
+                "annotation_offset": 0,
+            },
+            "seq2": {
+                "name": "seq2",
+                "seq": data["seq2"],
+                "info": None,
+                "type": seq_type,
+                "moltype": aln.moltype.label,
+                "version": __version__,
+                "annotation_offset": 0,
+            },
+            "seq3": {
+                "name": "seq3",
+                "seq": data["seq3"],
+                "info": None,
+                "type": seq_type,
+                "moltype": aln.moltype.label,
+                "version": __version__,
+                "annotation_offset": 0,
+            },
+        },
+        "moltype": aln.moltype.label,
+        "info": None,
+        "type": get_object_provenance(aln),
+        "version": __version__,
+    }
+    assert got == expect
+
+
+def test_array_alignment_to_rich_dict_not_alignment():  # will not port
+    data = {"seq1": "ACGG", "seq2": "CGCA", "seq3": "CCG-"}
+    aln = ArrayAlignment(data, moltype="dna")
     try:
         seq_type = get_object_provenance(aln.seqs[0].data)
     except AttributeError:
@@ -2426,7 +2508,9 @@ def test_to_rich_dict_alignment():
     got = aln.to_rich_dict()
 
     data = {
-        k: Aligned(*make_seq(s, name=k, moltype="dna").parse_out_gaps()).to_rich_dict()
+        k: Aligned(
+            *make_seq(seq=s, name=k, moltype="dna").parse_out_gaps()
+        ).to_rich_dict()
         for k, s in data.items()
     }
 
@@ -2456,11 +2540,19 @@ def test_dotplot_annotated(cls):  # ported for SequenceCollection
     _ = seqs.dotplot(show_progress=False)
 
 
-@pytest.mark.parametrize("cls", (Alignment, ArrayAlignment))
-def test_get_seq_entropy(cls):
+def test_array_alignment_get_seq_entropy():
     """ArrayAlignment get_seq_entropy should get entropy of each seq"""
-    seqs = [AB.make_seq(s, preserve_case=True) for s in ["abab", "bbbb", "abbb"]]
-    a = cls(seqs, moltype=AB)
+    seqs = [AB.make_seq(seq=s, preserve_case=True) for s in ["abab", "bbbb", "abbb"]]
+    a = ArrayAlignment(seqs, moltype=AB)
+    entropy = a.entropy_per_seq()
+    e = 0.81127812445913283  # sum(p log_2 p) for p = 0.25, 0.75
+    assert_allclose(entropy, array([1, 0, e]))
+
+
+def test_get_seq_entropy():
+    """Alignment get_seq_entropy should get entropy of each seq"""
+    seqs = [AB.make_seq(seq=s, preserve_case=True) for s in ["abab", "bbbb", "abbb"]]
+    a = Alignment(seqs, moltype=AB)
     entropy = a.entropy_per_seq()
     e = 0.81127812445913283  # sum(p log_2 p) for p = 0.25, 0.75
     assert_allclose(entropy, array([1, 0, e]))
@@ -2621,7 +2713,7 @@ def test_get_gap_array_equivalence():
 @pytest.mark.parametrize("reverse", (False, True))
 def test_aligned_rich_dict(reverse):
     map_, s = make_seq(
-        "TTGAAGAATATGT------GAAAGAG", name="s1", moltype="dna"
+        seq="TTGAAGAATATGT------GAAAGAG", name="s1", moltype="dna"
     ).parse_out_gaps()
     seq = Aligned(map_, s)
     if reverse:
@@ -2880,9 +2972,9 @@ def test_init_duplicate_keys_raises(cls):
     "seq",
     (
         "ACGG",
-        DNA.make_seq("ACGG"),
+        DNA.make_seq(seq="ACGG"),
         numpy.array([2, 1, 3, 3], dtype=int),
-        Aligned(*DNA.make_seq("AC-GG").parse_out_gaps()),
+        Aligned(*DNA.make_seq(seq="AC-GG").parse_out_gaps()),
     ),
 )
 def test_construct_unaligned_seq(seq):
@@ -2896,10 +2988,10 @@ def test_construct_unaligned_seq(seq):
     (
         [["s1", "ACGG"]],
         {"s1": "ACGG"},
-        {"s1": DNA.make_seq("ACGG")},
+        {"s1": DNA.make_seq(seq="ACGG")},
         (
             Aligned(
-                *DNA.make_seq("AC-GG", name="s1").parse_out_gaps(),
+                *DNA.make_seq(seq="AC-GG", name="s1").parse_out_gaps(),
             ),
         ),
         iter([["s1", "ACGG"]]),
@@ -3003,7 +3095,7 @@ def test_counts_per_seq_arr_alignment():
     """ArrayAlignment counts_per_seq should return motif counts each seq"""
     seqs = []
     for s in ["abaa", "abbb"]:
-        seqs.append(AB.make_seq(s, preserve_case=True))
+        seqs.append(AB.make_seq(seq=s, preserve_case=True))
     a = ArrayAlignment(seqs, moltype=AB)
     f = a.counts_per_seq()
     assert_equal(f.array, array([[3, 1], [1, 3]]))
@@ -3142,7 +3234,7 @@ def test_replace_seqs(cls):
 def test_get_alphabet_and_moltype():
     """ArrayAlignment should figure out correct alphabet and moltype"""
     s1 = "A"
-    s2 = RNA.make_seq("AA")
+    s2 = RNA.make_seq(seq="AA")
 
     d = ArrayAlignment(s1)
     assert d.moltype is BYTES
@@ -3196,9 +3288,9 @@ def test_init_dict(cls, d):  # will not port for SequenceCollection
 @pytest.mark.parametrize("cls", (Alignment, ArrayAlignment, SequenceCollection))
 def test_init_seq_info(cls):
     """SequenceCollection init from seqs w/ info should preserve data"""
-    a = Sequence("AAA", name="a", info={"x": 3})
-    b = Sequence("CCC", name="b", info={"x": 4})
-    c = Sequence("GGG", name="c", info={"x": 5})
+    a = Sequence(seq="AAA", name="a", info={"x": 3})
+    b = Sequence(seq="CCC", name="b", info={"x": 4})
+    c = Sequence(seq="GGG", name="c", info={"x": 5})
     seqs = [c, b, a]
     a = cls(seqs)
     assert list(a.names) == ["c", "b", "a"]
@@ -3341,7 +3433,7 @@ def test_sliced_deepcopy(data, name, rev):
 
 
 def test_aligned_deepcopy_sliced_map_matches_data():
-    m, seq = DNA.make_seq("ACAACGACG", name="seq1").parse_out_gaps()
+    m, seq = DNA.make_seq(seq="ACAACGACG", name="seq1").parse_out_gaps()
     aligned = Aligned(m, seq)
     sliced = aligned[3:5]
     sliced_copy = sliced.deepcopy(sliced=True)
@@ -3669,7 +3761,7 @@ def test_quick_tree(cls, calc, brca1_data):
 
 @pytest.mark.parametrize("raw", ("-AAAGGGGGAACCCT", "AAAGGGGGAACCCT"))
 def test_slice_aligned(raw):
-    imap, seq = DNA.make_seq(raw, name="x").parse_out_gaps()
+    imap, seq = DNA.make_seq(seq=raw, name="x").parse_out_gaps()
     al = Aligned(imap, seq)
     sliced = al[:-3]
     assert str(sliced) == raw[:-3]
@@ -3678,7 +3770,7 @@ def test_slice_aligned(raw):
 def test_slice_aligned_featuremap_allgap():
     from cogent3.core.location import FeatureMap, LostSpan
 
-    imap, seq = DNA.make_seq("AAAGGGGGAACCCT", name="x").parse_out_gaps()
+    imap, seq = DNA.make_seq(seq="AAAGGGGGAACCCT", name="x").parse_out_gaps()
     al = Aligned(imap, seq)
     fmap = FeatureMap(spans=[LostSpan(4)], parent_length=0)
     sliced = al[fmap]
@@ -3694,7 +3786,7 @@ def test_slice_aligned_featuremap_multi_spans():
     raw_seq = "AAAGG--GGG-AACCCT"
     #          01234  567 890123
     #                       1111
-    imap, seq = DNA.make_seq(raw_seq, name="x").parse_out_gaps()
+    imap, seq = DNA.make_seq(seq=raw_seq, name="x").parse_out_gaps()
     al = Aligned(imap, seq)
     fmap = FeatureMap.from_locations(
         locations=[(1, 4), (7, 9), (13, 16)], parent_length=len(raw_seq)

--- a/tests/test_core/test_annotation.py
+++ b/tests/test_core/test_annotation.py
@@ -2,9 +2,18 @@ import unittest
 
 import pytest
 
-from cogent3 import DNA, load_seq, make_aligned_seqs, make_unaligned_seqs
+from cogent3 import (
+    get_moltype,
+    load_seq,
+    make_aligned_seqs,
+    make_unaligned_seqs,
+)
 from cogent3.core.alignment import Alignment, SequenceCollection
+from cogent3.core.annotation_db import BasicAnnotationDb
 from cogent3.core.location import FeatureMap, Span
+
+
+DNA = get_moltype("dna")
 
 
 def makeSampleSequence(name, with_gaps=False):
@@ -14,7 +23,7 @@ def makeSampleSequence(name, with_gaps=False):
     if with_gaps:
         raw_seq = f"{raw_seq[:5]}-----{raw_seq[10:-2]}--"
     # name is required for creating annotations
-    seq = DNA.make_seq(raw_seq, name=name)
+    seq = DNA.make_seq(seq=raw_seq, name=name)
     seq.add_feature(biotype="CDS", name="CDS", spans=[cds])
     seq.add_feature(biotype="5'UTR", name="5' UTR", spans=[utr])
     return seq
@@ -222,7 +231,7 @@ def test_slice_seq_with_partial_start(ann_seq, annot_type, num):
 
 def test_seq_feature_to_dict():
     """create the attributes necessary to write into the user table"""
-    seq = DNA.make_seq("ATTGTACGCCCCTGA", name="test_seq")
+    seq = DNA.make_seq(seq="ATTGTACGCCCCTGA", name="test_seq")
     feature_data = {
         "biotype": "CDS",
         "name": "fake",
@@ -295,7 +304,7 @@ def test_gbdb_get_children_get_parent(DATA_DIR):
 def test_features_survives_seq_rename(rev):
     segments = ["A" * 10, "C" * 10, "T" * 5, "C" * 5, "A" * 5]
 
-    seq = DNA.make_seq("".join(segments), name="original")
+    seq = DNA.make_seq(seq="".join(segments), name="original")
     gene = seq.add_feature(biotype="gene", name="gene1", spans=[(10, 20), (25, 30)])
     gene_expect = str(seq[10:20]) + str(seq[25:30])
     assert str(gene.get_slice()) == gene_expect
@@ -319,11 +328,11 @@ def test_features_survives_seq_rename(rev):
 
 
 @pytest.mark.parametrize("rev", (False, True))
-@pytest.mark.parametrize("cls", (SequenceCollection, Alignment))
-def test_features_survives_aligned_seq_rename(rev, cls):
+@pytest.mark.parametrize("make_cls", (make_unaligned_seqs, Alignment))
+def test_features_survives_aligned_seq_rename(rev, make_cls):
     segments = ["A" * 10, "C" * 10, "T" * 5, "C" * 5, "A" * 5]
 
-    seqs = cls({"original": "".join(segments)}, moltype="dna")
+    seqs = make_cls({"original": "".join(segments)}, moltype="dna")
     seqs.annotation_db.add_feature(
         seqid="original", biotype="gene", name="gene1", spans=[(10, 20), (25, 30)]
     )

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -388,7 +388,7 @@ def test_feature_strand():
     minus_spans = [(4, 7), (11, 13)]
     minus_seq = "".join(raw_seq[s:e] for s, e in minus_spans)
     minus_seq = "".join([{"T": "A", "A": "T"}[b] for b in minus_seq[::-1]])
-    seq = make_seq(raw_seq, name="s1", moltype="dna")
+    seq = make_seq(seq=raw_seq, name="s1", moltype="dna")
     db = GffAnnotationDb()
     db.add_feature(
         seqid="s1",
@@ -426,7 +426,7 @@ def test_feature_nucleic():
 
     #                              111111
     #                    0123456789012345
-    seq = make_seq("AACCTTTGGGGAATTT", moltype="dna")
+    seq = make_seq(seq="AACCTTTGGGGAATTT", moltype="dna")
     mmap = loc.FeatureMap.from_locations(
         locations=[(4, 7), (10, 12)], parent_length=len(seq)
     )
@@ -630,7 +630,7 @@ def test_rc_get_slice_positive_feature(anno_db):
     the same sequence before and after the sequence is reverse complemented
     """
 
-    seq = DNA.make_seq("AAAAGGGG", name="seq1")
+    seq = DNA.make_seq(seq="AAAAGGGG", name="seq1")
 
     seq.annotation_db = anno_db
     anno_db.add_feature(
@@ -795,7 +795,7 @@ def test_relative_position_negative_feature(seq_db):
 
 
 def test_relative_position_positive_feature(anno_db):
-    seq = DNA.make_seq("AAAAGGGG", name="seq1")
+    seq = DNA.make_seq(seq="AAAAGGGG", name="seq1")
 
     seq.annotation_db = anno_db
     anno_db.add_feature(

--- a/tests/test_core/test_core_standalone.py
+++ b/tests/test_core/test_core_standalone.py
@@ -38,9 +38,9 @@ class TestConstructorFunctions(unittest.TestCase):
     def test_make_seq(self):
         """test constructor utility function"""
         _seq = "ACGGT"
-        seq = make_seq(_seq)
+        seq = make_seq(seq=_seq)
         self.assertEqual(seq.moltype.label, "text")
-        seq = make_seq(_seq, moltype="dna")
+        seq = make_seq(seq=_seq, moltype="dna")
         self.assertEqual(seq.moltype.label, "dna")
         self.assertEqual(str(seq), _seq)
 
@@ -94,10 +94,10 @@ class TestConstructorFunctions(unittest.TestCase):
         with TemporaryDirectory(dir=".") as dirname:
             json_path = os.path.join(dirname, "unaligned.json")
             path = os.path.join(DATA_DIR, "brca1_5.paml")
-            unaligned = load_unaligned_seqs(path)
+            unaligned = load_unaligned_seqs(path, moltype="dna")
             unaligned.write(json_path)
 
-            got = load_unaligned_seqs(json_path)
+            got = load_unaligned_seqs(json_path, moltype="dna")
             self.assertIsInstance(got, SequenceCollection)
             self.assertEqual(got.to_dict(), unaligned.to_dict())
             self.assertEqual(got.info["source"], path)
@@ -112,9 +112,9 @@ class TestConstructorFunctions(unittest.TestCase):
                 out.write(json.dumps(completed_record))
             # tests when provided record json file is uncompleted
             with self.assertRaises(TypeError):
-                load_unaligned_seqs(uncompleted_record_path)
+                load_unaligned_seqs(uncompleted_record_path, moltype="dna")
             # tests when provided record json is completed
-            got = load_unaligned_seqs(completed_record_path)
+            got = load_unaligned_seqs(completed_record_path, moltype="dna")
             self.assertIsInstance(got, SequenceCollection)
             self.assertEqual(got.to_dict(), unaligned.to_dict())
             self.assertEqual(got.info["source"], path)
@@ -153,7 +153,7 @@ class TestConstructorFunctions(unittest.TestCase):
                 out.write(json.dumps(completed_record))
             # tests when provided record json file is uncompleted
             with self.assertRaises(TypeError):
-                load_unaligned_seqs(uncompleted_record_path)
+                load_unaligned_seqs(uncompleted_record_path, moltype="dna")
             # tests when provided record json is completed
             got = load_aligned_seqs(completed_record_path)
             self.assertIsInstance(got, ArrayAlignment)
@@ -162,7 +162,7 @@ class TestConstructorFunctions(unittest.TestCase):
             # tests wrong input json file
             json_path = os.path.join(dirname, "unaligned.json")
             path = os.path.join(DATA_DIR, "brca1_5.paml")
-            unaligned = load_unaligned_seqs(path)
+            unaligned = load_unaligned_seqs(path, moltype="dna")
             unaligned.write(json_path)
             with self.assertRaises(TypeError):
                 load_aligned_seqs(json_path)
@@ -243,8 +243,8 @@ class AlignmentTestMethods(unittest.TestCase):
         # python classes without __getstate__ etc.
         import pickle as pickle
 
-        seq1 = DNA.make_seq("aagaagaagaccccca")
-        seq2 = DNA.make_seq("aagaagaagaccccct")
+        seq1 = DNA.make_seq(seq="aagaagaagaccccca")
+        seq2 = DNA.make_seq(seq="aagaagaagaccccct")
         seq2.add_feature(biotype="exon", name="fred", spans=[(10, 15)])
         aln = make_aligned_seqs(data={"a": seq1, "b": seq2})
         # TODO the ability to pickle/unpickle depends on the protocol
@@ -655,7 +655,7 @@ class SequenceTestMethods(unittest.TestCase):
     """Testing Sequence methods"""
 
     def setUp(self):
-        self.seq = make_seq("ATGACGTTGCGTAGCATAGCTCGA", "dna")
+        self.seq = make_seq(seq="ATGACGTTGCGTAGCATAGCTCGA", moltype="dna")
 
     def test_getlength(self):
         """testing getting length"""
@@ -675,17 +675,17 @@ class SequenceTestMethods(unittest.TestCase):
 
     def test_translate(self):
         """test of translating seqs"""
-        seq = make_seq("ATGACGTTGCGTAGCATAGCTCGA", moltype=DNA).get_translation()
+        seq = make_seq(seq="ATGACGTTGCGTAGCATAGCTCGA", moltype=DNA).get_translation()
         self.assertEqual(str(seq), "MTLRSIAR")
 
     def test_ambig_translate(self):
         """test of translating seqs"""
-        seq = make_seq("CGNTGN???---", moltype=DNA).get_translation()
+        seq = make_seq(seq="CGNTGN???---", moltype=DNA).get_translation()
         self.assertEqual(str(seq), "RX?-")
 
     def test_translate_incomplete(self):
         """test of translating seqs with incomplete codon"""
-        seq = make_seq("CGNTGNAC----", moltype=DNA)
+        seq = make_seq(seq="CGNTGNAC----", moltype=DNA)
         aa = seq.get_translation(incomplete_ok=True)
         self.assertEqual(str(aa), "RX?-")
         with self.assertRaises(AlphabetError):
@@ -830,7 +830,7 @@ def gb_file(tmp_dir, request):
 
 
 def test_gb_suffixes(gb_file):
-    seqs = load_unaligned_seqs(gb_file)
+    seqs = load_unaligned_seqs(gb_file, moltype="dna")
     isinstance(seqs, SequenceCollection)
 
 

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -17,7 +17,7 @@ class FeaturesTest(TestCase):
     def setUp(self):
         # A Sequence with a couple of exons on it.
         self.s = DNA.make_seq(
-            "AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA", name="Orig"
+            seq="AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA", name="Orig"
         )
         self.exon1 = self.s.add_feature(biotype="exon", name="fred", spans=[(10, 15)])
         self.exon2 = self.s.add_feature(biotype="exon", name="trev", spans=[(30, 40)])
@@ -75,7 +75,7 @@ class FeaturesTest(TestCase):
 
     def test_annotate_matches_to(self):
         """annotate_matches_to attaches annotations correctly to a Sequence"""
-        seq = DNA.make_seq("TTCCACTTCCGCTT", name="x")
+        seq = DNA.make_seq(seq="TTCCACTTCCGCTT", name="x")
         pattern = "CCRC"
         annot = seq.annotate_matches_to(
             pattern=pattern, biotype="domain", name="fred", allow_multiple=True
@@ -156,7 +156,9 @@ def test_feature_residue():
 @pytest.fixture(scope="function")
 def ann_seq():
     # A Sequence with a couple of exons on it.
-    s = DNA.make_seq("AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA", name="Orig")
+    s = DNA.make_seq(
+        seq="AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA", name="Orig"
+    )
     s.add_feature(biotype="gene", name="a-gene", spans=[(10, 40)])
     s.add_feature(
         biotype="exon", name="fred", spans=[(10, 15), (30, 40)], parent_id="a-gene"
@@ -198,7 +200,7 @@ def _add_features(obj, on_alignment):
 
 
 def test_feature_query_child_seq():
-    s = DNA.make_seq("AAAGGGAAAA", name="s1")
+    s = DNA.make_seq(seq="AAAGGGAAAA", name="s1")
     s = _add_features(s, on_alignment=False)
     gene = list(s.get_features(biotype="CDS"))[0]
     child = list(gene.get_children())
@@ -209,7 +211,7 @@ def test_feature_query_child_seq():
 
 
 def test_feature_query_parent_seq():
-    s = DNA.make_seq("AAAGGGAAAA", name="s1")
+    s = DNA.make_seq(seq="AAAGGGAAAA", name="s1")
     s = _add_features(s, on_alignment=False)
     exon = list(s.get_features(name="child"))[0]
     parent = list(exon.get_parent())
@@ -446,7 +448,9 @@ def test_feature_from_alignment():
 
 def test_nested_get_slice():
     """check the get_slice method works on nested annotations"""
-    s = DNA.make_seq("AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA", name="Orig")
+    s = DNA.make_seq(
+        seq="AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA", name="Orig"
+    )
     ex = s.add_feature(biotype="exon", name="fred", spans=[(10, 20)])
     s.add_feature(biotype="exon", name="trev", spans=[(30, 40)])
     s.add_feature(biotype="repeat", name="bob", spans=[(12, 17)], parent_id="fred")
@@ -458,7 +462,7 @@ def test_roundtrip_annotated_seq():
     """should work for a seq that has been reverse complemented"""
     # the key that exposed the bug was a gap in the middle of the sequence
     seq = DNA.make_seq(
-        "AAAGGGGGAACCT",
+        seq="AAAGGGGGAACCT",
         name="x",
     )
     seq.add_feature(biotype="exon", name="E1", spans=[(3, 8)])
@@ -499,7 +503,7 @@ def test_masking_strand_agnostic_seq():
     # Annotations should be correctly masked,
     # whether the sequence has been reverse complemented or not.
     # We use the plus/minus strand CDS containing sequences created above.
-    plus = DNA.make_seq("AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="plus")
+    plus = DNA.make_seq(seq="AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="plus")
     plus.annotation_db = db
     masked = plus.with_masked_annotations("CDS")
     assert len(masked) == len(plus)
@@ -540,7 +544,7 @@ def test_masking_strand_agnostic_aln():
 def test_roundtrip_json():
     """features can roundtrip from json"""
 
-    seq = DNA.make_seq("AAAAATATTATTGGGT")
+    seq = DNA.make_seq(seq="AAAAATATTATTGGGT")
     seq.add_feature(biotype="exon", name="myname", spans=[(0, 5)])
     got = seq.to_json()
     new = deserialise_object(got)
@@ -628,7 +632,7 @@ def test_feature_out_range():
 def test_search_with_ints(cast):
     """searching for features with numpy ints should work"""
     start, stop = cast([2, 5])
-    seq = DNA.make_seq("AAAGGGGGAACCCT", name="x")
+    seq = DNA.make_seq(seq="AAAGGGGGAACCCT", name="x")
     db = GffAnnotationDb()
     db.add_feature(seqid="x", biotype="exon", name="E1", spans=[(3, 8)])
     db.add_feature(seqid="x", biotype="exon", name="E2", spans=[(10, 13)])
@@ -674,7 +678,7 @@ def test_feature_reverse():
     # and show that after getting the reverse complement we have
     # exactly the same result from getting the CDS annotation.
 
-    plus = DNA.make_seq("AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="plus")
+    plus = DNA.make_seq(seq="AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="plus")
     plus_cds = plus.add_feature(
         biotype="CDS", name="gene", spans=[(2, 6), (10, 15), (25, 35)]
     )
@@ -687,7 +691,7 @@ def test_feature_reverse():
 @pytest.mark.parametrize("moltype", ("protein", "bytes", "text"))
 def test_rc_feature_on_wrong_moltype(moltype):
     moltype = get_moltype(moltype)
-    seq = moltype.make_seq("AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="s1")
+    seq = moltype.make_seq(seq="AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="s1")
     cds = seq.add_feature(
         biotype="CDS", name="gene", spans=[(2, 6), (10, 15), (25, 35)], strand="-"
     )
@@ -738,7 +742,9 @@ def test_hash_feature(ann_seq):
 
 
 def test_seq_degap_preserves_annotations():
-    s1 = DNA.make_seq("AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAGGGAACCCT", name="seq1")
+    s1 = DNA.make_seq(
+        seq="AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAGGGAACCCT", name="seq1"
+    )
     s1.add_feature(biotype="exon", name="A", spans=[(10, 15)])
     dg = s1.degap()
     assert len(s1.annotation_db) == len(dg.annotation_db)

--- a/tests/test_core/test_genetic_code.py
+++ b/tests/test_core/test_genetic_code.py
@@ -307,7 +307,7 @@ class GeneticCodeTests(TestCase):
         )
 
         # should also actually work with an RNA or DNA sequence!!!
-        test_rna = RNA.make_seq("AUGCUAACAUAAA")
+        test_rna = RNA.make_seq(seq="AUGCUAACAUAAA")
         self.assertEqual(
             sgc.sixframes(test_rna), ["MLT*", "C*HK", "ANI", "FMLA", "LC*H", "YVS"]
         )
@@ -315,7 +315,7 @@ class GeneticCodeTests(TestCase):
     def test_stop_indexes(self):
         """should return stop codon indexes for a specified frame"""
         sgc = GeneticCode(self.SGC)
-        seq = DNA.make_seq("ATGCTAACATAAA")
+        seq = DNA.make_seq(seq="ATGCTAACATAAA")
         expected = [[9], [4], []]
         for frame, expect in enumerate(expected):
             got = sgc.get_stop_indices(seq, start=frame)

--- a/tests/test_core/test_location.py
+++ b/tests/test_core/test_location.py
@@ -268,7 +268,7 @@ class MapTests(TestCase):
 
     def test_get_gap_coords(self):
         """returns gap start and lengths"""
-        m, _ = DNA.make_seq("-AC--GT-TTA--").parse_out_gaps()
+        m, _ = DNA.make_seq(seq="-AC--GT-TTA--").parse_out_gaps()
         got = m.get_gap_coordinates()
         self.assertEqual(dict(got), {0: 1, 2: 2, 4: 1, 7: 2})
 
@@ -330,8 +330,8 @@ def test_map_nucleic_reversed():
 @pytest.mark.parametrize("cls", (FeatureMap, IndelMap))
 def test_coordinate(cls):
     # coordinates are for ungapped segments in underlying sequence
-    #                   01   2 345
-    seq = DNA.make_seq("AC---G-TAA--")
+    #                       01   2 345
+    seq = DNA.make_seq(seq="AC---G-TAA--")
     m, _ = seq.parse_out_gaps()
     m = cls.from_spans(spans=tuple(m.spans), parent_length=m.parent_length)
     got = m.get_coordinates()
@@ -340,7 +340,7 @@ def test_coordinate(cls):
 
 @pytest.mark.parametrize("cls", (FeatureMap, IndelMap))
 def test_gap_coordinate(cls):
-    seq = DNA.make_seq("AC---G-TAA--")
+    seq = DNA.make_seq(seq="AC---G-TAA--")
     m, _ = seq.parse_out_gaps()
     m = cls.from_spans(spans=tuple(m.spans), parent_length=m.parent_length)
     got = m.get_gap_coordinates()
@@ -349,9 +349,9 @@ def test_gap_coordinate(cls):
 
 def test_gaps():
     # returns spans corresponding to position on "aligned" seq of gaps
-    #                   000000000011
-    #                   012345678901
-    seq = DNA.make_seq("AC---G-TAA--")
+    #                       000000000011
+    #                       012345678901
+    seq = DNA.make_seq(seq="AC---G-TAA--")
     m, _ = seq.parse_out_gaps()
     m = FeatureMap.from_spans(spans=tuple(m.spans), parent_length=m.parent_length)
     got = [(g.start, g.end) for g in tuple(m.gaps().spans)]
@@ -361,9 +361,9 @@ def test_gaps():
 @pytest.mark.parametrize("cls", (IndelMap, FeatureMap))
 def test_nongap(cls):
     # returns spans corresponding to position on "aligned" seq of nongaps
-    #                   000000000011
-    #                   012345678901
-    seq = DNA.make_seq("AC---G-TAA--")
+    #                       000000000011
+    #                       012345678901
+    seq = DNA.make_seq(seq="AC---G-TAA--")
     m, _ = seq.parse_out_gaps()
     m = cls.from_spans(spans=tuple(m.spans), parent_length=m.parent_length)
 
@@ -375,7 +375,7 @@ def test_nongap(cls):
 def test_nongap_startswith(cls):
     # returns spans corresponding to position on "aligned" seq of nongaps
     #                   012345678
-    seq = DNA.make_seq("--G-TAA--")
+    seq = DNA.make_seq(seq="--G-TAA--")
     m, _ = seq.parse_out_gaps()
     m = cls.from_spans(spans=tuple(m.spans), parent_length=m.parent_length)
 
@@ -387,7 +387,7 @@ def test_nongap_startswith(cls):
 def test_nongap_not_endswith(cls):
     # returns spans corresponding to position on "aligned" seq of nongaps
     #                   0123456
-    seq = DNA.make_seq("--G-TAA")
+    seq = DNA.make_seq(seq="--G-TAA")
     m, _ = seq.parse_out_gaps()
     m = cls.from_spans(spans=tuple(m.spans), parent_length=m.parent_length)
 
@@ -397,9 +397,9 @@ def test_nongap_not_endswith(cls):
 
 def test_spans_gen():
     # returns spans corresponding to position on "aligned" seq of nongaps
-    #                   000000000011
-    #                   012345678901
-    seq = DNA.make_seq("AC---G-TAA--")
+    #                       000000000011
+    #                       012345678901
+    seq = DNA.make_seq(seq="AC---G-TAA--")
     expect = [Span(0, 2), LostSpan(3), Span(2, 3), LostSpan(1), Span(3, 6), LostSpan(2)]
     m, _ = seq.parse_out_gaps()
     gap_data = numpy.array([(2, 3), (3, 1), (6, 2)])
@@ -411,9 +411,9 @@ def test_spans_gen():
 
 def test_spans_gap_start():
     # returns spans corresponding to position on "aligned" seq of nongaps
-    #                   000000000011
-    #                   012345678901
-    seq = DNA.make_seq("---TAA")
+    #                       000000000011
+    #                       012345678901
+    seq = DNA.make_seq(seq="---TAA")
     expect = [LostSpan(3), Span(0, 3)]
     im, _ = seq.parse_out_gaps()
     got = list(im.spans)
@@ -422,9 +422,9 @@ def test_spans_gap_start():
 
 def test_spans_gen_nogaps():
     # returns spans corresponding to position on "aligned" seq of nongaps
-    #                   000000000011
-    #                   012345678901
-    seq = DNA.make_seq("ACGTAA")
+    #                       000000000011
+    #                       012345678901
+    seq = DNA.make_seq(seq="ACGTAA")
     m, _ = seq.parse_out_gaps()
     spans = list(m.spans)
     assert len(spans) == 1
@@ -432,7 +432,7 @@ def test_spans_gen_nogaps():
 
 
 def test_round_trip_rich_dict():
-    seq = DNA.make_seq("AC---G-TAA--")
+    seq = DNA.make_seq(seq="AC---G-TAA--")
     im, _ = seq.parse_out_gaps()
     rd = im.to_rich_dict()
     got = IndelMap.from_rich_dict(rd)
@@ -591,7 +591,7 @@ def test_compare_map_indexed():
     from cogent3.core.alignment import Aligned
 
     raw_seq = "--AC-GTAA--"
-    im, seq = DNA.make_seq(raw_seq).parse_out_gaps()
+    im, seq = DNA.make_seq(seq=raw_seq).parse_out_gaps()
     ia = Aligned(im, seq)
     length = len(raw_seq)
     got = [str(ia[i]) for i in range(length)]
@@ -625,9 +625,9 @@ def test_indelmap_to_feature_map():
 def test_indelmap_nucleic_reversed(raw):
     from cogent3.core.alignment import Aligned
 
-    plus = DNA.make_seq(raw)
+    plus = DNA.make_seq(seq=raw)
     minus = plus.rc()
-    plus_imap, _ = DNA.make_seq(raw).parse_out_gaps()
+    plus_imap, _ = DNA.make_seq(seq=raw).parse_out_gaps()
     minus_imap, minus_seq = minus.parse_out_gaps()
     got = plus_imap.nucleic_reversed()
     assert got.get_coordinates() == minus_imap.get_coordinates()
@@ -668,8 +668,8 @@ def test_indel_map_get_gap_coords():
 )
 def test_indelmap_joined_segments(coords):
     raw = "--AC--GGGG--"
-    expect, _ = DNA.make_seq("".join(raw[s:e] for s, e in coords)).parse_out_gaps()
-    imap, _ = DNA.make_seq(raw).parse_out_gaps()
+    expect, _ = DNA.make_seq(seq="".join(raw[s:e] for s, e in coords)).parse_out_gaps()
+    imap, _ = DNA.make_seq(seq=raw).parse_out_gaps()
     got = imap.joined_segments(coords)
     assert got.gap_pos.tolist() == expect.gap_pos.tolist()
     assert got.cum_gap_lengths.tolist() == expect.cum_gap_lengths.tolist()
@@ -678,8 +678,8 @@ def test_indelmap_joined_segments(coords):
 def test_indelmap_slice_terminating():
     raw = "-CB-A--"
     start, end = 4, 6
-    expect, _ = DNA.make_seq(raw[start:end]).parse_out_gaps()
-    imap, _ = DNA.make_seq(raw).parse_out_gaps()
+    expect, _ = DNA.make_seq(seq=raw[start:end]).parse_out_gaps()
+    imap, _ = DNA.make_seq(seq=raw).parse_out_gaps()
     got = imap[start:end]
     assert got.gap_pos.tolist() == expect.gap_pos.tolist()
     assert got.cum_gap_lengths.tolist() == expect.cum_gap_lengths.tolist()
@@ -688,8 +688,8 @@ def test_indelmap_slice_terminating():
 def test_indelmap_slice_zero():
     raw = "-CB-A--"
     start, end = 0, 0
-    expect, s = DNA.make_seq(raw[start:end]).parse_out_gaps()
-    imap, _ = DNA.make_seq(raw).parse_out_gaps()
+    expect, s = DNA.make_seq(seq=raw[start:end]).parse_out_gaps()
+    imap, _ = DNA.make_seq(seq=raw).parse_out_gaps()
     got = imap[start:end]
     assert got.parent_length == len(s)
     assert got.gap_pos.tolist() == expect.gap_pos.tolist()
@@ -725,8 +725,8 @@ def test_indelmap_get_indices_errors():
 def test_indelmap_slice_innner_gap():
     start, end = 4, 6
     raw = "--AC--GGGG--"
-    expect, _ = DNA.make_seq(raw[start:end]).parse_out_gaps()
-    imap, _ = DNA.make_seq(raw).parse_out_gaps()
+    expect, _ = DNA.make_seq(seq=raw[start:end]).parse_out_gaps()
+    imap, _ = DNA.make_seq(seq=raw).parse_out_gaps()
     imap = imap[start:end]
     assert imap.gap_pos.tolist() == expect.gap_pos.tolist()
 
@@ -734,7 +734,7 @@ def test_indelmap_slice_innner_gap():
 def test_indelmap_slice_cum_length():
     start, end = 7, 11
     raw = "--AC--GGGG--"
-    expect, _ = DNA.make_seq(raw[start:end]).parse_out_gaps()
+    expect, _ = DNA.make_seq(seq=raw[start:end]).parse_out_gaps()
     imap, _ = DNA.make_seq(raw).parse_out_gaps()
     imap = imap[start:end]
     assert imap.gap_pos.tolist() == expect.gap_pos.tolist()
@@ -944,7 +944,7 @@ def test_gapped_convert_aln2seq_gapchar(data, gap_number):
 
 
 def test_gapped_convert_aln2seq_invalid():
-    gaps, _ = make_seq("AC--GTA-TG", moltype="dna").parse_out_gaps()
+    gaps, _ = make_seq(seq="AC--GTA-TG", moltype="dna").parse_out_gaps()
     with pytest.raises(IndexError):
         # absolute value of negative indices must be < seq length
         gaps.get_seq_index(-100)
@@ -1099,7 +1099,7 @@ def test_gap_coords_to_map():
     assert dict(got.get_gap_coordinates()) == gap_coords
 
     # and no gaps
-    m, seq = DNA.make_seq("ACGTTTA").parse_out_gaps()
+    m, seq = DNA.make_seq(seq="ACGTTTA").parse_out_gaps()
     got = gap_coords_to_map({}, len(seq))
     assert len(got) == len(m)
     assert got.get_coordinates() == m.get_coordinates()

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -1144,8 +1144,8 @@ def test_resolve_ambiguity_codons():  # ported
 
 
 def test_make_seq_on_seq():
-    seq = DNA.make_seq("ACGG")
-    got = DNA.make_seq(seq)
+    seq = DNA.make_seq(seq="ACGG")
+    got = DNA.make_seq(seq=seq)
     assert got is seq
 
 
@@ -1153,9 +1153,9 @@ def test_make_seq_on_seq():
 
 
 def test_make_seq_diff_moltype():
-    seq = RNA.make_seq("ACGG")
+    seq = RNA.make_seq(seq="ACGG")
     seq.add_feature(biotype="gene", name="test", spans=[(0, 2)])
-    got = DNA.make_seq(seq)
+    got = DNA.make_seq(seq=seq)
     assert len(got.annotation_db) == 1
 
 

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -796,6 +796,8 @@ class RnaMolTypeTests(TestCase):
         expect = {b + "_protein" for b in states}
         self.assertEqual(got, expect)
 
+    ("new MolType will not support setting label")
+
     def test_get_css_no_label(self):
         """should not fail when moltype has no label"""
         dna = get_moltype("dna")
@@ -1145,6 +1147,9 @@ def test_make_seq_on_seq():
     seq = DNA.make_seq("ACGG")
     got = DNA.make_seq(seq)
     assert got is seq
+
+
+("Dropping support for coerce_str")
 
 
 def test_make_seq_diff_moltype():

--- a/tests/test_core/test_new_moltype.py
+++ b/tests/test_core/test_new_moltype.py
@@ -1,7 +1,13 @@
 import numpy
 import pytest
 
-from cogent3.core import moltype, new_alphabet, new_moltype, new_sequence
+from cogent3.core import (
+    moltype,
+    new_alphabet,
+    new_genetic_code,
+    new_moltype,
+    new_sequence,
+)
 
 
 def test_make_pairs():
@@ -213,10 +219,7 @@ def test_resolve_ambiguity_nucs():
 
 
 def test_resolve_ambiguity_codons():
-    # refactor to using new_genetic_code when codon alphabet class is implemented
-    from cogent3 import get_code
-
-    gc = get_code(1)
+    gc = new_genetic_code.get_code(1)
     codon_alpha = gc.get_alphabet(include_stop=False)
     codon_alpha_w_gap = codon_alpha.with_gap_motif()
     assert (

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -843,7 +843,7 @@ class SequenceTests(TestCase):
 
         with self.assertRaises(TypeError):
             text = get_moltype("text")
-            m, s = text.make_seq("ACGGCTGAAGCGCTCCGGGTTTAAAACG").parse_out_gaps()
+            m, s = text.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG").parse_out_gaps()
             s.strand_symmetry(motif_length=1)
 
         # with motif_length=2
@@ -977,15 +977,15 @@ class SequenceSubclassTests(TestCase):
     def test_get_type(self):  # ported
         """returns moltype label"""
         for moltype in ("text", "dna", "bytes"):
-            seq = get_moltype(moltype).make_seq("ARCGT")
+            seq = get_moltype(moltype).make_seq(seq="ARCGT")
             self.assertEqual(seq.get_type(), moltype)
 
     def test_resolved_ambiguities(self):  # ported
-        seq = get_moltype("dna").make_seq("ARC")
+        seq = get_moltype("dna").make_seq(seq="ARC")
         got = seq.resolved_ambiguities()
         self.assertEqual(got, [("A",), ("A", "G"), ("C",)])
 
-        seq = get_moltype("dna").make_seq("AGC")
+        seq = get_moltype("dna").make_seq(seq="AGC")
         got = seq.resolved_ambiguities()
         self.assertEqual(got, [("A",), ("G",), ("C",)])
 
@@ -1128,7 +1128,7 @@ class DnaSequenceGapTests(TestCase):  # not porting: not supporting ArraySeqs
     def test_degap_name(self):
         """degap preserves name attribute"""
         # todo this should work for any seq class, but is not
-        seq = DNA.make_seq("ACG---T", "blah")
+        seq = DNA.make_seq(seq="ACG---T", name="blah")
         got = seq.degap()
         self.assertEqual(str(got), "ACGT")
         self.assertEqual(got.name, "blah")
@@ -1140,31 +1140,31 @@ class SequenceIntegrationTests(TestCase):  # not porting: not supporting ArraySe
     def test_regular_to_model(self):
         """Regular sequence should convert to model sequence"""
         r = RNA.make_seq("AAA", name="x")
-        s = RNA.make_array_seq(r)
+        s = RNA.make_array_seq(seq=r)
         self.assertEqual(str(s), "AAA")
         self.assertEqual(s.moltype, RNA)
         self.assertEqual(s.name, "x")
 
     def test_model_to_regular(self):
         """Model sequence should convert to regular sequence"""
-        r = RNA.make_array_seq("AAA", name="x")
-        s = RNA.make_seq(r)
+        r = RNA.make_array_seq(seq="AAA", name="x")
+        s = RNA.make_seq(seq=r)
         self.assertEqual(str(s), "AAA")
         self.assertEqual(s.moltype, RNA)
         self.assertEqual(s.name, "x")
 
     def test_regular_to_regular(self):
         """Regular sequence should convert to regular sequence"""
-        r = RNA.make_seq("AAA", name="x")
-        s = RNA.make_seq(r)
+        r = RNA.make_seq(seq="AAA", name="x")
+        s = RNA.make_seq(seq=r)
         self.assertEqual(str(s), "AAA")
         self.assertEqual(s.moltype, RNA)
         self.assertEqual(s.name, "x")
 
     def test_model_to_model(self):
         """Model sequence should convert to model sequence"""
-        r = RNA.make_array_seq("AAA", name="x")
-        s = RNA.make_array_seq(r)
+        r = RNA.make_array_seq(seq="AAA", name="x")
+        s = RNA.make_array_seq(seq=r)
         self.assertEqual(str(s), "AAA")
         self.assertEqual(s.moltype, RNA)
         self.assertEqual(s.name, "x")
@@ -1250,7 +1250,7 @@ class ModelSequenceTests(SequenceTests):  # not porting: not supporting ArraySeq
     def test_count_ab(self):
         """abseq array seq should count characters"""
         AB = get_moltype("ab")
-        seq = AB.make_array_seq("aaba-", alphabet=AB.alphabet.with_gap_motif())
+        seq = AB.make_array_seq(seq="aaba-", alphabet=AB.alphabet.with_gap_motif())
         c = seq.counts()
         self.assertEqual(c.to_dict(), {"a": 3, "b": 1})
         c = seq.counts(allow_gap=True)
@@ -1259,7 +1259,7 @@ class ModelSequenceTests(SequenceTests):  # not porting: not supporting ArraySeq
 
 @pytest.mark.parametrize("seq,rc", (("ATGTTT", False), ("AAACAT", True)))
 def test_translation(seq, rc):  # ported
-    seq = DNA.make_seq(seq)
+    seq = DNA.make_seq(seq=seq)
     if rc:
         seq = seq.rc()
     assert str(seq) == "ATGTTT"
@@ -1268,17 +1268,17 @@ def test_translation(seq, rc):  # ported
 
 
 def test_get_translation_include_stop():  # ported
-    s = DNA.make_seq("ATTTAACTT", name="s1")
+    s = DNA.make_seq(seq="ATTTAACTT", name="s1")
     aa = s.get_translation(include_stop=True)
     assert str(aa) == "I*L"
 
 
 def test_get_translation_trim_stop():  # ported
-    s = DNA.make_seq("ATTTCCTGA", name="s1")
+    s = DNA.make_seq(seq="ATTTCCTGA", name="s1")
     aa = s.get_translation(trim_stop=True)
     assert str(aa) == "IS"
     # no effect on internal stops
-    s = DNA.make_seq("ATTTAACTT", name="s1")
+    s = DNA.make_seq(seq="ATTTAACTT", name="s1")
     aa = s.get_translation(include_stop=True, trim_stop=True)
     assert str(aa) == "I*L"
 
@@ -2061,7 +2061,7 @@ def test_get_kmers_strict_DNA_RNA_Protein_mixed_ambiguities():  # ported
 def one_seq():
     from cogent3 import make_seq
 
-    return make_seq("AACCTGGAACC", moltype="dna")
+    return make_seq(seq="AACCTGGAACC", moltype="dna")
 
 
 @pytest.fixture(scope="session")
@@ -2106,7 +2106,7 @@ def test_seq_repr(one_seq, rc):  # ported
 
 
 def test_annotation_from_slice_with_stride():  # ported
-    seq = DNA.make_seq("AAACGCGCGAAAAAAA", name="s1")
+    seq = DNA.make_seq(seq="AAACGCGCGAAAAAAA", name="s1")
     seq.add_feature(biotype="exon", name="ex1", spans=[(3, 9)])
     f = list(seq.get_features(name="ex1"))[0]
     assert str(f.get_slice()) == "CGCGCG"
@@ -2273,7 +2273,7 @@ def test_annotate_gff_nested_features(DATA_DIR):  # ported
     #            *********            exon
     #                       *****     exon
     # ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC...
-    seq = DNA.make_seq("ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC", name="22")
+    seq = DNA.make_seq(seq="ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC", name="22")
     gff3_path = DATA_DIR / "ensembl_sample.gff3"
     seq.annotate_from_gff(gff3_path)
     # we have 8 records in the gff file
@@ -2305,7 +2305,7 @@ def test_annotate_gff_nested_features(DATA_DIR):  # ported
 
 def test_to_moltype_dna():  # ported
     """to_moltype("dna") ensures conversion from T to U"""
-    seq = DNA.make_seq("AAAAGGGGTTT", name="seq1")
+    seq = DNA.make_seq(seq="AAAAGGGGTTT", name="seq1")
     rna = seq.to_moltype("rna")
 
     assert "T" not in rna
@@ -2313,7 +2313,7 @@ def test_to_moltype_dna():  # ported
 
 def test_to_moltype_rna():  # ported
     """to_moltype("rna") ensures conversion from U to T"""
-    seq = RNA.make_seq("AAAAGGGGUUU", name="seq1")
+    seq = RNA.make_seq(seq="AAAAGGGGUUU", name="seq1")
     rna = seq.to_moltype("dna")
 
     assert "U" not in rna
@@ -2370,7 +2370,7 @@ def test_to_json(cls, with_offset):  # ported
 def test_offset_with_multiple_slices(DATA_DIR):  # ported
     from cogent3.util.deserialise import deserialise_object
 
-    seq = DNA.make_seq("ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC", name="22")
+    seq = DNA.make_seq(seq="ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC", name="22")
     gff3_path = DATA_DIR / "ensembl_sample.gff3"
     seq.annotate_from_gff(gff3_path)
     rd = seq[2:].to_rich_dict()
@@ -2515,7 +2515,7 @@ def test_get_drawable(DATA_DIR):  # ported
 @pytest.mark.parametrize("gc,seq", ((1, "TCCTGA"), (1, "ACGTAA---"), (2, "TCCAGG")))
 def test_has_terminal_stop_true(gc, seq):  # ported
     gc = cogent3.get_code(gc)
-    seq = cogent3.make_seq(seq, moltype="dna")
+    seq = cogent3.make_seq(seq=seq, moltype="dna")
     assert seq.has_terminal_stop(gc=gc)
 
 
@@ -2524,13 +2524,13 @@ def test_has_terminal_stop_true(gc, seq):  # ported
 )
 def test_has_terminal_stop_false(gc, seq):  # ported
     gc = cogent3.get_code(gc)
-    seq = cogent3.make_seq(seq, moltype="dna")
+    seq = cogent3.make_seq(seq=seq, moltype="dna")
     assert not seq.has_terminal_stop(gc=gc)
 
 
 def test_has_terminal_stop_strict():  # ported
     gc = cogent3.get_code(1)
-    seq = cogent3.make_seq("TCCAG", moltype="dna")
+    seq = cogent3.make_seq(seq="TCCAG", moltype="dna")
     with pytest.raises(AlphabetError):
         seq.has_terminal_stop(gc=gc, strict=True)
 
@@ -2548,7 +2548,7 @@ def test_trim_terminal_stop_true(gc, seq):  # ported
     gc = cogent3.get_code(gc)
     expect = re.sub("(TGA|AGG)(?=[-]*$)", "---" if "-" in seq else "", seq)
 
-    seq = cogent3.make_seq(seq, moltype="dna")
+    seq = cogent3.make_seq(seq=seq, moltype="dna")
     got = str(seq.trim_stop_codon(gc=gc))
     assert got == expect
 
@@ -2556,7 +2556,7 @@ def test_trim_terminal_stop_true(gc, seq):  # ported
 @pytest.mark.parametrize("gc,seq", ((1, "T?CTGC"), (2, "TCCAAG")))
 def test_trim_terminal_stop_nostop(gc, seq):  # ported
     gc = cogent3.get_code(gc)
-    seq = cogent3.make_seq(seq, moltype="dna")
+    seq = cogent3.make_seq(seq=seq, moltype="dna")
     got = seq.trim_stop_codon(gc=gc)
     assert str(got) == str(seq)
     # since there's no stop, we just return the same object
@@ -2568,27 +2568,27 @@ def test_trim_terminal_stop_nostop(gc, seq):  # ported
 )
 def test_trim_terminal_stop_false(gc, seq):  # ported
     gc = cogent3.get_code(gc)
-    seq = cogent3.make_seq(seq, moltype="dna")
+    seq = cogent3.make_seq(seq=seq, moltype="dna")
     assert str(seq.trim_stop_codon(gc=gc)) == str(seq)
 
 
 def test_trim_terminal_stop_strict():  # ported
     gc = cogent3.get_code(1)
-    seq = cogent3.make_seq("TCCAG", moltype="dna")
+    seq = cogent3.make_seq(seq="TCCAG", moltype="dna")
     with pytest.raises(AlphabetError):
         seq.trim_stop_codon(gc=gc, strict=True)
 
 
 @pytest.mark.parametrize("cast", (int, numpy.int32, numpy.int64, numpy.uint8))
 def test_index_a_seq(cast):  # ported
-    seq = cogent3.make_seq("TCCAG", moltype="dna")
+    seq = cogent3.make_seq(seq="TCCAG", moltype="dna")
     got = seq[cast(1)]
     assert isinstance(got, Sequence)
 
 
 @pytest.mark.parametrize("cast", (float, numpy.float32))
 def test_index_a_seq_float_fail(cast):  # ported
-    seq = cogent3.make_seq("TCCAG", moltype="dna")
+    seq = cogent3.make_seq(seq="TCCAG", moltype="dna")
     index = cast(1)
     with pytest.raises(TypeError):
         seq[index]
@@ -2597,14 +2597,14 @@ def test_index_a_seq_float_fail(cast):  # ported
 @pytest.mark.parametrize("moltype", ("dna", "protein"))
 def test_same_moltype(moltype):  # ported
     moltype = get_moltype(moltype)
-    seq = moltype.make_seq("TCCAG")
+    seq = moltype.make_seq(seq="TCCAG")
     got = seq.to_moltype(moltype)
     assert got is seq
 
 
 def test_gapped_by_map_segment_iter():  # ported
     moltype = get_moltype("dna")
-    m, seq = moltype.make_seq("-TCC--AG").parse_out_gaps()
+    m, seq = moltype.make_seq(seq="-TCC--AG").parse_out_gaps()
     g = list(seq.gapped_by_map_segment_iter(m, allow_gaps=True, recode_gaps=False))
     assert g == ["-", "TCC", "--", "AG"]
 
@@ -2614,7 +2614,7 @@ def test_gapped_by_map_segment_iter():  # ported
 @pytest.mark.parametrize("start_stop", ((None, None), (3, 7)))
 def test_copied_parent_coordinates(sliced, rev, start_stop):  # ported
     orig_name = "orig"
-    seq = DNA.make_seq("ACGGTGGGAC", name=orig_name)
+    seq = DNA.make_seq(seq="ACGGTGGGAC", name=orig_name)
     start, stop = start_stop
     start = start or 0
     stop = stop or len(seq)
@@ -2635,7 +2635,7 @@ def test_copied_parent_coordinates(sliced, rev, start_stop):  # ported
 
 @pytest.mark.parametrize("rev", (False, True))
 def test_parent_coordinates(rev):  # ported
-    seq = DNA.make_seq("ACGGTGGGAC")
+    seq = DNA.make_seq(seq="ACGGTGGGAC")
     seq = seq[1:1]
     if rev:
         seq = seq.rc()
@@ -2731,7 +2731,7 @@ def test_sequences_propogates_seqid():  # ported for Sequence and SeqView
 
 
 def test_make_seq_assigns_to_seqview():  # ported
-    seq = cogent3.make_seq("ACGT", name="s1")
+    seq = cogent3.make_seq(seq="ACGT", name="s1")
     assert seq.name == seq._seq.seqid == "s1"
 
 

--- a/tests/test_draw/test_dotplot.py
+++ b/tests/test_draw/test_dotplot.py
@@ -2,21 +2,24 @@ from unittest import TestCase
 
 import numpy
 
-from cogent3 import DNA, make_unaligned_seqs
+from cogent3 import get_moltype, make_unaligned_seqs
 from cogent3.core.alignment import Aligned, ArrayAlignment
 from cogent3.core.location import IndelMap
 from cogent3.draw.dotplot import Dotplot, _convert_input, get_align_coords
 
 
+DNA = get_moltype("dna")
+
+
 class TestUtilFunctions(TestCase):
     def test_len_seq(self):
         """returns length of sequence minus gaps"""
-        m, seq = DNA.make_seq("ACGGT--A").parse_out_gaps()
+        m, _ = DNA.make_seq(seq="ACGGT--A").parse_out_gaps()
         self.assertEqual(m.parent_length, 6)
 
     def test_convert_input(self):
         """converts data for dotplotting"""
-        m, seq = DNA.make_seq("ACGGT--A").parse_out_gaps()
+        m, seq = DNA.make_seq(seq="ACGGT--A").parse_out_gaps()
         aligned_seq = Aligned(m, seq)
         mapped_gap, new_seq = _convert_input(aligned_seq, None)
         self.assertIs(new_seq.moltype, DNA)
@@ -32,28 +35,28 @@ class TestUtilFunctions(TestCase):
         # ACGGT--A
         #   012345
         # --GGTTTA
-        m1, seq1 = DNA.make_seq("ACGGT--A").parse_out_gaps()
-        m2, seq2 = DNA.make_seq("--GGTTTA").parse_out_gaps()
+        m1, seq1 = DNA.make_seq(seq="ACGGT--A").parse_out_gaps()
+        m2, seq2 = DNA.make_seq(seq="--GGTTTA").parse_out_gaps()
         path = get_align_coords(m1, m2)
         expect = [2, 4, None, 5, 5], [0, 2, None, 5, 5]
         self.assertEqual(path.get_coords(), expect)
 
         # we have no gaps, so coords will be None
-        m1, s1 = seq1.parse_out_gaps()
-        m2, s2 = seq2.parse_out_gaps()
+        m1, _ = seq1.parse_out_gaps()
+        m2, _ = seq2.parse_out_gaps()
         path = get_align_coords(m1, m2)
         self.assertEqual(path.get_coords(), ([], []))
 
         # unless we indicate the seqs came from an Alignment
-        m1, seq1 = DNA.make_seq("ACGGTTTA").parse_out_gaps()
-        m2, seq2 = DNA.make_seq("GGGGTTTA").parse_out_gaps()
+        m1, seq1 = DNA.make_seq(seq="ACGGTTTA").parse_out_gaps()
+        m2, seq2 = DNA.make_seq(seq="GGGGTTTA").parse_out_gaps()
         paths = get_align_coords(m1, m2, aligned=True)
         # display ranges are inclusive, thus length - 1
         self.assertEqual(paths.get_coords(), ([0, len(seq1) - 1], [0, len(seq1) - 1]))
 
         # raises an exception if the Aligned seqs are different lengths
-        m1, seq1 = DNA.make_seq("ACGGTTTA").parse_out_gaps()
-        m2, seq2 = DNA.make_seq("GGGGTT").parse_out_gaps()
+        m1, seq1 = DNA.make_seq(seq="ACGGTTTA").parse_out_gaps()
+        m2, seq2 = DNA.make_seq(seq="GGGGTT").parse_out_gaps()
         with self.assertRaises(AssertionError):
             get_align_coords(m1, m2, aligned=True)
 

--- a/tests/test_evolve/test_distance.py
+++ b/tests/test_evolve/test_distance.py
@@ -743,7 +743,8 @@ class DistancesTests(TestCase):
                 "b": "GTACGTACGTAC",
                 "c": "GTACGTACGTTC",
                 "e": "GTACGTACTGGT",
-            }
+            },
+            moltype="dna",
         )
         self.collection = make_unaligned_seqs(
             data={
@@ -751,7 +752,8 @@ class DistancesTests(TestCase):
                 "b": "GTACGTACGTAC",
                 "c": "GTACGTACGTTC",
                 "e": "GTACGTACTGGT",
-            }
+            },
+            moltype="dna",
         )
 
     def assertDistsAlmostEqual(self, expected, observed, precision=4):

--- a/tests/test_parse/test_dialign.py
+++ b/tests/test_parse/test_dialign.py
@@ -87,7 +87,7 @@ class TestDialign(unittest.TestCase):
         }
         self.aln_seqs = {}
         for name, seq in list(aln_seqs.items()):
-            self.aln_seqs[name] = PROTEIN.make_seq(seq, name=name)
+            self.aln_seqs[name] = PROTEIN.make_seq(seq=seq, name=name)
         self.QualityScores = "00000005888882222229999999900000006666666666633334000333345555333333000000000000000"
 
     def test_line_split(self):

--- a/tests/test_util/test_deserialise.py
+++ b/tests/test_util/test_deserialise.py
@@ -692,7 +692,7 @@ def test_roundtrip_TN93_model_result():
 def test_roundtrip_seq(mtype):
     """seq to_json enables roundtrip"""
     mtype = moltype.get_moltype(mtype)
-    seq = mtype.make_seq("ACGGTCGG", "label", info={"something": 3})
+    seq = mtype.make_seq(seq="ACGGTCGG", name="label", info={"something": 3})
     got = deserialise_object(seq.to_json())
     assert got.info.something == 3
     assert got.name == "label"


### PR DESCRIPTION
DEV:
Misc changes to find middle ground between old and new API, i.e, 
- fixing occurrences of `make_seq` which do not use keyword args 
- fixing occurrences of creating seqs without a moltype 
- using `get_moltype` instead of directly importing a moltype in order to allow code to respect setting `new_type=True` with an environment variable 

DOC
- documentation of the existence of new API 