### PR TITLE
MAINT: revert `charset-normalizer` dependency to `chardet`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,17 @@
 
+<a id='changelog-2024.7.19a4'></a>
+# Changes in release "2024.7.19a4"
+
+This is a minor bug fix release.
+
+## Contributors
+
+- Contribution from @rmcar17 on fixing an encoding error when loading small newick trees.
+
+## BUG
+
+- Fixed an issue with `load_tree` incorrectly detecting the encoding of very small newick files.
+
 <a id='changelog-2024.7.19a3'></a>
 # Changes in release "2024.7.19a3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 keywords = ["biology", "genomics", "statistics", "phylogeny", "evolution", "bioinformatics"]
 readme = "README.md"
 license = { file = "LICENSE" }
-dependencies = ["charset-normalizer",
+dependencies = ["chardet",
         "numpy",
         "numba>0.53; python_version>='3.9' and python_version <'3.12'",
         "numba>0.54; python_version>='3.10' and python_version <'3.12'",

--- a/src/cogent3/_version.py
+++ b/src/cogent3/_version.py
@@ -1,2 +1,2 @@
 # remember to update version in pyproject.toml too!
-__version__ = "2024.7.19a3"
+__version__ = "2024.7.19a4"

--- a/src/cogent3/util/io.py
+++ b/src/cogent3/util/io.py
@@ -13,7 +13,7 @@ from urllib.parse import ParseResult, urlparse
 from urllib.request import urlopen
 from zipfile import ZipFile
 
-from charset_normalizer import detect
+from chardet import detect
 
 from cogent3.util.misc import _wout_period
 

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -2324,10 +2324,10 @@ def test_load_tree_bad_encoding():
     incorrectly detected the encoding of a file as UTF-16LE.
     """
     newick = "(a,b);"
-    tree = make_tree(newick)
 
-    with NamedTemporaryFile("+w", delete_on_close=False, suffix=".tre") as f:
-        f.write(tree.get_newick())
-        f.close()
+    with TemporaryDirectory(dir=".") as dirname:
+        tree_path = os.path.join(dirname, "tree.tree")
+        with open(tree_path, "wb") as f:
+            f.write(newick.encode("ascii"))
 
-        assert load_tree(f.name).get_newick() == newick
+        assert load_tree(tree_path).get_newick() == newick

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import random
 from copy import copy, deepcopy
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import pytest

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import random
 from copy import copy, deepcopy
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
 
 import pytest
@@ -2316,3 +2316,18 @@ def test_parser():
     tidied = tree.get_newick(with_distances=1)
     assert tidied == nice
     assert tree.get_node_matching_name("pair").params["other"] == ["com\nment"]
+
+
+def test_load_tree_bad_encoding():
+    """
+    charset_normalizer rather than chardet as a dependency
+    incorrectly detected the encoding of a file as UTF-16LE.
+    """
+    newick = "(a,b);"
+    tree = make_tree(newick)
+
+    with NamedTemporaryFile("+w", delete_on_close=False, suffix=".tre") as f:
+        f.write(tree.get_newick())
+        f.close()
+
+        assert load_tree(f.name).get_newick() == newick


### PR DESCRIPTION
Closes #1984 

`charset-normalizer` incorrectly detects the encoding of some small newick files such as for the string `(a,b);`. 

This adds a test for such a case and reverts the dependency on `charset-normalizer` back to `chardet`.