### PR TITLE
API: remove `make_seq` from SeqsData

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -3382,8 +3382,7 @@ class _IndexableSeqs:
 
     def __repr__(self) -> str:
         one_seq = self[self.parent.names[0]]
-        one_seq = f"{one_seq!r}, ... " if self.parent.num_seqs > 1 else f"{one_seq!r}"
-        return f"({one_seq}), {self.parent.num_seqs} x seqs"
+        return f"({one_seq!r}, + {self.parent.num_seqs -1} seqs)"
 
     def __len__(self) -> int:
         return self.parent.num_seqs

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -3399,7 +3399,8 @@ class _IndexableSeqs:
 
     def __repr__(self) -> str:
         one_seq = self[self.parent.names[0]]
-        return f"({one_seq!r}, {self.parent.num_seqs - 1} x seqs)"
+        one_seq = f"{one_seq!r}, ... " if self.parent.num_seqs > 1 else f"{one_seq!r}"
+        return f"[{one_seq}], {self.parent.num_seqs} x seqs"
 
     def __len__(self) -> int:
         return self.parent.num_seqs

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -29,16 +29,26 @@ def test_indexing_seqs_prop(func, index):
     assert str(got) == raw["seq1"]
 
 
-@pytest.mark.parametrize(
-    "func", (new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs)
-)
-def test_indexing_seqs_repr(func):
+def test_sequence_collection_indexing_seqs_repr():
     names = ["seq1", "seq2", "seq3"]
     seqs = "GGGTAC", "GTTTGC", "ACGTAC"
     raw = dict(zip(names, seqs))
-    obj = func(raw, moltype="dna")
+    obj = new_alignment.make_unaligned_seqs(raw, moltype="dna")
     got = repr(obj.seqs)
-    print(got, type(obj.seqs))
+    class_name = obj.seqs[0].__class__.__name__
+    expect = f"[{class_name}({seqs[0]}), ... ], {len(names)} x seqs"
+    assert got == expect
+
+
+def test_alignment_indexing_seqs_repr():
+    names = ["seq1", "seq2", "seq3"]
+    seqs = "GGGTAC", "GTTTGC", "ACGTAC"
+    raw = dict(zip(names, seqs))
+    obj = new_alignment.make_aligned_seqs(raw, moltype="dna")
+    got = repr(obj.seqs)
+    class_name = obj.seqs[0].__class__.__name__
+    expect = f"[{class_name}(map=[]/6, data={seqs[0]}), ... ], {len(names)} x seqs"
+    assert got == expect
 
 
 @pytest.fixture(scope="session")
@@ -307,7 +317,7 @@ def test_seqs_data_getitem_str(dna_sd, seq):
 
 
 @pytest.mark.parametrize("idx", (0, 1))
-def test_seqs_data_getitem_int(dna_sd, idx):
+def test_seqs_data_getitem_int(str_seqs_dict, dna_sd, idx):
     got = dna_sd[idx]
     assert isinstance(got, new_alignment.SeqDataView)
     assert got.parent == dna_sd

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -16,41 +16,6 @@ from cogent3.util.deserialise import deserialise_object
 from cogent3.util.misc import get_object_provenance
 
 
-@pytest.mark.parametrize(
-    "func", (new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs)
-)
-@pytest.mark.parametrize("index", (True, False))
-def test_indexing_seqs_prop(func, index):
-    names = ["seq1", "seq2", "seq3"]
-    seqs = "GGGTAC", "GTTTGC", "ACGTAC"
-    raw = dict(zip(names, seqs))
-    obj = func(raw, moltype="dna")
-    got = obj.seqs[0 if index else "seq1"]
-    assert str(got) == raw["seq1"]
-
-
-def test_sequence_collection_indexing_seqs_repr():
-    names = ["seq1", "seq2", "seq3"]
-    seqs = "GGGTAC", "GTTTGC", "ACGTAC"
-    raw = dict(zip(names, seqs))
-    obj = new_alignment.make_unaligned_seqs(raw, moltype="dna")
-    got = repr(obj.seqs)
-    class_name = obj.seqs[0].__class__.__name__
-    expect = f"[{class_name}({seqs[0]}), ... ], {len(names)} x seqs"
-    assert got == expect
-
-
-def test_alignment_indexing_seqs_repr():
-    names = ["seq1", "seq2", "seq3"]
-    seqs = "GGGTAC", "GTTTGC", "ACGTAC"
-    raw = dict(zip(names, seqs))
-    obj = new_alignment.make_aligned_seqs(raw, moltype="dna")
-    got = repr(obj.seqs)
-    class_name = obj.seqs[0].__class__.__name__
-    expect = f"[{class_name}(map=[]/6, data={seqs[0]}), ... ], {len(names)} x seqs"
-    assert got == expect
-
-
 @pytest.fixture(scope="session")
 def tmp_path(tmpdir_factory):
     return tmpdir_factory.mktemp("tmp_path")
@@ -3656,3 +3621,58 @@ def test_alignment_indexing_string(alignment, seqid):
     got = alignment.seqs[seqid]
     assert isinstance(got, new_alignment.Aligned)
     assert str(got) == alignment.to_dict()[seqid]
+
+
+## Tests of _IndexableSeqs
+
+
+@pytest.fixture
+def names_seqs():
+    names = ["seq1", "seq2", "seq3"]
+    seqs = ["GGGTAC", "GTTTGC", "ACGTAC"]
+    return names, seqs
+
+
+@pytest.mark.parametrize(
+    "func", (new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs)
+)
+@pytest.mark.parametrize("index", (True, False))
+def test_indexing_seqs_prop(names_seqs, func, index):
+    names, seqs = names_seqs
+    raw = dict(zip(names, seqs))
+    obj = func(raw, moltype="dna")
+    got = obj.seqs[0 if index else "seq1"]
+    assert str(got) == raw["seq1"]
+
+
+def test_sequence_collection_indexing_seqs_repr(names_seqs):
+    names, seqs = names_seqs
+    raw = dict(zip(names, seqs))
+    obj = new_alignment.make_unaligned_seqs(raw, moltype="dna")
+    got = repr(obj.seqs)
+    class_name = obj.seqs[0].__class__.__name__
+    expect = f"({class_name}({seqs[0]}), ... ), {len(names)} x seqs"
+    assert got == expect
+
+
+def test_alignment_indexing_seqs_repr(names_seqs):
+    names, seqs = names_seqs
+    raw = dict(zip(names, seqs))
+    obj = new_alignment.make_aligned_seqs(raw, moltype="dna")
+    got = repr(obj.seqs)
+    class_name = obj.seqs[0].__class__.__name__
+    expect = f"({class_name}(map=[]/6, data={seqs[0]}), ... ), {len(names)} x seqs"
+    assert got == expect
+
+
+@pytest.mark.parametrize(
+    "func", (new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs)
+)
+def test_indexing_seqs_iter(names_seqs, func):
+    names, seqs = names_seqs
+    raw = dict(zip(names, seqs))
+    obj = func(raw, moltype="dna")
+    # exercise __iter__
+    got = list(map(str, obj.seqs))
+    expect = list(seqs)
+    assert got == expect

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -3651,7 +3651,7 @@ def test_sequence_collection_indexing_seqs_repr(names_seqs):
     obj = new_alignment.make_unaligned_seqs(raw, moltype="dna")
     got = repr(obj.seqs)
     class_name = obj.seqs[0].__class__.__name__
-    expect = f"({class_name}({seqs[0]}), ... ), {len(names)} x seqs"
+    expect = f"({class_name}({seqs[0]}), + {len(names) - 1} seqs)"
     assert got == expect
 
 
@@ -3661,7 +3661,7 @@ def test_alignment_indexing_seqs_repr(names_seqs):
     obj = new_alignment.make_aligned_seqs(raw, moltype="dna")
     got = repr(obj.seqs)
     class_name = obj.seqs[0].__class__.__name__
-    expect = f"({class_name}(map=[]/6, data={seqs[0]}), ... ), {len(names)} x seqs"
+    expect = f"({class_name}(map=[]/6, data={seqs[0]}), + {len(names)-1} seqs)"
     assert got == expect
 
 


### PR DESCRIPTION
API changes
- remove `make_seq` from SeqsData
- `SeqsData.__getitem__` now returns a `SeqDataView` 