### PR TITLE
BUG: fixed a bug in jupyter notebook display of big tables

### DIFF
--- a/src/cogent3/util/table.py
+++ b/src/cogent3/util/table.py
@@ -745,15 +745,26 @@ class Table:
                     str(HE(HE("...", "span", css_classes=[css_class]), "td"))
                 )
 
-            ellipsis = str(HE("".join(ellipsis), "tr", css_classes="ellipsis"))
             num_rows = 0
+            col_num = 0
             for idx in range(len(html)):
                 item = html[idx]
                 if "<tr>" in item:
                     num_rows += 1
-                if num_rows == head:
-                    html.insert(idx + 1, ellipsis)
-                    break
+                if "<th>" in item:
+                    num_col = item.count("<th>")
+                    ellipsis_slice = str(
+                        HE(
+                            "".join(ellipsis[col_num : col_num + num_col]),
+                            "tr",
+                            css_classes="ellipsis",
+                        )
+                    )
+                    col_num += num_col
+                    num_rows = 0
+                elif num_rows == head and ellipsis_slice:
+                    html.insert(idx + 1, ellipsis_slice)
+                    ellipsis_slice = ""
 
         html.insert(-1, shape_info)
         html = "\n".join(html)

--- a/tests/test_util/test_table.py
+++ b/tests/test_util/test_table.py
@@ -2018,3 +2018,21 @@ def test_outer_join_col_naming(t2, t3):
     expect = list(t2.header) + [f"{col_prefix}{c}" for c in t3.header]
     assert list(got.header) == expect
     assert got.shape[0] == t2.shape[0] * t3.shape[0]
+
+
+def test_repr_html_continuation():
+    # should have an ellipsis row for every c ontinued table
+    t8_header = ["edge.name", "edge.parent", "length", "x", "y", "z"]
+    t8_rows = [
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+    ]
+    table = make_table(header=t8_header, data=t8_rows, max_width=30, title="a title")
+    # with 30 characters wide there are 3 subtables, so we expect 3 ellipsis rows
+    table.set_repr_policy(head=2, tail=2)
+    assert table._repr_html_().count('<tr class="ellipsis">') == 3


### PR DESCRIPTION
[FIXED] If a table was very wide it was split into subsequent blocks.
    For tables with many rows an ellipsis line was added but this line
    was only added to the first table. This is now fixed.

## Summary by Sourcery

Fix the display of wide tables in Jupyter Notebook by ensuring ellipsis lines are added to all continued tables, and add a test to verify this behavior.

Bug Fixes:
- Fix the issue where ellipsis lines were only added to the first table when displaying wide tables in Jupyter Notebook.

Tests:
- Add a test to ensure that an ellipsis row is included for every continued table in the HTML representation.