### PR TITLE
ENH: simplify display from available_apps()

### DIFF
--- a/doc/app/app_overview/available-apps.rst
+++ b/doc/app/app_overview/available-apps.rst
@@ -16,3 +16,6 @@ The ``name_filter`` argument can be used to display only the apps that match a s
 .. jupyter-execute::
 
     available_apps(name_filter="load")
+
+
+.. note:: The first column lists the package providing the app.

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -34,9 +34,8 @@ def _get_extension_attr(extension):
         )
 
     _types = _make_types(obj)
-
     return [
-        extension.module_name,
+        extension.module_name.split(".")[0],
         extension.name,
         is_app_composable(obj),
         _doc_summary(obj.__doc__ or ""),
@@ -90,7 +89,7 @@ def available_apps(name_filter: str | None = None) -> Table:
             # probably a local scope issue in testing!
             rows.append(_get_extension_attr(extension))
 
-    header = ["module", "name", "composable", "doc", "input type", "output type"]
+    header = ["package", "name", "composable", "doc", "input type", "output type"]
     return Table(header=header, data=rows)
 
 

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -172,3 +172,4 @@ def test_available_apps_package():
     app_name_filter: str = "model"
     filtered_apps = available_apps(app_name_filter)
     assert filtered_apps.columns["package"][0] == "cogent3"
+    assert all("." not in pkg for pkg in filtered_apps.columns["package"])

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -165,3 +165,10 @@ def test_available_apps_filter():
     assert sum(app_name_filter in n for n in filtered_apps.columns["name"]) == len(
         filtered_apps
     )
+
+
+def test_available_apps_package():
+    """available apps lists just the package"""
+    app_name_filter: str = "model"
+    filtered_apps = available_apps(app_name_filter)
+    assert filtered_apps.columns["package"][0] == "cogent3"


### PR DESCRIPTION
[CHANGED] Renamed the column "module" as "package". Now only lists the package,
    not the fully resolved path to the app.

## Summary by Sourcery

Simplify the display of available apps by renaming the 'module' column to 'package' and listing only the package name. Add a test to ensure the correct package name is displayed.

Enhancements:
- Simplify the display of available apps by renaming the column 'module' to 'package' and listing only the package name instead of the full path.

Tests:
- Add a test to verify that available apps list only the package name.