### PR TITLE
ENH: add function to split the internal name field in newick into name and support value, fixes #2045

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2206,7 +2206,7 @@ def split_name_and_support(name_field: str | None) -> tuple[str | None, float | 
     # handle case where mutiple '/' in the name field
     elif len(support) > 1:
         raise ValueError(
-            f"Support value at node: {name!r} should be int or float not {"/".join(support)!r}."
+            f"Support value at node: {name!r} should be int or float not {'/'.join(support)!r}."
         )
     else:
         support_value = None

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2183,6 +2183,7 @@ def split_name_and_support(name_field: str | None) -> tuple[str | None, float | 
     """Handle cases in the Newick format where an internal node name field
     contains a name or/and support value, like 'edge.98/100'.
     """
+    # handle the case where the name field is an empty string or None
     if not name_field:
         return None, None
 
@@ -2196,20 +2197,19 @@ def split_name_and_support(name_field: str | None) -> tuple[str | None, float | 
             support = float(parts[1])
         except ValueError as e:
             raise ValueError(
-                f"Support value at node: {name} should be int/float"
+                f"Support value at node: {name} should be int or float."
             ) from e
         return name, support
-    # for name fields containing only one element,
-    # treat the element that can be converted to a float as a support value
     elif len(parts) == 1:
         try:
             support = float(parts[0])
             return None, support
         except ValueError:
             return parts[0], None
-    # handle the case where the name field is an empty string
     else:
-        return None, None
+        raise ValueError(
+            f"Invalid name field: {name_field}. It should contain at most one forward slash."
+        )
 
 
 class TreeBuilder(object):

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2255,9 +2255,9 @@ class TreeBuilder(object):
     def create_edge(self, children, name_field, params, name_loaded=True):
         """Callback for newick parser"""
         # split name and support by forward slash if present
-        splitted = split_name_and_support(name_field)
-        name = splitted[0]
-        params["support"] = splitted[1]
+        name, support = split_name_and_support(name_field)
+        if support is not None:
+            params["support"] = support
 
         if children is None:
             children = []

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2252,12 +2252,9 @@ class TreeBuilder(object):
                 children, edge.name, params, name_loaded=edge.name_loaded
             )
 
-    def create_edge(self, children, name_field, params, name_loaded=True):
+    def create_edge(self, children, name, params, name_loaded=True):
         """Callback for newick parser"""
-        # split name and support by forward slash if present
-        name, support = split_name_and_support(name_field)
-        if support is not None:
-            params["support"] = support
+        # TODO: split name and support by forward slash if present
 
         if children is None:
             children = []

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -2355,5 +2355,6 @@ def test_split_name_and_support_invalid_support():
 
 
 def test_split_name_and_support_invalid_name():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         split_name_and_support("edge.98/24/invalid")
+    assert "Invalid name format" in str(excinfo.value)

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -14,7 +14,8 @@ from numpy.testing import assert_allclose, assert_equal
 
 from cogent3 import load_tree, make_tree, open_
 from cogent3._version import __version__
-from cogent3.core.tree import PhyloNode, TreeError, TreeNode
+from cogent3.core.tree import (PhyloNode, TreeError, TreeNode,
+                               split_name_and_support)
 from cogent3.maths.stats.test import correlation
 from cogent3.parse.tree import DndParser
 from cogent3.util.misc import get_object_provenance
@@ -2332,3 +2333,27 @@ def test_load_tree_bad_encoding():
             f.write(newick.encode("ascii"))
 
         assert load_tree(tree_path).get_newick() == newick
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    (
+        (None, (None, None)),
+        ("", (None, None)),
+        ("edge.98/24", ("edge.98", 24.0)),
+        ("edge.98", ("edge.98", None)),
+        ("24", (None,24.0)),
+    ),
+)
+def test_split_name_and_support(name, expected):
+    assert split_name_and_support(name) == expected
+
+
+def test_split_name_and_support_invalid_support():
+    with pytest.raises(ValueError):
+        split_name_and_support("edge.98/invalid")
+
+
+def test_split_name_and_support_invalid_name():
+    with pytest.raises(ValueError):
+        split_name_and_support("edge.98/24/invalid")

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -2342,19 +2342,14 @@ def test_load_tree_bad_encoding():
         ("", (None, None)),
         ("edge.98/24", ("edge.98", 24.0)),
         ("edge.98", ("edge.98", None)),
-        ("24", (None,24.0)),
+        ("24", (None, 24.0)),
     ),
 )
 def test_split_name_and_support(name, expected):
     assert split_name_and_support(name) == expected
 
 
-def test_split_name_and_support_invalid_support():
+@pytest.mark.parametrize("invalid", ("edge.98/invalid", "edge.98/23/invalid"))
+def test_split_name_and_support_invalid_support(invalid):
     with pytest.raises(ValueError):
-        split_name_and_support("edge.98/invalid")
-
-
-def test_split_name_and_support_invalid_name():
-    with pytest.raises(ValueError) as excinfo:
-        split_name_and_support("edge.98/24/invalid")
-    assert "Invalid name format" in str(excinfo.value)
+        split_name_and_support(invalid)


### PR DESCRIPTION
#2045

## Summary by Sourcery

Add a new function to split internal node name fields in Newick format into separate name and support values, and implement corresponding tests to ensure correct functionality.

New Features:
- Introduce a function `split_name_and_support` to handle Newick format internal node name fields that contain both a name and a support value.

Tests:
- Add parameterized tests for the `split_name_and_support` function to verify its behavior with various input cases, including valid and invalid formats.