### PR TITLE
ENH: extract support measures on tree nodes from newick strings

### DIFF
--- a/changelog.d/20241023_080011_Gavin.Huttley.md
+++ b/changelog.d/20241023_080011_Gavin.Huttley.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Contributors
+
+- @YapengLang added the key function for parsing support from newick format
+  to tree object 💪
+
+
+### ENH
+
+- cogent3 now supports parsing from newick format with node support
+  statistics. The support measure is stored in `node.params["support"]`.
+
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -14,8 +14,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from cogent3 import load_tree, make_tree, open_
 from cogent3._version import __version__
-from cogent3.core.tree import (PhyloNode, TreeError, TreeNode,
-                               split_name_and_support)
+from cogent3.core.tree import PhyloNode, TreeError, TreeNode, split_name_and_support
 from cogent3.maths.stats.test import correlation
 from cogent3.parse.tree import DndParser
 from cogent3.util.misc import get_object_provenance
@@ -2353,3 +2352,23 @@ def test_split_name_and_support(name, expected):
 def test_split_name_and_support_invalid_support(invalid):
     with pytest.raises(ValueError):
         split_name_and_support(invalid)
+
+
+def test_phylonode_support():
+    tip_names = [str(i) for i in range(1, 13)]
+    tree = make_tree(
+        treestring="(1,(((2,3),4)/53,(5,((6,(7,(8,9))def/25),(10,11)abc))),12);"
+    )
+    assert tree.get_tip_names() == tip_names
+    # parent of 4 is node with only support value
+    just_support = tree.get_node_matching_name("4").parent
+    assert just_support.params["support"] == 53.0
+    # parent of 10 has a node name only
+    just_name = tree.get_node_matching_name("10").parent
+    assert just_name.name == "abc"
+    assert "support" not in just_name.params
+    # the node with name "def/25" correctly resoloved into node
+    # name "def" and support 25.0
+    name_and_support = tree.get_node_matching_name("def")
+    assert name_and_support.name == "def"  # bit redundant given selection process
+    assert name_and_support.params["support"] == 25.0


### PR DESCRIPTION
[NEW] handled automatically while parsing, uses the new `split_name_and_support()`
    function.

[NEW] added scriv changelog snippet

[CHANGED] modernised length property and no longer inherit from
    object

## Summary by Sourcery

Enhance the tree parsing functionality to extract and store node support measures from Newick strings. Modernize the TreeNode class by removing the object inheritance and updating the length property. Add tests for the new parsing functionality and update the documentation with a changelog entry.

New Features:
- Add support for parsing node support measures from Newick strings in tree objects.

Enhancements:
- Modernize the TreeNode class by removing inheritance from object and updating the length property to use Python's property decorator.

Documentation:
- Add a new changelog entry describing the enhancement of parsing node support from Newick format.

Tests:
- Add tests for the new functionality of parsing node support measures from Newick strings.