### PR TITLE
BUG: array alignments raise exception if seq has incorrect moltype

### DIFF
--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -666,12 +666,20 @@ class CharAlphabet(Alphabet):
         would produce the result [1,1,2,0], returning the index of each
         element in the input.
         """
-        return array(
+        result = array(
             memoryview(
                 bytearray(data.translate(self._chars_to_indices).encode("utf8"))
             ),
             dtype=self.array_type,
         )
+        # check we are within alphabet range
+        max_val = len(self)
+        if (result >= max_val).any():
+            invalid_chars = result >= max_val
+            invalid = array(list(data))[invalid_chars]
+            raise AlphabetError(f"invalid character(s) found: {invalid.tolist()}")
+
+        return result
 
     @to_indices.register
     def _(self, data: bytes) -> ndarray:

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -213,7 +213,7 @@ class Enumeration(tuple):
         try:
             self.to_indices(seq)
             return True
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, AlphabetError):
             return False
 
     def from_indices(self, data):
@@ -587,7 +587,7 @@ class CharAlphabet(Alphabet):
                 return True
             ind = self.to_indices(seq)
             return max(ind) < len(self) and min(ind) >= 0
-        except (TypeError, KeyError):
+        except (TypeError, KeyError, AlphabetError):
             return False
 
     def to_chars(self, data):

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -2579,3 +2579,19 @@ def test_sequence_serialisation_round_trip(moltype, data):
     got = deserialise_object(rd)
     assert isinstance(got, type(seq))
     assert got.to_rich_dict() == seq.to_rich_dict()
+
+
+@pytest.fixture
+def aa_moltype(DATA_DIR, tmp_path):
+    # make a directory that contains both DNA and protein
+    outpath = tmp_path / "aa.fa"
+    aln = cogent3.load_aligned_seqs(DATA_DIR / "brca1_5.paml", moltype="dna")
+    aa = aln.get_translation()
+    aa.write(outpath)
+    return outpath
+
+
+def test_load_invalid_moltype(aa_moltype):
+    with pytest.raises(AssertionError):
+        # this should be an AlphabetError
+        cogent3.load_seq(aa_moltype, moltype="dna", new_type=True)


### PR DESCRIPTION
## Summary by Sourcery

Fix sequence loading to raise AlphabetError for invalid characters when the moltype is incorrect, and add a test to ensure this behavior.

Bug Fixes:
- Fix exception raised when loading sequences with incorrect moltype by raising AlphabetError for invalid characters.

Tests:
- Add test to verify that loading sequences with an invalid moltype raises an AlphabetError.