### PR TITLE
ENH: handled comparison between nodes where name is None

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -132,7 +132,6 @@ class TreeNode:
         other_name = other.name or ""
 
         return self_name < other_name
-        
 
     def __gt__(self, other):
         self_name = self.name or ""

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -128,10 +128,17 @@ class TreeNode:
     # return self.name != other.name
 
     def __lt__(self, other):
-        return self.name < other.name
+        self_name = self.name or ""
+        other_name = other.name or ""
+
+        return self_name < other_name
+        
 
     def __gt__(self, other):
-        return self.name > other.name
+        self_name = self.name or ""
+        other_name = other.name or ""
+
+        return self_name > other_name
 
     def compare_name(self, other):
         """Compares TreeNode by name"""

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1232,12 +1232,10 @@ class TreeNodeTests(TestCase):
     def test_treenode_comparison_with_none_name(self):
         assert self.Empty < self.Single
         assert self.Single > self.Empty
-        assert self.Empty == TreeNode(name=None)
         assert self.Single > TreeNode(name=None)
         assert TreeNode(name=None) < self.Single
         assert TreeNode(name="test") > self.Empty
         assert self.Empty < TreeNode(name="test")
-
 
 
 class PhyloNodeTests(TestCase):

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1228,6 +1228,11 @@ class TreeNodeTests(TestCase):
 
         result = self.t.compare_by_subsets(self.TreeRoot)
         self.assertEqual(result, 1)
+    def test_treenode_comparison_with_none_name(self):
+        # check that comparison with name=None is handled as "" correctly
+        assert self.Empty < self.Single
+        assert self.Single > self.Empty
+
 
 
 class PhyloNodeTests(TestCase):

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1228,10 +1228,14 @@ class TreeNodeTests(TestCase):
 
         result = self.t.compare_by_subsets(self.TreeRoot)
         self.assertEqual(result, 1)
-    def test_treenode_comparison_with_none_name(self):
-        # check that comparison with name=None is handled as "" correctly
-        assert self.Empty < self.Single
-        assert self.Single > self.Empty
+def test_treenode_comparison_with_none_name(self):
+    assert self.Empty < self.Single
+    assert self.Single > self.Empty
+    assert self.Empty == TreeNode(name=None)
+    assert self.Single > TreeNode(name=None)
+    assert TreeNode(name=None) < self.Single
+    assert TreeNode(name="test") > self.Empty
+    assert self.Empty < TreeNode(name="test")
 
 
 

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1228,14 +1228,15 @@ class TreeNodeTests(TestCase):
 
         result = self.t.compare_by_subsets(self.TreeRoot)
         self.assertEqual(result, 1)
-def test_treenode_comparison_with_none_name(self):
-    assert self.Empty < self.Single
-    assert self.Single > self.Empty
-    assert self.Empty == TreeNode(name=None)
-    assert self.Single > TreeNode(name=None)
-    assert TreeNode(name=None) < self.Single
-    assert TreeNode(name="test") > self.Empty
-    assert self.Empty < TreeNode(name="test")
+
+    def test_treenode_comparison_with_none_name(self):
+        assert self.Empty < self.Single
+        assert self.Single > self.Empty
+        assert self.Empty == TreeNode(name=None)
+        assert self.Single > TreeNode(name=None)
+        assert TreeNode(name=None) < self.Single
+        assert TreeNode(name="test") > self.Empty
+        assert self.Empty < TreeNode(name="test")
 
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance TreeNode comparison methods to handle cases where the name attribute is None by treating it as an empty string, and add corresponding test cases to ensure correct behavior.

Enhancements:
- Handle comparison between TreeNode objects where the name attribute is None by treating None as an empty string.

Tests:
- Add test cases to verify TreeNode comparison behavior when the name attribute is None.