### PR TITLE
MAINT: old SequenceCollection.take_seqs() does not create new annotation_db

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -637,11 +637,6 @@ class _SequenceCollectionBase:
             return {}  # safe value; can't construct empty alignment
 
         result = self.__class__(result, names=seqs, info=self.info, **kwargs)
-        if self.annotation_db:
-            result.annotation_db = type(self.annotation_db)()
-            result.annotation_db.update(
-                annot_db=self.annotation_db, seqids=result.names
-            )
         return result
 
     def get_seq_indices(self, f, negate=False):  # ported


### PR DESCRIPTION
[CHANGED] because the Sequences are the same, modifying the
    annotation_db screws up the original collection

## Summary by Sourcery

Bug Fixes:
- Fix issue where modifying the annotation_db in SequenceCollection.take_seqs() affects the original collection.