### PR TITLE
ENH: add SeqsData class method for construction from dict

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -283,11 +283,11 @@ class SeqsData(SeqsDataABC):
         self._alphabet = alphabet
         self._offset = offset or {}
         if check:
-            assert set(self._offset.keys()) <= set(
-                data.keys()
+            assert (
+                self._offset.keys() <= data.keys()
             ), "sequence name provided in offset not found in data"
             if any(not alphabet.is_valid(seq) for seq in data.values()):
-                raise ValueError(
+                raise new_alphabet.AlphabetError(
                     f"One or more sequences are invalid for alphabet {alphabet}"
                 )
         self._data: dict[str, numpy.ndarray] = {}
@@ -2418,7 +2418,7 @@ def _(
 @seq_to_gap_coords.register
 def _(seq: str, *, alphabet: new_alphabet.AlphabetABC) -> tuple[str, numpy.ndarray]:
     if not alphabet.is_valid(seq):
-        raise ValueError(f"Sequence is invalid for alphabet {alphabet}")
+        raise new_alphabet.AlphabetError(f"Sequence is invalid for alphabet {alphabet}")
 
     return seq_to_gap_coords(alphabet.to_indices(seq), alphabet=alphabet)
 

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -187,7 +187,12 @@ class SeqsDataABC(ABC):
 
     @classmethod
     @abstractmethod
-    def from_seqs(cls, seqs: dict[str, StrORBytesORArray]) -> SeqsDataABC: ...
+    def from_seqs(
+        cls,
+        seqs: dict[str, StrORBytesORArray],
+        alphabet: new_alphabet.AlphabetABC,
+        **kwargs,
+    ) -> SeqsDataABC: ...
 
     @abstractmethod
     def seq_lengths(self) -> dict[str, int]: ...

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -4348,7 +4348,7 @@ def _(
     # todo: implement a coerce to AlignedSeqsData dict function
     moltype = new_moltype.get_moltype(moltype)
     alphabet = moltype.most_degen_alphabet()
-    aligned_data = AlignedSeqsData.from_aligned_seqs(
+    aligned_data = AlignedSeqsData.from_seqs(
         data=data,
         alphabet=alphabet,
         offset=offset,

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -189,6 +189,7 @@ class SeqsDataABC(ABC):
     @abstractmethod
     def from_seqs(
         cls,
+        *,
         seqs: dict[str, StrORBytesORArray],
         alphabet: new_alphabet.AlphabetABC,
         **kwargs,

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -190,10 +190,10 @@ class SeqsDataABC(ABC):
     def from_seqs(
         cls,
         *,
-        seqs: dict[str, StrORBytesORArray],
+        data: dict[str, StrORBytesORArray],
         alphabet: new_alphabet.AlphabetABC,
         **kwargs,
-    ) -> SeqsDataABC: ...
+    ): ...
 
     @abstractmethod
     def seq_lengths(self) -> dict[str, int]: ...

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -185,10 +185,9 @@ class SeqsDataABC(ABC):
 
     __slots__ = ()
 
-    # refactor: design
-    # SeqsData needs a class method for creating instances from a dict, which will need to be
-    # on AlignedSeqsData as well. If we rename AlignedSeqsData.from_aligned_seqs to from_seqs
-    # (or something similar), we can use the same method name for both classes.
+    @classmethod
+    @abstractmethod
+    def from_seqs(cls, seqs: dict[str, StrORBytesORArray]) -> SeqsDataABC: ...
 
     @abstractmethod
     def seq_lengths(self) -> dict[str, int]: ...
@@ -276,18 +275,32 @@ class SeqsData(SeqsDataABC):
         check: bool = True,
     ):
         self._alphabet = alphabet
+        self._offset = offset or {}
+        if check:
+            assert set(self._offset.keys()) <= set(
+                data.keys()
+            ), "sequence name provided in offset not found in data"
+            if any(not alphabet.is_valid(seq) for seq in data.values()):
+                raise ValueError(
+                    f"One or more sequences are invalid for alphabet {alphabet}"
+                )
         self._data: dict[str, numpy.ndarray] = {}
         for name, seq in data.items():
             arr = self._alphabet.to_indices(seq)
             arr.flags.writeable = False
             self._data[str(name)] = arr
-        self._offset = offset or {}
-        if check:
-            assert set(self._offset.keys()) <= set(
-                self._data.keys()
-            ), "sequence name provided in offset not found in data"
         self._reversed = reversed
         # refactor: rename reversed argument to not clash with python built-in
+
+    @classmethod
+    def from_seqs(
+        cls,
+        *,
+        data: dict[str, StrORBytesORArray],
+        alphabet: new_alphabet.AlphabetABC,
+        **kwargs,
+    ):
+        return cls(data=data, alphabet=alphabet, **kwargs)
 
     @property
     def names(self) -> list:
@@ -786,17 +799,16 @@ class SequenceCollection:
         -----
         The returned collection will not retain an annotation_db if present.
         """
-        # todo: kath, constructing the SeqsData object here violates loose coupling
-        # can we put this in the SeqsData class?
         seqs = {
             name: self.moltype.degap(self._seqs_data.get_seq_array(seqid=name))
             for name in self.names
         }
-        seqs_data = self._seqs_data.__class__(
+        seqs_data = self._seqs_data.from_seqs(
             data=coerce_to_seqs_data_dict(seqs),
             alphabet=self._seqs_data.alphabet,
             offset=self._seqs_data.offset,
             reversed=self._seqs_data.is_reversed,
+            check=False,
         )
         return self.__class__(
             seqs_data=seqs_data,
@@ -1394,17 +1406,13 @@ class SequenceCollection:
             return self
 
         new_seqs = {s.name: s.trim_stop_codon(gc=gc, strict=strict) for s in self.seqs}
-        # todo: kath
-        # should we be using the seqs_data object to do this?
-        # creating the new SeqsData object here violates the loose coupling
-        # principle which we have been trying to adhere to.
-        # or we warn of the potential change in the seqs_data object
 
-        seqs_data = self._seqs_data.__class__(
+        seqs_data = self._seqs_data.from_seqs(
             data=coerce_to_seqs_data_dict(new_seqs),
             alphabet=self._seqs_data.alphabet,
             offset=self._seqs_data.offset,
             reversed=self._seqs_data.is_reversed,
+            check=False,
         )
         result = self.__class__(
             seqs_data=seqs_data,
@@ -2585,15 +2593,6 @@ class AlignedSeqsDataABC(SeqsDataABC):
 
     @classmethod
     @abstractmethod
-    def from_aligned_seqs(
-        cls,
-        *,
-        data: dict[str, StrORArray],
-        alphabet: new_alphabet.AlphabetABC,
-    ): ...
-
-    @classmethod
-    @abstractmethod
     def from_seqs_and_gaps(
         cls,
         *,
@@ -2703,7 +2702,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
         self._offset = offset or {}
 
     @classmethod
-    def from_aligned_seqs(
+    def from_seqs(
         cls,
         *,
         data: dict[str, StrORArray],

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -2260,7 +2260,8 @@ def test_sequence_collection_distance_matrix_raises_wrong_moltype(moltype):
 def test_sequence_collection_distance_matrix_passes_correct_moltype(moltype):
     data = {"s1": "ACGA", "s2": "ACGA"}
     seqs = new_alignment.make_unaligned_seqs(data, moltype=moltype)
-    seqs.distance_matrix()
+    got = seqs.distance_matrix()
+    assert got[("s1", "s2")] == 0.0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -173,7 +173,7 @@ def test_seqs_data_construction(str_seqs_dict, dna_alphabet):
 
 
 def test_seqs_data_construction_wrong_alphabet(str_seqs_dict, rna_alphabet):
-    """SeqsData can be constructed from a dict and alphabet, either directly or via from_seqs"""
+    """SeqsData should raise ValueError if alphabet is incompatible with data"""
     with pytest.raises(ValueError):
         _ = new_alignment.SeqsData(data=str_seqs_dict, alphabet=rna_alphabet)
 

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -174,7 +174,7 @@ def test_seqs_data_construction(str_seqs_dict, dna_alphabet):
 
 def test_seqs_data_construction_wrong_alphabet(str_seqs_dict, rna_alphabet):
     """SeqsData should raise ValueError if alphabet is incompatible with data"""
-    with pytest.raises(ValueError):
+    with pytest.raises(new_alphabet.AlphabetError):
         _ = new_alignment.SeqsData(data=str_seqs_dict, alphabet=rna_alphabet)
 
 
@@ -2808,7 +2808,7 @@ def test_aligned_seqs_data_add_seqs_diff_moltype_raises(dna_alphabet):
     data = {"seq1": "ACGT-", "seq2": "ACG-T"}  # DNA
     ad = new_alignment.AlignedSeqsData.from_seqs(data=data, alphabet=dna_alphabet)
     new_data = {"seq3": "ACGU-", "seq4": "ACG-U"}  # RNA
-    with pytest.raises(ValueError):
+    with pytest.raises(new_alphabet.AlphabetError):
         _ = ad.add_seqs(new_data)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a 'from_seqs' class method for SeqsData and AlignedSeqsData to standardize construction from a dictionary and alphabet, replacing the previous 'from_aligned_seqs' method. Update tests to validate the new method and ensure correct behavior with different alphabets.

Enhancements:
- Introduce a class method 'from_seqs' for SeqsData and AlignedSeqsData to facilitate construction from a dictionary and alphabet.

Tests:
- Add tests to verify the construction of SeqsData from a dictionary and alphabet, including cases with incorrect alphabets.