### PR TITLE
ENH: consistent colours for legend groups

### DIFF
--- a/src/cogent3/draw/drawable.py
+++ b/src/cogent3/draw/drawable.py
@@ -855,7 +855,7 @@ class _MakeShape:
         kwargs |= dict(reverse=reverse)
 
         klass = self._shapes.get(type_.lower(), Rectangle)
-        color = self._colors.get(type_.lower())
+        color = self.get_colour(type_)
         if klass != Arrow:
             kwargs.pop("reverse", None)
 
@@ -881,6 +881,16 @@ class _MakeShape:
                 **kwargs,
             )
         return result
+
+    def get_colour(self, label):
+        from plotly.colors import sample_colorscale
+
+        label = label.lower()
+
+        if label not in self._colors:
+            self._colors[label] = sample_colorscale("Viridis", numpy.random.rand())[0]
+
+        return self._colors[label]
 
 
 make_shape = _MakeShape()

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -1,5 +1,6 @@
 import pathlib
 import unittest
+import uuid
 
 from numpy.testing import assert_allclose
 
@@ -10,6 +11,7 @@ from cogent3.draw.drawable import (
     Drawable,
     _calc_arrow_width,
     get_domain,
+    make_shape,
 )
 from cogent3.util.union_dict import UnionDict
 
@@ -416,3 +418,12 @@ def test_calculating_arrow_width_adjusted():
     assert aw == 10
     aw = _calc_arrow_width(parent_length=100, feature_width=10, frac=0.05)
     assert aw == 5
+
+
+def test_colour_choice():
+    label = str(uuid.uuid4())
+    assert label not in make_shape._colors
+    shape1 = make_shape(type_=label, coords=[(10, 20)])
+    assert label in make_shape._colors
+    shape2 = make_shape(type_=label, coords=[(30, 60)])
+    assert shape1.fillcolor == shape2.fillcolor == make_shape._colors[label]


### PR DESCRIPTION
[NEW] plotly chooses random colours for unless otherwise specified.
    For feature types explicitly identified in drawable we have set colours.
    I've adapted this to use a randomly selected colour from the Viridis colour map
    for each novel legend group.

## Summary by Sourcery

Enhance the drawable module to assign consistent colors to novel legend groups using the Viridis color map, and add a test to ensure this functionality works as expected.

Enhancements:
- Implement consistent color assignment for novel legend groups using the Viridis color map in drawable.

Tests:
- Add a test to verify consistent color assignment for novel legend groups.