### PR TITLE
ENH: register misc_RNA as arrow shape for drawing

### DIFF
--- a/changelog.d/20241101_070906_Gavin.Huttley.md
+++ b/changelog.d/20241101_070906_Gavin.Huttley.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Contributors
+
+- A bullet item for the Contributors category.
+
+-->
+### ENH
+
+- Standardise arrow head sizes on annotation feature displays.
+
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/src/cogent3/draw/drawable.py
+++ b/src/cogent3/draw/drawable.py
@@ -817,6 +817,7 @@ class _MakeShape:
     _colors = dict(
         cds="rgba(0,0,150,0.75)",
         rrna="rgba(0,0,150,0.75)",
+        misc_rna="rgba(0,0,150,0.75)",
         trna="rgba(0,0,150,0.75)",
         exon="rgba(0,0,100,0.75)",
         gene="rgba(161,0,0,0.75)",
@@ -828,6 +829,7 @@ class _MakeShape:
     _shapes = dict(
         cds=Arrow,
         rrna=Arrow,
+        misc_rna=Arrow,
         trna=Arrow,
         exon=Arrow,
         transcript=Arrow,

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -2,12 +2,14 @@ import pathlib
 import unittest
 import uuid
 
+import pytest
 from numpy.testing import assert_allclose
 
 from cogent3 import load_aligned_seqs, make_aligned_seqs, make_table
 from cogent3.core.annotation_db import GffAnnotationDb
 from cogent3.draw.drawable import (
     AnnotatedDrawable,
+    Arrow,
     Drawable,
     _calc_arrow_width,
     get_domain,
@@ -427,3 +429,9 @@ def test_colour_choice():
     assert label in make_shape._colors
     shape2 = make_shape(type_=label, coords=[(30, 60)])
     assert shape1.fillcolor == shape2.fillcolor == make_shape._colors[label]
+
+
+@pytest.mark.parametrize("biotype", ("mRNA", "MRNA", "gene", "misc_RNA", "tRNA", "CDS"))
+def test_arrow_shapes(biotype):
+    shape = make_shape(type_=biotype, coords=[(10, 20)], parent_length=20)
+    assert isinstance(shape, Arrow)


### PR DESCRIPTION
## Summary by Sourcery

Register 'misc_RNA' as an arrow shape in the drawing module and add corresponding tests to ensure correct shape instantiation. Update the changelog to reflect these enhancements.

Enhancements:
- Register 'misc_RNA' as an arrow shape for drawing in the _MakeShape class.

Documentation:
- Add a changelog entry for the enhancement of standardizing arrow head sizes on annotation feature displays.

Tests:
- Add a parameterized test to verify that various biotypes, including 'misc_RNA', are correctly instantiated as Arrow shapes.