### PR TITLE
DEV: SeqDataView.map sliced by slice_record

### DIFF
--- a/tests/test_draw/test_new_draw_integration.py
+++ b/tests/test_draw/test_new_draw_integration.py
@@ -244,9 +244,6 @@ def test_coevo_drawables(load_alignment):
     check_drawable_styles(aln.coevolution, styles, show_progress=False)
 
 
-@pytest.mark.xfail(
-    reason="todo: for sliced alignment, inconsistent length between length of alignment and length of the map"
-)
 def test_coevo_annotated(load_alignment):
     """coevolution on alignment with annotated seqs should add to heatmap plot"""
     aln = load_alignment(True, False)


### PR DESCRIPTION
Addressing comment on https://github.com/cogent3/cogent3/pull/2079#discussion_r1825401297

## Summary by Sourcery

Enhance the SeqDataView class by slicing the IndelMap in the 'map' property using slice_record, and update the parent_seq_coords method to use the parent's IndelMap for accurate index retrieval. Additionally, remove the xfail marker from a test, indicating a resolved issue.

Enhancements:
- Modify the 'map' property in SeqDataView to return a sliced IndelMap based on slice_record.

Tests:
- Remove the xfail marker from the test_coevo_annotated test, indicating the issue with inconsistent length between alignment and map has been resolved.