### PR TITLE
MAINT: stricter check on Sequence.is_annotated()

### DIFF
--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1530,9 +1530,10 @@ class Sequence:
         return indel_map, seq
 
     def is_annotated(self):
-        """returns True if sequence has any annotations"""
-        num = self.annotation_db.num_matches() if self.annotation_db else 0
-        return num != 0
+        """returns True if sequence parent name has any annotations"""
+        with contextlib.suppress(AttributeError):
+            return self.annotation_db.num_matches(seqid=self._seq.seqid) != 0
+        return False
 
     def annotate_matches_to(
         self, pattern: str, biotype: str, name: str, allow_multiple: bool = False

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -881,6 +881,8 @@ def test_not_is_annotated():
         seqid="s2", biotype="gene", name="blah", spans=[(0, 10)]
     )
     assert not s.is_annotated()
+    s.annotation_db = None
+    assert not s.is_annotated()
 
 
 def test_to_html():

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -867,14 +867,20 @@ def test_strand_symmetry():
 
 def test_is_annotated():
     """is_annotated operates correctly"""
-    s = new_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG")
-    if hasattr(s, "annotation_db"):
-        assert not s.is_annotated()
-        _ = s.add_feature(biotype="gene", name="blah", spans=[(0, 10)])
-        assert s.is_annotated()
-    else:
-        with pytest.raises(AttributeError):
-            s.is_annotated()
+    s = new_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG", name="s1")
+    _ = s.add_feature(biotype="gene", name="blah", spans=[(0, 10)])
+    assert s.is_annotated()
+
+
+def test_not_is_annotated():
+    """is_annotated operates correctly"""
+    s = new_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG", name="s1")
+    assert not s.is_annotated()
+    # annotation on different seq
+    s.annotation_db.add_feature(
+        seqid="s2", biotype="gene", name="blah", spans=[(0, 10)]
+    )
+    assert not s.is_annotated()
 
 
 def test_to_html():


### PR DESCRIPTION
[CHANGED] return True only if records matching the sequence parent
    name are in the bound annotation_db. Don't Fail if annotation_db
    is None, just return False.

## Summary by Sourcery

Improve the Sequence.is_annotated() method to ensure it returns True only when annotations match the sequence's parent name and handle cases where annotation_db is None by returning False. Update tests to cover these scenarios.

Bug Fixes:
- Fix the behavior of Sequence.is_annotated() to return False instead of raising an AttributeError when annotation_db is None.

Enhancements:
- Enhance Sequence.is_annotated() to return True only if annotations match the sequence's parent name.

Tests:
- Add tests to verify the correct operation of Sequence.is_annotated() when annotations match or do not match the sequence's parent name.