### PR TITLE
ENH: add quick_tree, distance_matrix to new Alignment

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1542,14 +1542,14 @@ def get_moltype(name, new_type: bool = False):
         style will be removed as of 2025.6.
     """
     from cogent3.core import new_moltype
-    
+
     if new_type or "COGENT3_NEW_TYPE" in os.environ:
         return new_moltype.get_moltype(name=name)
     if isinstance(name, MolType):
         return name
     if isinstance(name, new_moltype.MolType):
         return name
-    
+
     name = name.lower()
     if name not in moltypes:
         raise ValueError(f"unknown moltype {name!r}")

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1541,13 +1541,15 @@ def get_moltype(name, new_type: bool = False):
         The default will be changed to True in 2024.12. Support for the old
         style will be removed as of 2025.6.
     """
+    from cogent3.core import new_moltype
+    
     if new_type or "COGENT3_NEW_TYPE" in os.environ:
-        from cogent3.core.new_moltype import get_moltype as new_get_moltype
-
-        return new_get_moltype(name=name)
-
+        return new_moltype.get_moltype(name=name)
     if isinstance(name, MolType):
         return name
+    if isinstance(name, new_moltype.MolType):
+        return name
+    
     name = name.lower()
     if name not in moltypes:
         raise ValueError(f"unknown moltype {name!r}")

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -3949,6 +3949,7 @@ class Alignment(SequenceCollection):
         negate
             if True, all columns except those in cols are kept
         """
+        # refactor: array - use array operations throughout method
         if negate:
             col_lookup = dict.fromkeys(cols)
             cols = [i for i in range(len(self)) if i not in col_lookup]

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4202,6 +4202,7 @@ def test_alignment_distance_matrix():
         _ = aln.distance_matrix(calc="paralinear")
     # but setting drop_invalid=False allows calc
     dists = aln.distance_matrix(calc="paralinear", drop_invalid=True)
+    assert dists is None
 
 
 def test_alignment_sample_with_replacement():


### PR DESCRIPTION
## Summary by Sourcery

Add new methods 'distance_matrix' and 'quick_tree' to the Alignment class for calculating pairwise distances and generating phylogenetic trees, respectively. Enhance the 'get_translation' method with a 'name_map' parameter. Introduce comprehensive tests for the new methods and sequence renaming functionality.

New Features:
- Introduce the 'distance_matrix' method to calculate pairwise distances between sequences in an alignment, with options for different calculators and handling of invalid data.
- Add the 'quick_tree' method to generate a phylogenetic tree from an alignment, with support for bootstrapping and handling of invalid data.

Enhancements:
- Improve the 'get_translation' method by adding a 'name_map' parameter to better handle sequence naming.

Tests:
- Add tests for the 'distance_matrix' method to ensure correct calculation of pairwise distances, including handling of invalid data.
- Introduce tests for the 'quick_tree' method to verify the generation of phylogenetic trees and the handling of bootstrap replicates.
- Enhance tests for sequence renaming in the 'iter_seqs' method and the 'get_translation' method to ensure correct functionality.