### PR TITLE
ENH: omit_gap_pos now faster

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -117,7 +117,7 @@ def _gap_ok_vector_single(
     gap_index: int,
     missing_index: int,
     num_allowed: int,
-) -> bool:
+) -> bool:  # pragma: no cover
     """returns indicies for which the number of gaps & missing data is less than or equal to num_allowed"""
     num = 0
     for i in range(len(data)):
@@ -139,7 +139,7 @@ def _gap_ok_vector_multi(
     missing_index: int,
     motif_length: int,
     num_allowed: int,
-) -> numpy.ndarray[bool]:
+) -> numpy.ndarray[bool]:  # pragma: no cover
     """returns indicies for which the number of gaps & missing data in a vector of motifs is less than or equal to num_allowed"""
     num = 0
     for motif in motifs:
@@ -4583,7 +4583,7 @@ class Alignment(SequenceCollection):
         alpha = self.moltype.most_degen_alphabet()
         gap_index = alpha.gap_index
         missing_index = alpha.missing_index
-        if not gap_index or not missing_index:
+        if not gap_index and not missing_index:
             return self
 
         allowed_num = int(numpy.floor(self.num_seqs * allowed_gap_frac))

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4513,7 +4513,8 @@ def test_omit_gap_pos():
     new_aln = aln.add_seqs({"d": "-------", "e": "XYZXYZX", "f": "AB-CDEF"})
 
     # if no gaps are allowed, we get None
-    assert new_aln.omit_gap_pos(0) is None
+    got = new_aln.omit_gap_pos(0)
+    assert not len(got)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4517,6 +4517,15 @@ def test_omit_gap_pos():
     assert not len(got)
 
 
+def test_omit_gap_pos_no_gap_moltype():
+    """if moltype does not support gap, just returns self"""
+    aln = new_alignment.make_aligned_seqs(
+        {"a": "--A-BC-", "b": "-CB-A--", "c": "--D-EF-"}, moltype="bytes"
+    )
+    got = aln.omit_gap_pos()
+    assert got is aln
+
+
 @pytest.fixture(scope="session")
 def brca1_data():
     return load_aligned_seqs("data/brca1.fasta", moltype="dna", new_type=True).to_dict()


### PR DESCRIPTION
[NEW] _gap_ok_vector_single() and _gap_ok_vector_multi() are numba.jit functions that
    determine whether the number of gaps & missing data is less than or equal to a
    threshold. These functions are used by omit_gap_pos() to filter columns of an
    alignment.

[CHANGED] private methods _omit_gap_pos_single() and _omit_gap_pos_multi() are added
    to Alignment to handle the filtering of columns in an alignment, using the above
    functions.

[CHANGED] GapsOk is removed and replaced by the above functions.

[CHANGED] omit_gap_pos() now returns an empty alignment, instead of None, if
     no positions remain.

## Summary by Sourcery

Enhance the performance of omit_gap_pos() by introducing numba.jit functions for gap checking, replacing the GapsOk class, and updating the function to return an empty alignment instead of None when no positions remain.

New Features:
- Introduce _gap_ok_vector_single() and _gap_ok_vector_multi() as numba.jit functions to efficiently determine if the number of gaps and missing data is within a threshold.

Enhancements:
- Refactor omit_gap_pos() to use new numba.jit functions for improved performance in filtering alignment columns.
- Replace the GapsOk class with new numba.jit functions for gap checking.

Tests:
- Update test for omit_gap_pos() to check for an empty alignment return instead of None when no positions remain.