### PR TITLE
API: add SliceRecordABC.plus_start and plus_stop

### DIFF
--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -2119,6 +2119,22 @@ class SliceRecordABC(ABC):
         return start
 
     @property
+    def plus_stop(self) -> int:
+        """stop on plus strand"""
+        if self.is_reversed:
+            # self.start becomes the stop, self.start will be negative
+            assert self.start < 0, "expected start on reverse strand SeqView < 0"
+            stop = self.start + self.parent_len + 1
+        else:
+            stop = self.stop
+        return stop
+
+    @property
+    def plus_step(self) -> int:
+        """step on plus strand"""
+        return abs(self.step)
+
+    @property
     def parent_start(self) -> int:
         """returns the start on the parent plus strand
 
@@ -2136,17 +2152,6 @@ class SliceRecordABC(ABC):
     @property
     def is_reversed(self):
         return self.step < 0
-
-    @property
-    def plus_stop(self) -> int:
-        """stop on plus strand"""
-        if self.is_reversed:
-            # self.start becomes the stop, self.start will be negative
-            assert self.start < 0, "expected start on reverse strand SeqView < 0"
-            stop = self.start + self.parent_len + 1
-        else:
-            stop = self.stop
-        return stop
 
     @property
     def parent_stop(self) -> int:

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -2584,6 +2584,17 @@ def test_seqview_seq_len_init(start, stop, step, length, dna_alphabet):
     assert sv._parent_len == expect
 
 
+@pytest.mark.parametrize("step", (1, 3))
+@pytest.mark.parametrize("rev", (False, True))
+def test_seqview_plus_attrs(rev, step):
+    # always equal values from plkus strand
+    start = 2
+    stop = 12
+    sr = new_sequence.SliceRecord(start=start, stop=stop, step=step, parent_len=30)
+    sr = sr[::-1] if rev else sr
+    assert (sr.plus_start, sr.plus_stop, sr.plus_step) == (start, stop, step)
+
+
 def test_seqview_copy_propagates_seq_len(dna_alphabet):
     seq = "ACGGTGGGAC"
     sv = new_sequence.SeqView(parent=seq, alphabet=dna_alphabet)


### PR DESCRIPTION
[NEW] these return start and stop in plus strand coordinates,
     irrespective of whether reversed or not. This is most critical
     in SeqDataView where previous code was passing just parent_start
     and parent_stop. The latter use the offset, which should be
     employed only for feature querying. Adding comments to that effect
     to the docstrings.

## Summary by Sourcery

Add plus_start and plus_stop properties to SliceRecordABC to provide consistent plus strand coordinates, refactor SeqDataView to utilize these properties, and update documentation and tests accordingly.

New Features:
- Introduce plus_start and plus_stop properties in SliceRecordABC to return start and stop in plus strand coordinates, regardless of strand orientation.

Enhancements:
- Refactor SeqDataView to use plus_start and plus_stop for sequence retrieval, ensuring consistent handling of strand orientation.

Documentation:
- Add notes to docstrings clarifying the intended use of parent_start and parent_stop properties, emphasizing they should not be used for slicing on the parent object.

Tests:
- Add tests for the new plus_start, plus_stop, and plus_step properties to ensure they return correct values for both forward and reverse strand orientations.