### PR TITLE
DEV: drop support for py3.9

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,2 +1,2 @@
 rule_settings:
-  python_version: '3.9'
+  python_version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ license = { file = "LICENSE" }
 dependencies = ["chardet",
         "loky",
         "numpy",
-        "numba>0.53; python_version>='3.9' and python_version <'3.12'",
         "numba>0.54; python_version>='3.10' and python_version <'3.12'",
         "numba>=0.57.0; python_version=='3.11'",
         "numba>=0.59.0; python_version=='3.12'",
@@ -26,7 +25,7 @@ dependencies = ["chardet",
         "tqdm",
         "typing_extensions"]
 # remember to update version in requires-python and classifiers
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
@@ -34,7 +33,6 @@ classifiers = [
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -5,12 +5,11 @@ execution on compute systems with 1000s of CPUs."""
 import os
 import pathlib
 import pickle
-import sys
 import warnings
 from typing import Callable, Optional, Union
 
 from cogent3._version import __version__
-from cogent3.app import app_help, available_apps, get_app, open_data_store
+from cogent3.app import app_help, available_apps, get_app, open_data_store  # noqa
 from cogent3.core import annotation_db as _anno_db
 from cogent3.core.alignment import (
     Alignment,
@@ -18,21 +17,24 @@ from cogent3.core.alignment import (
     Sequence,
     SequenceCollection,
 )
-from cogent3.core.genetic_code import available_codes, get_code
+from cogent3.core.genetic_code import available_codes, get_code  # noqa
 
 # note that moltype has to be imported last, because it sets the moltype in
 # the objects created by the other modules.
 from cogent3.core.moltype import (
-    ASCII,
-    DNA,
-    PROTEIN,
-    RNA,
-    available_moltypes,
-    get_moltype,
+    ASCII,  # noqa
+    DNA,  # noqa
+    PROTEIN,  # noqa
+    RNA,  # noqa
+    available_moltypes,  # noqa
+    get_moltype,  # noqa
 )
 from cogent3.core.tree import PhyloNode, TreeBuilder, TreeError, TreeNode
-from cogent3.evolve.fast_distance import available_distances, get_distance_calculator
-from cogent3.evolve.models import available_models, get_model
+from cogent3.evolve.fast_distance import (  # noqa
+    available_distances,
+    get_distance_calculator,
+)
+from cogent3.evolve.models import available_models, get_model  # noqa
 from cogent3.parse.cogent3_json import load_from_json
 from cogent3.parse.newick import parse_string as newick_parse_string
 from cogent3.parse.sequence import get_parser, is_genbank
@@ -47,14 +49,6 @@ __copyright__ = "Copyright 2007-2023, The Cogent Project"
 __credits__ = "https://github.com/cogent3/cogent3/graphs/contributors"
 __license__ = "BSD-3"
 
-
-_min_version = (3, 9)
-if (sys.version_info.major, sys.version_info.minor) < _min_version:
-    PY_VERSION = ".".join([str(n) for n in sys.version_info])
-    _min_version = ".".join(str(e) for e in _min_version)
-    raise RuntimeError(
-        f"Python-{_min_version} or greater is required, Python-{PY_VERSION} used."
-    )
 
 version = __version__
 version_info = tuple([int(v) for v in version.split(".") if v.isdigit()])


### PR DESCRIPTION
## Summary by Sourcery

Drop support for Python 3.9 and update the minimum required Python version to 3.10, including changes to dependencies and CI configurations.

Enhancements:
- Remove support for Python 3.9 across the codebase, updating the minimum required Python version to 3.10.

CI:
- Update CI workflows to remove Python 3.9 from the testing matrix and set Python 3.12 as the default version for linters.