### PR TITLE
ENH: added apply_scaled_gaps() method

### DIFF
--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4928,15 +4928,17 @@ def test_alignment_apply_scaled_gaps_invalid_seqlen(codon_and_aa_alns):
         aa.apply_scaled_gaps(ungapped, aa_to_codon=True)
 
 
-@pytest.mark.parametrize(
-    "moltype1,moltype2", [("protein", "text"), ("text", "protein")]
-)
-def test_alignment_apply_scaled_gaps_invalid_moltype(
-    codon_and_aa_alns, moltype1, moltype2
-):
+def test_alignment_apply_scaled_gaps_aa2codon_invalid_moltype(codon_and_aa_alns):
     codon, aa = codon_and_aa_alns
-    aa = aa.to_moltype(moltype1)
-    codon = codon.to_moltype(moltype2)
+    codon = codon.to_moltype("text")
     ungapped = codon.degap()
     with pytest.raises(ValueError):
         aa.apply_scaled_gaps(ungapped, aa_to_codon=True)
+
+
+def test_alignment_apply_scaled_gaps_codon2aa_invalid_moltype(codon_and_aa_alns):
+    codon, aa = codon_and_aa_alns
+    ungapped = aa.degap()
+    codon = codon.to_moltype("text")
+    with pytest.raises(ValueError):
+        codon.apply_scaled_gaps(ungapped, aa_to_codon=False)

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4892,3 +4892,51 @@ def test_make_gap_filter():
     assert f3(s1) == False
     assert f1(s3) == False
     assert f3(s4) == True
+
+
+@pytest.fixture(scope="session")
+def codon_and_aa_alns():
+    import cogent3
+
+    data = dict(s1="ATG --- --- GAT --- AAA", s2="ATG CAA TCG AAT GAA ATA")
+    dna = cogent3.make_aligned_seqs(
+        {n: s.replace(" ", "") for n, s in data.items()}, moltype="dna", new_type=True
+    )
+    aa = dna.get_translation()
+    return dna, aa
+
+
+def test_alignment_apply_scaled_gaps_aa_to_codon(codon_and_aa_alns):
+    codon, aa = codon_and_aa_alns
+    ungapped = codon.degap()
+    scaled = aa.apply_scaled_gaps(ungapped, aa_to_codon=True)
+    assert scaled.to_dict() == codon.to_dict()
+
+
+def test_alignment_apply_scaled_gaps_codon_to_aa(codon_and_aa_alns):
+    codon, aa = codon_and_aa_alns
+    ungapped = aa.degap()
+    scaled = codon.apply_scaled_gaps(ungapped, aa_to_codon=False)
+    assert scaled.to_dict() == aa.to_dict()
+
+
+def test_alignment_apply_scaled_gaps_invalid_seqlen(codon_and_aa_alns):
+    codon, aa = codon_and_aa_alns
+    codon = codon[:-2]
+    ungapped = codon.degap()
+    with pytest.raises(ValueError):
+        aa.apply_scaled_gaps(ungapped, aa_to_codon=True)
+
+
+@pytest.mark.parametrize(
+    "moltype1,moltype2", [("protein", "text"), ("text", "protein")]
+)
+def test_alignment_apply_scaled_gaps_invalid_moltype(
+    codon_and_aa_alns, moltype1, moltype2
+):
+    codon, aa = codon_and_aa_alns
+    aa = aa.to_moltype(moltype1)
+    codon = codon.to_moltype(moltype2)
+    ungapped = codon.degap()
+    with pytest.raises(ValueError):
+        aa.apply_scaled_gaps(ungapped, aa_to_codon=True)


### PR DESCRIPTION
## Summary by Sourcery

Add the apply_scaled_gaps() method to enable gap scaling between codon and amino acid alignments, and enhance the IndelMap class with a scaled() method for scaling indel maps. Include comprehensive tests for these new functionalities.

New Features:
- Introduce the apply_scaled_gaps() method to handle gap scaling between codon and amino acid alignments.

Enhancements:
- Add the scaled() method to the IndelMap class for scaling indel maps by a specified factor, facilitating conversions between codon and amino acid alignments.

Tests:
- Add tests for the apply_scaled_gaps() method to ensure correct gap scaling between codon and amino acid alignments.
- Add tests for the IndelMap.scaled() method to verify correct scaling behavior and error handling for invalid scales.