### PR TITLE
ENH: add get_projected_features

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -4716,7 +4716,9 @@ class Alignment(AlignmentI, SequenceCollection):
         self.annotation_db.add_feature(**feature.to_dict())
         return result
 
-    def get_projected_features(self, *, seqid: str, **kwargs) -> list[Feature]:
+    def get_projected_features(
+        self, *, seqid: str, **kwargs
+    ) -> list[Feature]:  # ported
         """projects all features from other sequences onto seqid"""
         # todo gah should there be a generator version,
         # iter_projected_features()?

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -5373,6 +5373,17 @@ class Alignment(SequenceCollection):
         self.annotation_db.add_feature(**feature.to_dict())
         return result
 
+    def get_projected_features(self, *, seqid: str, **kwargs) -> list[Feature]:
+        """projects all features from other sequences onto seqid"""
+        # todo gah should there be a generator version,
+        # iter_projected_features()?
+        annots = []
+        for name in self.names:
+            if name == seqid:
+                continue
+            annots.extend(list(self.get_features(seqid=name, **kwargs)))
+        return [self.get_projected_feature(seqid=seqid, feature=a) for a in annots]
+
     def get_drawables(
         self, *, biotype: Optional[str, typing.Iterable[str]] = None
     ) -> dict:

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -5375,8 +5375,6 @@ class Alignment(SequenceCollection):
 
     def get_projected_features(self, *, seqid: str, **kwargs) -> list[Feature]:
         """projects all features from other sequences onto seqid"""
-        # todo gah should there be a generator version,
-        # iter_projected_features()?
         annots = []
         for name in self.names:
             if name == seqid:

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -416,7 +416,7 @@ def test_nested_annotated_region_masks():
     assert got["y"] == "-T----TTTTG-GTT"
 
 
-def test_feature_from_alignment():  # ported to test_new_aln_integration.py
+def test_feature_from_alignment():
     """seq features obtained from the alignment"""
 
     # we no longer support copying annotations individually

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -416,7 +416,7 @@ def test_nested_annotated_region_masks():
     assert got["y"] == "-T----TTTTG-GTT"
 
 
-def test_feature_from_alignment():
+def test_feature_from_alignment():  # ported to test_new_aln_integration.py
     """seq features obtained from the alignment"""
 
     # we no longer support copying annotations individually


### PR DESCRIPTION
## Summary by Sourcery

Add the 'get_projected_features' method to project features from other sequences onto a specified sequence ID and include corresponding tests to validate its functionality.

New Features:
- Introduce the 'get_projected_features' method to project all features from other sequences onto a specified sequence ID.

Tests:
- Add tests for the 'get_projected_features' method to ensure correct feature projection onto specified sequence IDs.