### PR TITLE
ENH: implement eq and neq methods

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -264,7 +264,7 @@ class SeqsDataABC(ABC):
     def __eq__(self, value: object) -> bool: ...
 
     @abstractmethod
-    def __neq__(self, value: object) -> bool: ...
+    def __ne__(self, value: object) -> bool: ...
 
     @abstractmethod
     def get_seq_length(self, seqid: str) -> int: ...
@@ -378,8 +378,8 @@ class SeqsData(SeqsDataABC):
             for name in self._data
         )
 
-    def __neq__(self, other: object) -> bool:
-        return self != other
+    def __ne__(self, other: object) -> bool:
+        return not self == other
 
     @classmethod
     def from_seqs(
@@ -3180,8 +3180,8 @@ class AlignedSeqsData(AlignedSeqsDataABC):
 
         return numpy.all(self._gapped == other._gapped)
 
-    def __neq__(self, other: object) -> bool:
-        return self != other
+    def __ne__(self, other: object) -> bool:
+        return not self == other
 
     @classmethod
     def from_seqs(

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -2014,10 +2014,16 @@ class SequenceCollection:
 
         return FORMATTERS["fasta"](self.to_dict())
 
-    def __eq__(
-        self, other: Union[SequenceCollection, dict]
-    ) -> bool:  # refactor: design
-        return id(self) == id(other)
+    def __eq__(self, other: SequenceCollection) -> bool:
+        self_init = self._get_init_kwargs()
+        other_init = other._get_init_kwargs()
+        for key, self_val in self_init.items():
+            if key in ("annotation_db", "slice_record"):
+                continue
+            other_val = other_init.get(key)
+            if self_val != other_val:
+                return False
+        return True
 
     def __ne__(self, other: SequenceCollection) -> bool:
         return not self.__eq__(other)
@@ -3928,6 +3934,12 @@ class Alignment(SequenceCollection):
 
     def _post_init(self):
         self._seqs = _IndexableSeqs(self, make_seq=self._make_aligned)
+
+    def __eq__(self, other: "Alignment") -> bool:
+        return super().__eq__(other) and self._slice_record == other._slice_record
+
+    def __ne__(self, other: "Alignment") -> bool:
+        return not self == other
 
     def _get_init_kwargs(self) -> dict:
         """returns the kwargs needed to re-instantiate the object"""

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -324,14 +324,12 @@ class SeqsData(SeqsDataABC):
         an instance of CharAlphabet valid for the sequences
     offset
         a dictionary of {name: offset} pairs indicating the offset of the sequence
-    reversed
-        a boolean indicating if the sequences are reversed
     check
         a boolean indicating if the data should be checked for naming consistency
         between arguments
     """
 
-    __slots__ = ("_data", "_alphabet", "_offset", "_reversed")
+    __slots__ = ("_data", "_alphabet", "_offset")
 
     def __init__(
         self,

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -2081,6 +2081,11 @@ class SliceRecordABC(ABC):
 
     __slots__ = ("start", "stop", "step", "_offset")
 
+    @abstractmethod
+    def __eq__(self, other): ...
+
+    @abstractmethod
+    def __neq__(self, other): ...
     @property
     @abstractmethod
     def parent_len(self) -> int: ...
@@ -2514,6 +2519,18 @@ class SliceRecord(SliceRecordABC):
         self.step = step
         self._parent_len = parent_len
         self._offset = offset or 0
+
+    def __eq__(self, other: SliceRecordABC) -> bool:
+        return (
+            self.start == other.start
+            and self.stop == other.stop
+            and self.step == other.step
+            and self._parent_len == other.parent_len
+            and self._offset == other.offset
+        )
+
+    def __neq__(self, other: SliceRecordABC) -> bool:
+        return self != other
 
     @property
     def parent_len(self) -> int:

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5029,3 +5029,42 @@ def test_alignment_deepcopy(simple_aln):
     assert set(copied.names) == set(renamed.names)
     # and can get a sequence with a new name
     assert str(copied.seqs["A"]) == str(renamed.seqs["A"])
+
+
+@pytest.mark.parametrize(
+    "mk_cls",
+    [
+        new_alignment.make_unaligned_seqs,
+        new_alignment.make_aligned_seqs,
+    ],
+)
+def test_collections_equal(aligned_dict, mk_cls):
+    coll1 = mk_cls(aligned_dict, moltype="dna")
+    coll2 = mk_cls(aligned_dict, moltype="dna")
+    assert coll1 is not coll2
+    assert coll1 == coll2
+
+
+@pytest.mark.parametrize(
+    "mk_cls",
+    [
+        new_alignment.make_unaligned_seqs,
+        new_alignment.make_aligned_seqs,
+    ],
+)
+@pytest.mark.parametrize(
+    "kwargs",
+    [dict(moltype="protein"), dict(is_reversed=True), dict(name_map=dict(A="a")), {}],
+)
+def test_collections_not_equal(aligned_dict, mk_cls, kwargs):
+    coll1 = mk_cls(aligned_dict, moltype="dna")
+    aligned_dict = aligned_dict if kwargs else {**aligned_dict, **{"seq1": "TTTTTT"}}
+    kwargs = {**dict(moltype="dna"), **kwargs}
+    coll2 = mk_cls(aligned_dict, **kwargs)
+    assert coll1 != coll2
+
+
+def test_alignment_not_equal_sliced(aligned_dict):
+    coll1 = new_alignment.make_aligned_seqs(aligned_dict, moltype="dna")
+    coll2 = coll1[:2]
+    assert coll1 != coll2

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5068,3 +5068,16 @@ def test_alignment_not_equal_sliced(aligned_dict):
     coll1 = new_alignment.make_aligned_seqs(aligned_dict, moltype="dna")
     coll2 = coll1[:2]
     assert coll1 != coll2
+
+
+@pytest.mark.parametrize(
+    "type1,type2",
+    [
+        (new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs),
+        (new_alignment.make_aligned_seqs, new_alignment.make_unaligned_seqs),
+    ],
+)
+def test_alignment_not_equal_types(aligned_dict, type1, type2):
+    coll1 = type1(aligned_dict, moltype="dna")
+    coll2 = type2(aligned_dict, moltype="dna")
+    assert coll1 != coll2


### PR DESCRIPTION
## Summary by Sourcery

Implement equality and inequality methods for sequence-related classes to support object comparison and add corresponding tests to ensure their correct functionality.

Enhancements:
- Implement equality (__eq__) and inequality (__neq__) methods for various classes in the new_alignment and new_sequence modules to enable object comparison.

Tests:
- Add tests to verify the correct behavior of the newly implemented equality and inequality methods for sequence collections and alignments.