### PR TITLE
ENH: implementation of new Alignment.with_masked_annotations()

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -2771,7 +2771,7 @@ class Aligned:
         else:
             # gapped_array_value gives the reverse of the plus strand
             # so we need to complement it. We do that here because with a
-            # step != 1 we cannot retain a connection to the underlying
+            # step != 1, we cannot retain a connection to the underlying
             # annotations
             seq = self.moltype.degap(self.data.gapped_array_value)
             seq = self.moltype.complement(seq)
@@ -6152,6 +6152,43 @@ class Alignment(SequenceCollection):
         return self.__class__(
             **kwargs,
         )
+
+    def with_masked_annotations(
+        self, biotypes: PySeqStr, mask_char: str = "?", shadow: bool = False
+    ):
+        """returns an alignment with regions replaced by mask_char
+
+        Parameters
+        ----------
+        biotypes
+            annotation type(s)
+        mask_char
+            must be a character valid for the moltype. The default value is
+            the most ambiguous character, eg. '?' for DNA
+        shadow
+            If True, masks everything but the biotypes
+        """
+        # by doing numpy.array(seq), this method applies the slice_record
+        # and modifies the underlying sequence data. We therefore split
+        # gapped sequences into their gaps and seq components and discard
+        # the current slice_record.
+        gaps = {}
+        ungapped = {}
+        for seq in self.seqs:
+            parent_name = self._name_map[seq.name]
+            gaps[parent_name] = seq.map.array
+            ungapped[parent_name] = numpy.array(
+                seq.seq.with_masked_annotations(biotypes, mask_char, shadow)
+            )
+
+        seq_data = self._seqs_data.from_seqs_and_gaps(
+            seqs=ungapped, gaps=gaps, alphabet=self.moltype.most_degen_alphabet()
+        )
+        init = self._get_init_kwargs()
+        init["seqs_data"] = seq_data
+        # we have to drop the slice record since we have changed the data
+        init["slice_record"] = None
+        return self.__class__(**init)
 
 
 @singledispatch

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -287,7 +287,7 @@ def test_terminal_gaps():
     assert aln_exons[0].get_slice().to_dict() == dict(x="AAAAA", y="--T--")
 
 
-def test_annotated_region_masks():
+def test_annotated_region_masks():  # ported to test_new_aln_annotation.py
     """masking a sequence with specific features"""
 
     # Annotated regions can be masked (observed sequence characters
@@ -388,7 +388,7 @@ def test_annotated_region_masks():
     }
 
 
-def test_nested_annotated_region_masks():
+def test_nested_annotated_region_masks():  # ported to test_new_aln_annotation.py
     """masking a sequence with specific features when nested annotations"""
     db = GffAnnotationDb()
     db.add_feature(seqid="x", biotype="gene", name="norwegian", spans=[(0, 4)])


### PR DESCRIPTION
## Summary by Sourcery

Implement the Alignment.with_masked_annotations() method to enable masking of annotated regions in sequences. Refactor and port related tests to a new test file for better organization and clarity.

New Features:
- Introduce the Alignment.with_masked_annotations() method to allow masking of annotated regions in sequences with a specified character.

Enhancements:
- Refactor tests related to annotated region masking by porting them from test_features.py to test_new_aln_annotation.py and breaking them into multiple tests for clarity.