### PR TITLE
ENH: improved speed of variable_positions

### DIFF
--- a/src/cogent3/core/new_alphabet.py
+++ b/src/cogent3/core/new_alphabet.py
@@ -260,17 +260,17 @@ class CharAlphabet(tuple, AlphabetABC, MonomerAlphabetABC):
         gap: OptStr = None,
         missing: OptStr = None,
     ):
+        self.dtype = get_array_type(len(self))
         self._gap_char = gap
-        self._gap_index = self.index(gap) if gap else None
+        self._gap_index = self.dtype(self.index(gap)) if gap else None
         self._missing_char = missing
-        self._missing_index = self.index(missing) if missing else None
+        self._missing_index = self.dtype(self.index(missing)) if missing else None
 
         # the number of canonical states are non-gap, non-missing states
         adj = (1 if gap else 0) + (1 if missing else 0)
 
         self._num_canonical = len(self) - adj
 
-        self.dtype = get_array_type(len(self))
         self._chars = set(self)  # for quick lookup
         byte_chars = self.as_bytes()
         self._bytes2arr = bytes_to_array(byte_chars, dtype=self.dtype)

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -3816,12 +3816,56 @@ def test_variable_positions():
     """correctly identify variable positions"""
     new_seqs = {"A": "-CG-C", "B": "ACAA?", "C": "GCGAC"}
     aln = new_alignment.make_aligned_seqs(new_seqs, moltype="dna")
-    assert aln.variable_positions(include_gap_motif=True) == [0, 2, 3, 4]
-    assert aln.variable_positions(include_gap_motif=False) == [0, 2]
+    assert aln.variable_positions(include_gap_motif=True) == (0, 2, 3, 4)
+    assert aln.variable_positions(include_gap_motif=False) == (0, 2)
     new_seqs = {"A": "GCGAC", "B": "GCGAC", "C": "GCGAC"}
     aln = new_alignment.make_aligned_seqs(new_seqs, moltype="dna")
-    assert aln.variable_positions(include_gap_motif=True) == []
-    assert aln.variable_positions(include_gap_motif=False) == []
+    assert aln.variable_positions(include_gap_motif=True) == ()
+    assert aln.variable_positions(include_gap_motif=False) == ()
+    new_seqs = {"A": "-CG?C-", "B": "ACAAYA", "C": "GCGACA"}
+    aln = new_alignment.make_aligned_seqs(new_seqs, moltype="dna")
+    assert aln.variable_positions(include_gap_motif=False, include_ambiguity=True) == (
+        0,
+        2,
+        3,
+        4,
+    )
+    assert aln.variable_positions(include_gap_motif=True, include_ambiguity=True) == (
+        0,
+        2,
+        3,
+        4,
+        5,
+    )
+
+
+def test_variable_positions_motif_length():
+    """correctly identify variable positions"""
+    #                 *  - ?
+    new_seqs = {"A": "-CG-CA", "B": "ACGACA", "C": "GCGACY"}
+    aln = new_alignment.make_aligned_seqs(new_seqs, moltype="dna")
+    # only the first dinucleotide is variable if gaps and ambigs disallowed
+    assert aln.variable_positions(
+        motif_length=2, include_gap_motif=False, include_ambiguity=False
+    ) == (0, 1)
+    # if gaps are allowed, the second dinucleotide is also variable
+    assert aln.variable_positions(
+        motif_length=2, include_gap_motif=True, include_ambiguity=False
+    ) == (0, 1, 2, 3)
+    # if no gaps but ambig allowed, the third dinucleotide is also variable
+    assert aln.variable_positions(
+        motif_length=2, include_gap_motif=False, include_ambiguity=True
+    ) == (0, 1, 4, 5)
+    # if gaps and ambig allowed all are variable
+    assert aln.variable_positions(
+        motif_length=2, include_gap_motif=True, include_ambiguity=True
+    ) == (0, 1, 2, 3, 4, 5)
+    # variable remains modulo motif_length
+    new_seqs = {"A": "-CG-CAA", "B": "ACGACAC", "C": "GCGACYG"}
+    aln = new_alignment.make_aligned_seqs(new_seqs, moltype="dna")
+    assert aln.variable_positions(
+        motif_length=2, include_gap_motif=True, include_ambiguity=True
+    ) == (0, 1, 2, 3, 4, 5)
 
 
 def test_alignment_counts_per_pos():


### PR DESCRIPTION
[CHANGED] use numba.jit functions for different argument cases.
     These are now cached.

[NEW] added motif_length argument to variable_positions method

## Summary by Sourcery

Enhance the variable_positions method by integrating numba.jit for performance improvements and introducing a new motif_length argument. Update tests to validate the new functionality and performance enhancements.

New Features:
- Add a motif_length argument to the variable_positions method, enabling the identification of variable positions based on motif length.

Enhancements:
- Improve performance of the variable_positions method by using numba.jit for different argument cases, allowing for caching and faster execution.

Tests:
- Expand tests for the variable_positions method to cover new functionality, including the motif_length argument and different combinations of include_gap_motif and include_ambiguity parameters.