### PR TITLE
DEV: views and seqs_data do not support serialisation

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -640,11 +640,12 @@ class SequenceCollection:
         # both SequenceCollection and Alignment implement _get_init_kwargs,
         # ensuring methods in SequenceCollection that are inherited by Alignment
         # capture initialisation arguments unique to the subclass.
+        # mutable arguments are copied
         return {
             "seqs_data": self._seqs_data,
             "moltype": self.moltype,
-            "name_map": self._name_map,
-            "info": self.info,
+            "name_map": self._name_map.copy(),
+            "info": self.info.copy(),
             "annotation_db": self.annotation_db,
             "is_reversed": self._is_reversed,
         }
@@ -886,8 +887,6 @@ class SequenceCollection:
         """
         kwargs = self._get_init_kwargs()
         kwargs.pop("is_reversed", None)  # reversal is realised
-        kwargs["name_map"] = self._name_map.copy()  # name_map is mutable
-        kwargs["info"] = self.info.copy()  # info is mutable
         kwargs["moltype"] = self.moltype.label
         kwargs.pop("annotation_db", None)
         kwargs.pop(
@@ -3927,8 +3926,8 @@ class Alignment(SequenceCollection):
         return {
             "seqs_data": self._seqs_data,
             "moltype": self.moltype,
-            "name_map": self._name_map,
-            "info": self.info,
+            "name_map": self._name_map.copy(),
+            "info": self.info.copy(),
             "annotation_db": self.annotation_db,
             "slice_record": self._slice_record,
         }
@@ -6097,8 +6096,6 @@ class Alignment(SequenceCollection):
     def copy(self):
         """creates new instance, only mutable attributes are copied"""
         kwargs = self._get_init_kwargs()
-        kwargs["name_map"] = self._name_map.copy()
-        kwargs["info"] = self.info.copy()
         return self.__class__(**kwargs)
 
     def deepcopy(self, **kwargs):
@@ -6113,8 +6110,6 @@ class Alignment(SequenceCollection):
 
         kwargs = self._get_init_kwargs()
         kwargs.pop("seqs_data")
-        kwargs["name_map"] = self._name_map.copy()
-        kwargs["info"] = self.info.copy()
         kwargs["annotation_db"] = (
             None
             if len(self) != self._seqs_data.align_len
@@ -6143,8 +6138,6 @@ class Alignment(SequenceCollection):
         """returns a json serialisable dict"""
         kwargs = self._get_init_kwargs()
         kwargs.pop("slice_record")  # slice is realised
-        kwargs["name_map"] = self._name_map.copy()  # name_map is mutable
-        kwargs["info"] = self.info.copy()  # info is mutable
         kwargs["moltype"] = self.moltype.label
         kwargs.pop("annotation_db", None)  # we dont serialise the annotation db
         kwargs.pop(

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -306,9 +306,6 @@ class SeqsDataABC(ABC):
     def add_seqs(self, seqs, **kwargs) -> SeqsDataABC: ...
 
     @abstractmethod
-    def to_rich_dict(self) -> dict: ...
-
-    @abstractmethod
     def __len__(self) -> int: ...
 
     @abstractmethod
@@ -543,33 +540,6 @@ class SeqsData(SeqsDataABC):
     @__getitem__.register
     def _(self, index: int) -> new_sequence.SeqViewABC:
         return self[self.names[index]]
-
-    def to_rich_dict(self) -> dict[str, str | dict[str, str]]:
-        """returns a json serialisable dict"""
-        return {
-            "init_args": {
-                "data": {name: self.get_seq_str(seqid=name) for name in self.names},
-                "alphabet": self.alphabet.to_rich_dict(),
-                "offset": self._offset,
-            },
-            "type": get_object_provenance(self),
-            "version": __version__,
-        }
-
-    @classmethod
-    def from_rich_dict(cls, data: dict[str, str | dict[str, str]]) -> SeqsData:
-        """returns a new instance from a rich dict"""
-        alphabet = deserialise_object(data["init_args"]["alphabet"])
-        return cls(
-            data=data["init_args"]["data"],
-            alphabet=alphabet,
-            offset=data["init_args"]["offset"],
-        )
-
-
-@register_deserialiser(get_object_provenance(SeqsData))
-def deserialise_seqs_data(data: dict[str, str | dict[str, str]]) -> SeqsData:
-    return SeqsData.from_rich_dict(data)
 
 
 class SequenceCollection:
@@ -3590,10 +3560,6 @@ class AlignedSeqsData(AlignedSeqsDataABC):
 
         return self._gapped[indices, start:stop:step]
 
-    def to_rich_dict(self):
-        # todo: kath
-        ...
-
 
 class AlignedDataViewABC(new_sequence.SeqViewABC):
     __slots__ = ()
@@ -3786,10 +3752,6 @@ class AlignedDataView(new_sequence.SeqViewABC):
             "alphabet": self.alphabet,
             "slice_record": self.slice_record,
         }
-
-    def to_rich_dict(self) -> dict:
-        ...
-        # todo: kath...
 
     def get_seq_view(self) -> new_sequence.SeqViewABC:
         # we want the parent coordinates in sequence coordinates

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -335,18 +335,6 @@ def test_seqs_data_to_alphabet_invalid():
         _ = seqs.to_alphabet(DNA)
 
 
-def test_seqs_data_round_trip(dna_alphabet):
-    seqs_data = new_alignment.SeqsData(
-        data={"seq1": "ACGG", "seq2": "CGCA", "seq3": "CCG-"}, alphabet=dna_alphabet
-    )
-    rd = seqs_data.to_rich_dict()
-    got = deserialise_object(rd)
-    assert isinstance(got, new_alignment.SeqsData)
-    assert got.to_rich_dict() == seqs_data.to_rich_dict()
-    expect = "ACGG"
-    assert str(got.get_view("seq1")) == expect
-
-
 @pytest.mark.parametrize(
     "index",
     [

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -2470,8 +2470,6 @@ def test_copied_parent_coordinates(sliced, rev, start_stop):
     # matches original
     assert copied.parent_coordinates() == seq.parent_coordinates()
     # and expected -- the coordinate name always reflects the underlying sequence
-    # the strand will always be 1 for a copied sequence because the reversal is
-    #
     assert copied.parent_coordinates() == (orig_name, start, stop, -1 if rev else 1)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Remove support for SeqView serialization and simplify the serialization process by directly using sequence strings. Update tests to reflect the removal of SeqView serialization.

Enhancements:
- Simplify the serialization process by removing the use of SeqView in the to_rich_dict method.

Tests:
- Remove tests related to SeqView serialization, as the feature is no longer supported.