### PR TITLE
ENH: add a SequenceCollection.count_ambiguous_per_seq method, fixes #2005

### DIFF
--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -828,7 +828,7 @@ def cogent3_score(aln: AlignedSeqsType) -> float:
     if aln.num_seqs == 1 or len(aln) == 0:
         msg = "zero length" if len(aln) == 0 else "single sequence"
         return NotCompleted(
-            "FAL",
+            "FAIL",
             "cogent3_score",
             f"cannot compute alignment quality because {msg}",
             source=aln.info,
@@ -838,7 +838,7 @@ def cogent3_score(aln: AlignedSeqsType) -> float:
     return align_params.get(
         "lnL",
         NotCompleted(
-            "FAL", "cogent3_score", "no alignment quality score", source=aln.info
+            "FAIL", "cogent3_score", "no alignment quality score", source=aln.info
         ),
     )
 

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -987,7 +987,9 @@ class omit_bad_seqs:
                 ]
             else:
                 warnings.warn(
-                    "ambig_fraction cannot be applied to old style alignments, set new_type=True in make_aligned_seqs to create an Alignment which supports this feature",
+                    "ambig_fraction cannot be applied to old style alignments, set "
+                    "new_type=True in make_aligned_seqs to create an Alignment which "
+                    "supports this feature",
                     UserWarning,
                 )
         result = aln.take_seqs(keep)

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import defaultdict
 from typing import List, Optional, Union
 
@@ -986,12 +985,14 @@ class omit_bad_seqs:
                     n for n in keep if ambigs_per_seq[n] / length < self._ambig_fraction
                 ]
             else:
-                warnings.warn(
+                msg = (
                     "ambig_fraction cannot be applied to old style alignments, set "
                     "new_type=True in make_aligned_seqs to create an Alignment which "
-                    "supports this feature",
-                    UserWarning,
+                    "supports this feature"
                 )
+
+                return NotCompleted("FAIL", self, msg, aln.info.source)
+
         result = aln.take_seqs(keep)
         if self._quantile is not None:
             result = result.omit_bad_seqs(quantile=self._quantile)

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -4565,13 +4565,11 @@ class Alignment(SequenceCollection):
     def count_ambiguous_per_seq(self) -> DictArray:
         """Return the counts of ambiguous characters per sequence as a DictArray."""
 
-        darr = DictArrayTemplate(self.names)
         gap_index = self.moltype.most_degen_alphabet().gap_index
+        ambigs_pos = self.array_seqs > gap_index
+        ambigs = ambigs_pos.sum(axis=1)
 
-        ambigs = self.array_seqs > gap_index
-        result = ambigs.sum(axis=1)
-
-        return darr.wrap(result)
+        return DictArray.from_array_names(ambigs, self.names)
 
     def variable_positions(
         self,

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -363,6 +363,12 @@ class Sequence:
 
         return counts
 
+    def count_ambiguous(self) -> int:
+        """Returns the number of ambiguous characters in the sequence."""
+        data = numpy.array(self)
+        gap_index = self.moltype.most_degen_alphabet().gap_index
+        return numpy.sum(data > gap_index)
+
     def __lt__(self, other):
         """compares based on the sequence string."""
         return str(self) < str(other)

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from warnings import catch_warnings, filterwarnings
 
 import pytest
 
@@ -293,40 +294,6 @@ class TranslateTests(TestCase):
         for name, seq in got.to_dict().items():
             self.assertIn(seq, expect[name])
 
-    def test_omit_bad_seqs(self):
-        """correctly omit bad sequences from an alignment"""
-        data = {
-            "s1": "---ACC---TT-",
-            "s2": "---ACC---TT-",
-            "s3": "---ACC---TT-",
-            "s4": "--AACCG-GTT-",
-            "s5": "--AACCGGGTTT",
-            "s6": "AGAACCGGGTT-",
-            "s7": "------------",
-        }
-        aln = make_aligned_seqs(data=data, moltype=DNA)
-        # default just eliminates strict gap sequences
-        dropbad = sample.omit_bad_seqs()
-        got = dropbad(aln)
-        expect = data.copy()
-        del expect["s7"]
-        self.assertEqual(got.to_dict(), expect)
-        # providing a more stringent gap_frac
-        dropbad = sample.omit_bad_seqs(gap_fraction=0.5)
-        got = dropbad(aln)
-        expect = data.copy()
-        for n in ("s1", "s2", "s3", "s7"):
-            del expect[n]
-        self.assertEqual(got.to_dict(), expect)
-
-        # setting quantile drops additional sequences
-        dropbad = sample.omit_bad_seqs(quantile=6 / 7)
-        got = dropbad(aln)
-        expect = data.copy()
-        for n in ("s6", "s7"):
-            del expect[n]
-        self.assertEqual(got.to_dict(), expect)
-
     def test_omit_duplicated(self):
         """correctly drop duplicated sequences"""
         # strict omit_duplicated
@@ -565,3 +532,91 @@ def test_concat_empty(data):
     ccat = sample.concat()
     got = ccat(data)
     assert isinstance(got, NotCompleted)
+
+
+@pytest.fixture
+def bad_gap_data():
+    return {
+        "s1": "---ACC---TT-",
+        "s2": "---ACC---TT-",
+        "s3": "---ACC---TT-",
+        "s4": "--AACCG-GTT-",
+        "s5": "--AACCGGGTTT",
+        "s6": "AGAACCGGGTT-",
+        "s7": "------------",
+    }
+
+
+@pytest.mark.parametrize(
+    "gap_fraction, quantile, expected_keys",
+    [
+        (
+            1,
+            None,
+            {"s1", "s2", "s3", "s4", "s5", "s6"},
+        ),  # default just eliminates strict gap sequences
+        (0.5, None, {"s4", "s5", "s6"}),  # providing a more stringent gap_frac
+        (
+            1,
+            6 / 7,
+            {"s1", "s2", "s3", "s4", "s5"},
+        ),  # setting quantile drops additional sequences
+    ],
+)
+def test_omit_bad_seqs(bad_gap_data, gap_fraction, quantile, expected_keys):
+    """correctly omit bad sequences from an alignment"""
+
+    dropbad = sample.omit_bad_seqs(gap_fraction=gap_fraction, quantile=quantile)
+    aln = make_aligned_seqs(bad_gap_data, moltype=DNA)
+    got = dropbad(aln)
+    expected = {k: bad_gap_data[k] for k in expected_keys}
+    assert got.to_dict() == expected
+
+
+@pytest.fixture
+def bad_ambig_gap_data():
+    return {
+        "s1": "---ACC---TT-",
+        "s2": "---ACC---TT-",
+        "s3": "SSSACCSSSTTS",
+        "s4": "SSAACCGSGTTS",
+        "s5": "--AACCGGGTTT",
+        "s6": "AGAACCGGGTT-",
+        "s7": "SSSSSSSSSSSS",
+    }
+
+
+def test_omit_bad_seqs_ambigs(bad_ambig_gap_data):
+    """correctly omit sequences from a new style alignment via fraction of ambiguous data"""
+    from cogent3.core import new_alignment
+
+    aln = new_alignment.make_aligned_seqs(bad_ambig_gap_data, moltype="dna")
+
+    # drop sequences with all ambiguous data
+    dropbad = sample.omit_bad_seqs(ambig_fraction=1)
+    got = dropbad(aln)
+    assert set(got.to_dict().keys()) == {"s1", "s2", "s3", "s4", "s5", "s6"}
+
+    # drop sequences with more than 50% ambiguous data
+    dropbad = sample.omit_bad_seqs(ambig_fraction=0.5)
+    got = dropbad(aln)
+    assert set(got.to_dict().keys()) == {"s1", "s2", "s4", "s5", "s6"}
+
+    # drop sequences with more than 50% ambiguous data and 50% gaps
+    dropbad = sample.omit_bad_seqs(gap_fraction=0.5, ambig_fraction=0.5)
+    got = dropbad(aln)
+    assert set(got.to_dict().keys()) == {"s4", "s5", "s6"}
+
+
+def test_omit_bad_seqs_ambigs_old_aln(bad_ambig_gap_data):
+    # ambig_fraction should be ignored if using old style alignment
+
+    aln = make_aligned_seqs(bad_ambig_gap_data, moltype=DNA)
+    dropbad = sample.omit_bad_seqs(gap_fraction=0.5, ambig_fraction=0.5)
+
+    with catch_warnings():
+        filterwarnings("ignore", category=UserWarning)
+        got = dropbad(aln)
+
+    # only sequences with more than 50% gaps should be dropped
+    assert set(got.to_dict().keys()) == {"s3", "s4", "s5", "s6", "s7"}

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -602,6 +602,11 @@ def test_omit_bad_seqs_ambigs(bad_ambig_gap_data):
     got = dropbad(aln)
     assert set(got.to_dict().keys()) == {"s1", "s2", "s4", "s5", "s6"}
 
+    # drop sequences with any ambiguous data
+    dropbad = sample.omit_bad_seqs(ambig_fraction=0.01)
+    got = dropbad(aln)
+    assert set(got.to_dict().keys()) == {"s1", "s2", "s5", "s6"}
+
     # drop sequences with more than 50% ambiguous data and 50% gaps
     dropbad = sample.omit_bad_seqs(gap_fraction=0.5, ambig_fraction=0.5)
     got = dropbad(aln)

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from warnings import catch_warnings, filterwarnings
 
 import pytest
 
@@ -619,9 +618,5 @@ def test_omit_bad_seqs_ambigs_old_aln(bad_ambig_gap_data):
     aln = make_aligned_seqs(bad_ambig_gap_data, moltype=DNA)
     dropbad = sample.omit_bad_seqs(gap_fraction=0.5, ambig_fraction=0.5)
 
-    with catch_warnings():
-        filterwarnings("ignore", category=UserWarning)
-        got = dropbad(aln)
-
-    # only sequences with more than 50% gaps should be dropped
-    assert set(got.to_dict().keys()) == {"s3", "s4", "s5", "s6", "s7"}
+    got = dropbad(aln)
+    assert isinstance(got, NotCompleted)

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -1839,6 +1839,22 @@ def test_sequence_collection_counts():
     assert all(got[k] == v for k, v in expect.items())
 
 
+@pytest.mark.parametrize(
+    "mk_cls", [new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs]
+)
+def test_sequence_collection_count_ambiguous_per_seq(mk_cls):
+    data = {
+        "a": "AGGGT",
+        "b": "AGGN?",
+        "c": "?????",
+        "d": "-----",
+    }
+    coll = mk_cls(data, moltype="dna")
+    got = coll.count_ambiguous_per_seq()
+    expect = {"a": 0, "b": 2, "c": 5, "d": 0}
+    assert got == expect
+
+
 def test_sequence_collection_make_feature(seqs):
     data = {"seqid": "seq1", "biotype": "xyz", "name": "abc", "spans": [(1, 2)]}
     feat = seqs.make_feature(feature=data)

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -831,6 +831,20 @@ def test_counts():
     assert dict(got) == expect
 
 
+@pytest.mark.parametrize(
+    "data, expect",
+    [
+        ("CCTTNN", 2),
+        ("???MMM", 6),
+        ("TGCAGG", 0),
+        ("", 0),
+    ],
+)
+def test_count_ambiguous(data, expect):
+    seq = new_moltype.DNA.make_seq(seq=data)
+    assert seq.count_ambiguous() == expect
+
+
 def test_strand_symmetry():
     """correctly compute test of strand symmetry"""
     from cogent3 import get_moltype


### PR DESCRIPTION
## Summary by Sourcery

Add a new method to count ambiguous characters per sequence and enhance sequence filtering by introducing an ambig_fraction parameter. Update tests to cover these new functionalities.

New Features:
- Introduce a method count_ambiguous_per_seq in SequenceCollection to count ambiguous characters per sequence.

Enhancements:
- Add ambig_fraction parameter to omit_bad_seqs function to allow filtering sequences based on ambiguous character content.

Tests:
- Add tests for the new count_ambiguous_per_seq method in SequenceCollection.
- Add tests for the ambig_fraction parameter in omit_bad_seqs function.