### PR TITLE
BUG: fixed a regression in expanding user paths for loading sequences

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -286,6 +286,7 @@ def _load_files_to_unaligned_seqs(
 
 def _load_seqs(file_format, filename, fmt, parser_kw):
     """utility function for loading sequences"""
+    filename = pathlib.Path(filename).expanduser()
     fmt = fmt or file_format
     if not fmt:
         msg = "could not determined file format, set using the format argument"
@@ -487,6 +488,7 @@ def load_aligned_seqs(
     label_to_name=None,
     parser_kw=None,
     info=None,
+    new_type: bool = False,
     **kw,
 ):
     """
@@ -506,6 +508,11 @@ def load_aligned_seqs(
         function for converting original name into another name.
     parser_kw : dict
         optional arguments for the parser
+    new_type
+        if True, the returned Alignment will be of the new type,
+        (cogent3.core.new_alignment.Alignment). The default will be
+        changed to True in 2024.12. Support for the old style will be removed
+        as of 2025.6.
     kw
         passed to make_aligned_seqs
 
@@ -525,6 +532,7 @@ def load_aligned_seqs(
         moltype=moltype,
         source=filename,
         info=info,
+        new_type=new_type,
         **kw,
     )
 

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5221,8 +5221,23 @@ def test_deserialise_alignment():
     assert str(aln.get_seq("new_seq2")) == "TAGC"
 
 
+@pytest.fixture
+def home_seqs(DATA_DIR) -> str:
+    """makes a temporary directory with file"""
+    import tempfile
+
+    HOME = pathlib.Path("~").expanduser()
+    fn = "brca1.fasta"
+    contents = (DATA_DIR / fn).read_text()
+    with tempfile.TemporaryDirectory(dir=HOME) as dn:
+        dn = pathlib.Path(dn)
+        outpath = HOME / dn.name / fn
+        outpath.expanduser().write_text(contents)
+        yield f"~/{dn.name}/{fn}"
+
+
 @pytest.mark.parametrize("mk_cls", [load_aligned_seqs, load_unaligned_seqs])
-def test_load_with_pathlib(mk_cls, DATA_DIR):
-    path = f"~/{(DATA_DIR / 'brca1.fasta').relative_to(pathlib.Path.home())}"
+def test_load_with_pathlib(mk_cls, home_seqs):
+    path = home_seqs
     got = mk_cls(path, moltype="dna")
     assert "Human" in got.names

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5219,3 +5219,10 @@ def test_deserialise_alignment():
     assert aln.names == ["new_seq1", "new_seq2"]
     assert str(aln.get_seq("new_seq1")) == "ATCG"
     assert str(aln.get_seq("new_seq2")) == "TAGC"
+
+
+@pytest.mark.parametrize("mk_cls", [load_aligned_seqs, load_unaligned_seqs])
+def test_load_with_pathlib(mk_cls, DATA_DIR):
+    path = f"~/{(DATA_DIR / "brca1.fasta").relative_to(pathlib.Path.home())}"
+    got = mk_cls(path, moltype="dna")
+    assert "Human" in got.names

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5223,6 +5223,6 @@ def test_deserialise_alignment():
 
 @pytest.mark.parametrize("mk_cls", [load_aligned_seqs, load_unaligned_seqs])
 def test_load_with_pathlib(mk_cls, DATA_DIR):
-    path = f"~/{(DATA_DIR / "brca1.fasta").relative_to(pathlib.Path.home())}"
+    path = f"~/{(DATA_DIR / 'brca1.fasta').relative_to(pathlib.Path.home())}"
     got = mk_cls(path, moltype="dna")
     assert "Human" in got.names


### PR DESCRIPTION
## Summary by Sourcery

Fix a regression in user path expansion for sequence loading and introduce a new parameter to support future alignment type changes. Add a test to ensure correct path handling with pathlib.

Bug Fixes:
- Fix a regression in expanding user paths for loading sequences by using pathlib.Path.expanduser().

Enhancements:
- Add a new parameter 'new_type' to the load_aligned_seqs function to support future changes in alignment type.

Tests:
- Add a test to verify loading sequences with user paths expanded using pathlib.