### PR TITLE
TST: convert the union_dict class to pytest style

### DIFF
--- a/tests/test_util/test_union_dict.py
+++ b/tests/test_util/test_union_dict.py
@@ -1,115 +1,118 @@
-#!/usr/bin/env python
-
 """Unit tests for union_dict."""
-
-from unittest import TestCase
 
 from cogent3.util.union_dict import UnionDict
 
 
-class UnionDictTests(TestCase):
-    """Tests of individual functions in union_dict"""
+def test_attr():
+    """test the "." read/write functionality"""
+    d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
+    assert d.a == 1
+    assert d.b == 2
+    assert d.d.e == 5
+    d.c = 0
+    d.d.f = 0
+    assert d.c == 0
+    assert d.d.f == 0
 
-    def test_attr(self):
-        """test the "." read/write functionality"""
-        d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
-        self.assertEqual(d.a, 1)
-        self.assertEqual(d.b, 2)
-        self.assertEqual(d.d.e, 5)
-        d.c = 0
-        d.d.f = 0
-        self.assertEqual(d.c, 0)
-        self.assertEqual(d.d.f, 0)
 
-    def test_construction(self):
-        """should handle deeply nested dict"""
-        data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
-        d = UnionDict(data)
-        self.assertEqual(d.xaxis.title.text, "Alignment Position")
+def test_construction():
+    """should handle deeply nested dict"""
+    data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
+    d = UnionDict(data)
+    assert d.xaxis.title.text == "Alignment Position"
 
-    def test_construct_from_empty(self):
-        """successfully define from an empty"""
-        data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
-        # empty object
-        d = UnionDict()
-        self.assertTrue(len(d) == 0)
-        # using update
-        d.update(data)
-        self.assertEqual(d.xaxis.title.text, "Alignment Position")
 
-    def test_construct_from_kwargs(self):
-        """successfully define from an kwargs"""
-        data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
-        # empty object
-        d = UnionDict(**data)
-        self.assertEqual(d.xaxis.title.text, "Alignment Position")
+def test_construct_from_empty():
+    """successfully define from an empty"""
+    data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
+    # empty object
+    d = UnionDict()
+    assert len(d) == 0
+    # using update
+    d.update(data)
+    assert d.xaxis.title.text == "Alignment Position"
 
-    def test_union(self):
-        """correctly adjust a prob vector so all values > minval"""
-        d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
-        e = UnionDict({"b": 0, "d": {"f": 0, "g": 7}})
-        d |= e
-        self.assertEqual(d.a, 1)
-        self.assertEqual(d.b, 0)
-        self.assertEqual(d.d.e, 5)
-        self.assertEqual(d.d.f, 0)
-        self.assertEqual(d.d.g, 7)
 
-    def test_or(self):
-        """should not modify original"""
-        d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
-        e = UnionDict({"b": 0, "d": {"f": 0, "g": 7}})
-        f = d | e
-        self.assertEqual(f.a, 1)
-        self.assertEqual(f.b, 0)
-        self.assertEqual(f.d.e, 5)
-        self.assertEqual(f.d.f, 0)
-        self.assertEqual(f.d.g, 7)
-        self.assertTrue(f.d is not e.d)
+def test_construct_from_kwargs():
+    """successfully define from an kwargs"""
+    data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
+    # empty object
+    d = UnionDict(**data)
+    assert d.xaxis.title.text == "Alignment Position"
 
-    def test_union_value_dict(self):
-        """replacing union or of a value with a dict should be dict"""
-        d = UnionDict({"A": {"B": "Blah"}})
-        e = UnionDict({"A": "Blah"})
-        f = UnionDict(d.copy())
-        f |= e
-        self.assertNotEqual(d, f)
-        e |= d
-        self.assertEqual(d, e)
 
-    def test_union_with_empty_sub_dict(self):
-        """unioning with a dict that has an empty sub-dict"""
-        d = UnionDict({"title": {}})
-        e = UnionDict({"title": {"text": "Alignment Position"}})
-        f = UnionDict(e.copy())
-        e |= d
-        self.assertEqual(e, f)
+def test_union():
+    """correctly adjust a prob vector so all values > minval"""
+    d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
+    e = UnionDict({"b": 0, "d": {"f": 0, "g": 7}})
+    d |= e
+    assert d.a == 1
+    assert d.b == 0
+    assert d.d.e == 5
+    assert d.d.f == 0
+    assert d.d.g == 7
 
-    def test_sub_dicts_are_union(self):
-        """checks if UnionDict is propogated to children"""
-        d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
-        d.e = {"g": 7}
-        d.e.g = {"h": 8}
-        self.assertTrue(isinstance(d, UnionDict))
-        self.assertTrue(isinstance(d.d, UnionDict))
-        self.assertTrue(isinstance(d.e, UnionDict))
-        self.assertTrue(isinstance(d.e.g, UnionDict))
 
-    def test_get_subattr(self):
-        """_getsubattr_ returns nested values via key"""
-        d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
-        self.assertEqual(d._getsubattr_([], "a"), 1)
-        self.assertEqual(d._getsubattr_([], "d"), UnionDict({"e": 5, "f": 6}))
-        self.assertEqual(d._getsubattr_(["d"], "e"), 5)
+def test_or():
+    """should not modify original"""
+    d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
+    e = UnionDict({"b": 0, "d": {"f": 0, "g": 7}})
+    f = d | e
+    assert f.a == 1
+    assert f.b == 0
+    assert f.d.e == 5
+    assert f.d.f == 0
+    assert f.d.g == 7
+    assert f.d is not e.d
 
-    def test_setitem(self):
-        """should work via property or key"""
-        d = UnionDict()
-        d.a = 23
-        d.b = dict(c=42)
-        self.assertEqual(d.a, 23)
-        self.assertEqual(d["a"], 23)
-        self.assertEqual(d.b, dict(c=42))
-        self.assertEqual(d.b.c, 42)
-        self.assertEqual(d["b"], dict(c=42))
-        self.assertIsInstance(d.b, UnionDict)
+
+def test_union_value_dict():
+    """replacing union or of a value with a dict should be dict"""
+    d = UnionDict({"A": {"B": "Blah"}})
+    e = UnionDict({"A": "Blah"})
+    f = UnionDict(d.copy())
+    f |= e
+    assert d != f
+    e |= d
+    assert d == e
+
+
+def test_union_with_empty_sub_dict():
+    """unioning with a dict that has an empty sub-dict"""
+    d = UnionDict({"title": {}})
+    e = UnionDict({"title": {"text": "Alignment Position"}})
+    f = UnionDict(e.copy())
+    e |= d
+    assert e == f
+
+
+def test_sub_dicts_are_union():
+    """checks if UnionDict is propogated to children"""
+    d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
+    d.e = {"g": 7}
+    d.e.g = {"h": 8}
+    assert isinstance(d, UnionDict)
+    assert isinstance(d.d, UnionDict)
+    assert isinstance(d.e, UnionDict)
+    assert isinstance(d.e.g, UnionDict)
+
+
+def test_get_subattr():
+    """_getsubattr_ returns nested values via key"""
+    d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
+    assert d._getsubattr_([], "a") == 1
+    assert d._getsubattr_([], "d") == UnionDict({"e": 5, "f": 6})
+    assert d._getsubattr_(["d"], "e") == 5
+
+
+def test_setitem():
+    """should work via property or key"""
+    d = UnionDict()
+    d.a = 23
+    d.b = {"c": 42}
+    assert d.a == 23
+    assert d["a"] == 23
+    assert d.b == {"c": 42}
+    assert d.b.c == 42
+    assert d["b"] == {"c": 42}
+    assert isinstance(d.b, UnionDict)

--- a/tests/test_util/test_union_dict.py
+++ b/tests/test_util/test_union_dict.py
@@ -1,5 +1,6 @@
 """Unit tests for union_dict."""
 
+
 from cogent3.util.union_dict import UnionDict
 
 
@@ -14,13 +15,11 @@ def test_attr():
     assert d.c == 0
     assert d.d.f == 0
 
-
 def test_construction():
     """should handle deeply nested dict"""
     data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
     d = UnionDict(data)
     assert d.xaxis.title.text == "Alignment Position"
-
 
 def test_construct_from_empty():
     """successfully define from an empty"""
@@ -32,7 +31,6 @@ def test_construct_from_empty():
     d.update(data)
     assert d.xaxis.title.text == "Alignment Position"
 
-
 def test_construct_from_kwargs():
     """successfully define from an kwargs"""
     data = {"width": 600.0, "xaxis": {"title": {"text": "Alignment Position"}}}
@@ -40,9 +38,8 @@ def test_construct_from_kwargs():
     d = UnionDict(**data)
     assert d.xaxis.title.text == "Alignment Position"
 
-
 def test_union():
-    """correctly adjust a prob vector so all values > minval"""
+    """correctly merges two UnionDicts"""
     d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
     e = UnionDict({"b": 0, "d": {"f": 0, "g": 7}})
     d |= e
@@ -51,7 +48,6 @@ def test_union():
     assert d.d.e == 5
     assert d.d.f == 0
     assert d.d.g == 7
-
 
 def test_or():
     """should not modify original"""
@@ -65,7 +61,6 @@ def test_or():
     assert f.d.g == 7
     assert f.d is not e.d
 
-
 def test_union_value_dict():
     """replacing union or of a value with a dict should be dict"""
     d = UnionDict({"A": {"B": "Blah"}})
@@ -76,7 +71,6 @@ def test_union_value_dict():
     e |= d
     assert d == e
 
-
 def test_union_with_empty_sub_dict():
     """unioning with a dict that has an empty sub-dict"""
     d = UnionDict({"title": {}})
@@ -84,7 +78,6 @@ def test_union_with_empty_sub_dict():
     f = UnionDict(e.copy())
     e |= d
     assert e == f
-
 
 def test_sub_dicts_are_union():
     """checks if UnionDict is propogated to children"""
@@ -96,14 +89,12 @@ def test_sub_dicts_are_union():
     assert isinstance(d.e, UnionDict)
     assert isinstance(d.e.g, UnionDict)
 
-
 def test_get_subattr():
     """_getsubattr_ returns nested values via key"""
     d = UnionDict({"a": 1, "b": 2, "c": 3, "d": {"e": 5, "f": 6}})
     assert d._getsubattr_([], "a") == 1
     assert d._getsubattr_([], "d") == UnionDict({"e": 5, "f": 6})
     assert d._getsubattr_(["d"], "e") == 5
-
 
 def test_setitem():
     """should work via property or key"""


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Convert the union_dict test class from unittest to pytest style, replacing class-based tests with standalone functions and using assert statements instead of self.assert methods.