### PR TITLE
API: added abstract base class for annotation db's

### DIFF
--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -303,7 +303,12 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
     def add_records(self, **kwargs): ...
 
     @abc.abstractmethod
-    def update(self, **kwargs): ...
+    def update(
+        self,
+        annot_db,
+        seqids: OptionalStrList = None,
+        **kwargs,
+    ): ...
 
     @abc.abstractmethod
     def union(self, **kwargs): ...
@@ -1117,6 +1122,7 @@ class SqliteAnnotationDbMixin:
         self,
         annot_db: SupportsFeatures,
         seqids: OptionalStrList = None,
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """update records with those from an instance of the same type"""
         if not isinstance(annot_db, SupportsFeatures):

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -92,6 +92,7 @@ class FeatureDataType(typing.TypedDict):
     spans: list[tuple[int, int]]
     strand: str  # "-" if feature on reverse strand
     on_alignment: bool  # True if feature on an alignment
+    xattr: dict[str, typing.Any]  # extra attributes
 
 
 @typing.runtime_checkable


### PR DESCRIPTION
## Summary by Sourcery

Introduce an abstract base class 'AnnotationDbABC' to standardize the interface for annotation databases and update existing database classes to implement this new interface.

New Features:
- Introduce an abstract base class 'AnnotationDbABC' for annotation databases, defining a standard interface for various operations such as adding features, updating records, and querying features.

Enhancements:
- Extend existing annotation database classes (BasicAnnotationDb, GffAnnotationDb, GenbankAnnotationDb) to implement the new 'AnnotationDbABC' abstract base class, ensuring a consistent interface across different database types.