### PR TITLE
MAINT: type hinting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,22 @@ target-version = "py310"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["ALL"]
-ignore = ["EXE002", "FA100", "E501", "D"]
+# ICN001 not adhering to nuimpy as np convention due to
+# name collision, where np is used as num params
+# N801 CamelCase is not always appropriate
+# PLR0913 number of arguments sometimes needs to be > 5
+# FBT001 and FBT002, positional boolean arguments are allowed!
+ignore = [
+    "EXE002", 
+    "FA100", 
+    "E501", 
+    "D", 
+    "N801", 
+    "ICN001", 
+    "PLR0913",
+    "FBT001",
+    "FBT002",
+    ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -202,7 +217,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "INP001", # __init__.py files are not required...
     "ANN",
     "N802",
-    "N803"
+    "N803",
+    "S608",  # sql injection unlikely
 ]
 "noxfile.py" = [
     "S101", # asserts allowed in tests...

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -23,15 +23,15 @@ from cogent3.util.misc import extend_docstring_from, get_object_provenance
 from cogent3.util.progress_display import display_wrap
 from cogent3.util.table import Table
 
-OptionalInt = typing.Optional[int]
-OptionalStr = typing.Optional[str]
-OptionalStrList = typing.Optional[str | list[str]]
-OptionalStrContainer = typing.Optional[str | typing.Sequence]
-OptionalBool = typing.Optional[bool]
-OptionalDbCursor = typing.Optional[sqlite3.Cursor]
-ReturnType = tuple[str, tuple]  # the sql statement and corresponding values
+OptionalInt = int | None
+OptionalStr = str | None
+OptionalStrList = str | list[str] | None
+OptionalStrContainer = str | typing.Sequence[str] | None
+OptionalBool = bool | None
+OptionalDbCursor = sqlite3.Cursor | None
+ReturnType = tuple[str, tuple[typing.Any]]  # the sql statement and corresponding values
 # data type for sqlitedb constructors
-T = typing.Optional[typing.Iterable[dict]]
+T = typing.Iterable[dict] | None
 
 # used for presence of sqlite feature
 _is_ge_3_11 = (sys.version_info.major, sys.version_info.minor) >= (3, 11)
@@ -43,8 +43,7 @@ def array_to_sqlite(data: numpy.ndarray) -> bytes:
     with io.BytesIO() as out:
         numpy.save(out, data)
         out.seek(0)
-        output = out.read()
-    return output
+        return out.read()
 
 
 def sqlite_to_array(data: bytes) -> numpy.ndarray:
@@ -65,6 +64,7 @@ def sqlite_to_array(data: bytes) -> numpy.ndarray:
                 "Update the file format using cogent3.core.annotation_db.update_file_format() "
                 "For reason see https://github.com/cogent3/cogent3/issues/1776.",
                 UserWarning,
+                stacklevel=2,
             )
 
     return result
@@ -74,7 +74,7 @@ def dict_to_sqlite_as_json(data: dict) -> str:
     return json.dumps(data)
 
 
-def sqlite_json_to_dict(data):
+def sqlite_json_to_dict(data: str) -> dict[str, typing.Any]:
     return json.loads(data)
 
 
@@ -101,7 +101,7 @@ class SerialisableType(typing.Protocol):  # pragma: no cover
 
     def to_json(self) -> str: ...
 
-    def from_dict(self, data): ...
+    def from_dict(self, data: dict[str, typing.Any]) -> None: ...
 
 
 @typing.runtime_checkable
@@ -118,7 +118,7 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
         on_alignment: OptionalBool = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> typing.Iterator[FeatureDataType]: ...
 
     def get_feature_children(
@@ -127,7 +127,7 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         name: str,
         start: OptionalInt = None,
         stop: OptionalInt = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> list[FeatureDataType]: ...
 
     def get_feature_parent(
@@ -136,7 +136,7 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         name: str,
         start: OptionalInt = None,
         stop: OptionalInt = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> list[FeatureDataType]: ...
 
     def num_matches(
@@ -148,7 +148,7 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
         on_alignment: OptionalBool = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> int: ...
 
     def subset(
@@ -161,8 +161,8 @@ class SupportsQueryFeatures(typing.Protocol):  # pragma: no cover
         stop: OptionalInt = None,
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
-        **kwargs,
-    ): ...
+        **kwargs: dict[str, typing.Any],
+    ) -> None: ...
 
 
 @typing.runtime_checkable
@@ -179,7 +179,7 @@ class SupportsWriteFeatures(typing.Protocol):  # pragma: no cover
         attributes: OptionalStr = None,
         strand: OptionalStr = None,
         on_alignment: bool = False,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> None: ...
 
     def add_records(
@@ -188,23 +188,23 @@ class SupportsWriteFeatures(typing.Protocol):  # pragma: no cover
         records: typing.Sequence[dict],
         # seqid required for genbank
         seqid: OptionalStr = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> None: ...
 
     def update(
         self,
-        annot_db,
+        annot_db: AnnotationDbABC,
         seqids: OptionalStrList = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         # update records with those from an instance of the same type
         ...
 
     def union(
         self,
-        annot_db,
-        **kwargs,
-    ):
+        annot_db: AnnotationDbABC,
+        **kwargs: dict[str, typing.Any],
+    ) -> SupportsFeatures:
         # returns a new instance of the more complex class
         ...
 
@@ -218,21 +218,21 @@ class SupportsFeatures(
     typing.Protocol,
 ):  # pragma: no cover
     # should be defined centrally
-    def __len__(self):
+    def __len__(self) -> int:
         # the number of records
         ...
 
-    def __eq__(self, other):
+    def __eq__(self, other: typing_extensions.Self) -> bool:
         # equality based on class and identity of the bound db
         ...
 
 
 class AnnotationDbABC(abc.ABC, SupportsFeatures):
     @abc.abstractmethod
-    def __len__(self): ...
+    def __len__(self) -> int: ...
 
     @abc.abstractmethod
-    def __eq__(self, other): ...
+    def __eq__(self, other: typing_extensions.Self) -> bool: ...
 
     @abc.abstractmethod
     def get_features_matching(
@@ -246,7 +246,7 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         strand: str | None = None,
         attributes: str | None = None,
         on_alignment: bool | None = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> collections.Iterator[FeatureDataType]: ...
 
     @abc.abstractmethod
@@ -256,7 +256,7 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         name: str,
         start: int | None = None,
         stop: int | None = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> list[FeatureDataType]: ...
 
     @abc.abstractmethod
@@ -266,7 +266,7 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         name: str,
         start: int | None = None,
         stop: int | None = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> list[FeatureDataType]: ...
 
     @abc.abstractmethod
@@ -279,7 +279,7 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         strand: str | None = None,
         attributes: str | None = None,
         on_alignment: bool | None = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> int: ...
 
     @abc.abstractmethod
@@ -293,25 +293,29 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         stop: int | None = None,
         strand: str | None = None,
         attributes: str | None = None,
-        **kwargs,
-    ): ...
+        **kwargs: dict[str, typing.Any],
+    ) -> typing_extensions.Self: ...
 
     @abc.abstractmethod
-    def add_feature(self, **kwargs): ...
+    def add_feature(self, **kwargs: dict[str, typing.Any]) -> None: ...
 
     @abc.abstractmethod
-    def add_records(self, **kwargs): ...
+    def add_records(self, **kwargs: dict[str, typing.Any]) -> None: ...
 
     @abc.abstractmethod
     def update(
         self,
-        annot_db,
+        annot_db: AnnotationDbABC,
         seqids: OptionalStrList = None,
-        **kwargs,
-    ): ...
+        **kwargs: dict[str, typing.Any],
+    ) -> None: ...
 
     @abc.abstractmethod
-    def union(self, **kwargs): ...
+    def union(
+        self,
+        annot_db: AnnotationDbABC,
+        **kwargs: dict[str, typing.Any],
+    ) -> SupportsFeatures: ...
 
 
 def _make_table_sql(
@@ -363,9 +367,9 @@ def _add_record_sql(
 
 
 def _matching_conditions(
-    conditions: dict,
+    conditions: dict[str, typing.Any],
     allow_partial: bool = True,
-):
+) -> ReturnType:
     """creates WHERE clause
 
     Parameters
@@ -392,7 +396,7 @@ def _matching_conditions(
         for col, val in conditions.items():
             # conditions are filtered for None before here, so we should add
             # an else where the op is assigned !=
-            if isinstance(val, (tuple, set, list)):
+            if isinstance(val, tuple | set | list):
                 placeholders = ",".join(["?" for _ in val])
                 op = "IN"
                 conds.append(f"{col} {op} ({placeholders})")
@@ -436,7 +440,7 @@ def _del_records_sql(
     conditions: dict,
     start: OptionalInt = None,
     stop: OptionalInt = None,
-    allow_partial=True,
+    allow_partial: bool = True,
 ) -> ReturnType:
     """creates the SQL and values for identifying records to be deleted
 
@@ -476,24 +480,19 @@ def _select_records_sql(
     table_name: str,
     conditions: dict,
     columns: list[str] | None = None,
-    start: OptionalInt = None,
-    stop: OptionalInt = None,
-    allow_partial=True,
+    allow_partial: bool = True,
 ) -> ReturnType:
     """create SQL select statement and values
 
     Parameters
     ----------
-    table_name : str
+    table_name
         containing the data to be selected from
-    columns : Tuple[str]
+    columns
         values to select
-    conditions : dict
+    conditions
         the WHERE conditions
-    start, stop : OptionalInt
-        select records whose (start, stop) values lie between start and stop,
-        or overlap them if (allow_partial is True)
-    allow_partial : bool, optional
+    allow_partial
         if False, only records within start, stop are included. If True,
         all records that overlap the segment defined by start, stop are included.
 
@@ -519,10 +518,7 @@ def _select_records_sql(
 def _count_records_sql(
     table_name: str,
     conditions: dict,
-    columns: list[str] | None = None,
-    start: OptionalInt = None,
-    stop: OptionalInt = None,
-    allow_partial=True,
+    allow_partial: bool = True,
 ) -> ReturnType:
     """create SQL count statement and values
 
@@ -564,7 +560,7 @@ def _compatible_schema(db: sqlite3.Connection, schema: dict[str, set]) -> bool:
     for table in db.execute(
         "SELECT name FROM sqlite_master WHERE type='table'",
     ).fetchall():
-        table = table["name"]
+        table = table["name"]  # noqa: PLW2901
         if table not in schema:
             return False
 
@@ -616,7 +612,7 @@ def _rename_column_if_exists(
 
 class SqliteAnnotationDbMixin:
     # table schema for user provided annotations
-    _user_schema = {
+    _user_schema: typing.ClassVar = {
         "biotype": "TEXT",
         "seqid": "TEXT",
         "name": "TEXT",
@@ -631,7 +627,7 @@ class SqliteAnnotationDbMixin:
     # args to exclude from serialisation init
     _exclude_init = "db", "data"
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs: dict[str, typing.Any]):
         obj = object.__new__(cls)
         init_sig = inspect.signature(cls.__init__)
         bargs = init_sig.bind_partial(cls, *args, **kwargs)
@@ -641,10 +637,10 @@ class SqliteAnnotationDbMixin:
             init_vals.pop(param)
         init_vals.pop("self", None)
 
-        obj._serialisable = init_vals
+        obj._serialisable = init_vals  # noqa: SLF001
         return obj
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = self.__class__.__name__
         total_records = len(self)
         args = ", ".join(
@@ -654,7 +650,7 @@ class SqliteAnnotationDbMixin:
         )
         return f"{name}({args}, total_records={total_records})"
 
-    def __deepcopy__(self, memodict=None):
+    def __deepcopy__(self, memodict: dict | None = None) -> typing_extensions.Self:
         memodict = memodict or {}
         if _is_ge_3_11:
             new = self.__class__(source=self.source)
@@ -665,16 +661,16 @@ class SqliteAnnotationDbMixin:
         rd = self.to_rich_dict()
         return type(self).from_dict(rd)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, typing.Any]:
         if _is_ge_3_11:
             return {"data": self._db.serialize(), "source": self.source}
 
         return self.to_rich_dict()
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, typing.Any]) -> typing_extensions.Self:
         if _is_ge_3_11:
             new = self.__class__(source=state.pop("source", None))
-            new._db.deserialize(state["data"])
+            new._db.deserialize(state["data"])  # noqa: SLF001
             self.__dict__.update(new.__dict__)
             return self
 
@@ -683,10 +679,10 @@ class SqliteAnnotationDbMixin:
         self.__dict__.update(data.__dict__)
         return self
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.num_matches()
 
-    def __eq__(self, other):
+    def __eq__(self, other: typing_extensions.Self) -> bool:
         return isinstance(other, self.__class__) and other.db is self.db
 
     @property
@@ -706,14 +702,16 @@ class SqliteAnnotationDbMixin:
                 schema[table_name] = set(attr.items())
 
             if not _compatible_schema(db, schema):
-                raise TypeError("incompatible schema")
+                msg = "incompatible schema"
+                raise TypeError(msg)
 
             self._db = db
             self._init_tables()
             return
 
         if db and not self.compatible(db):
-            raise TypeError(f"cannot initialise annotation db from {type(db)}")
+            msg = f"cannot initialise annotation db from {type(db)}"
+            raise TypeError(msg)
 
         self._init_tables()
 
@@ -732,7 +730,7 @@ class SqliteAnnotationDbMixin:
     @property
     def db(self) -> sqlite3.Connection:
         if self._db is None:
-            # TODO gah understand serialisation issue
+            # TODO: gah understand serialisation issue
             # the check_same_thread=False is required for multiprocess, even
             # when the db is empty (tests fail). This  appears unrelated to
             # our code, and does not affect pickling/unpickling on the same
@@ -749,7 +747,11 @@ class SqliteAnnotationDbMixin:
 
         return self._db
 
-    def _execute_sql(self, cmnd, values=None):
+    def _execute_sql(
+        self,
+        cmnd: str,
+        values: tuple[typing.Any] | None = None,
+    ) -> sqlite3.Cursor:
         with self.db:
             # context manager ensures safe transactions
             cursor = self.db.cursor()
@@ -801,7 +803,7 @@ class SqliteAnnotationDbMixin:
     def _get_records_matching(
         self,
         table_name: str,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> typing.Iterator[sqlite3.Row]:
         """return all fields"""
         if kwargs.get("attributes") and "%%" not in kwargs["attributes"]:
@@ -822,22 +824,19 @@ class SqliteAnnotationDbMixin:
         columns: typing.Iterable[str] | None,
         column: str,
         name: str,
-        start: OptionalInt = None,
-        stop: OptionalInt = None,
         biotype: OptionalStr = None,
         allow_partial: bool = False,
-    ) -> list[FeatureDataType]:
+        **kwargs: dict[str, typing.Any],  # noqa: ARG002
+    ) -> typing.Iterator[FeatureDataType]:
         # we return the parent_id because `get_feature_parent()` requires it
         sql, vals = _select_records_sql(
             table_name=table_name,
             conditions={column: name, "biotype": biotype},
             columns=columns,
-            start=start,
-            stop=stop,
             allow_partial=allow_partial,
         )
         for result in self._execute_sql(sql, values=vals):
-            result = dict(zip(result.keys(), result, strict=False))
+            result = dict(zip(result.keys(), result, strict=False))  # noqa: PLW2901
             result["on_alignment"] = result.get("on_alignment")
             result["spans"] = [tuple(c) for c in result["spans"]]
             yield result
@@ -846,7 +845,7 @@ class SqliteAnnotationDbMixin:
         self,
         name: str,
         biotype: OptionalStr = None,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],
     ) -> typing.Iterator[FeatureDataType]:
         """yields children of name"""
         # kwargs is used because other classes need start / stop
@@ -869,7 +868,7 @@ class SqliteAnnotationDbMixin:
     def get_feature_parent(
         self,
         name: str,
-        **kwargs,
+        **kwargs: dict[str, typing.Any],  # noqa: ARG002
     ) -> typing.Iterator[FeatureDataType]:
         """yields parents of name"""
         for table_name in self.table_names:
@@ -888,7 +887,7 @@ class SqliteAnnotationDbMixin:
                 if not result["parent_id"]:
                     return
 
-                for name in result["parent_id"].replace(" ", "").split(","):
+                for name in result["parent_id"].replace(" ", "").split(","):  # noqa: PLR1704
                     if parent := list(
                         self._get_feature_by_id(
                             table_name=table_name,
@@ -906,14 +905,14 @@ class SqliteAnnotationDbMixin:
     def get_records_matching(
         self,
         *,
-        biotype: str = None,
-        seqid: str = None,
-        name: str = None,
-        start: int = None,
-        stop: int = None,
+        biotype: str | None = None,
+        seqid: str | None = None,
+        name: str | None = None,
+        start: int | None = None,
+        stop: int | None = None,
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
-        on_alignment: bool = None,
+        on_alignment: bool | None = None,
         allow_partial: bool = False,
     ) -> typing.Iterator[dict]:
         """return all fields for matching records"""
@@ -930,14 +929,14 @@ class SqliteAnnotationDbMixin:
     def get_features_matching(
         self,
         *,
-        biotype: str = None,
-        seqid: str = None,
-        name: str = None,
-        start: int = None,
-        stop: int = None,
+        biotype: str | None = None,
+        seqid: str | None = None,
+        name: str | None = None,
+        start: int | None = None,
+        stop: int | None = None,
         strand: OptionalStr = None,
         attributes: OptionalStr = None,
-        on_alignment: bool = None,
+        on_alignment: bool | None = None,
         allow_partial: bool = False,
     ) -> typing.Iterator[FeatureDataType]:
         # returns essential values to create a Feature
@@ -960,7 +959,7 @@ class SqliteAnnotationDbMixin:
                 columns=columns,
                 **query_args,
             ):
-                result = dict(zip(result.keys(), result, strict=False))
+                result = dict(zip(result.keys(), result, strict=False))  # noqa: PLW2901
                 result["on_alignment"] = result.get("on_alignment")
                 result["spans"] = [tuple(c) for c in result["spans"]]
                 yield result
@@ -980,11 +979,11 @@ class SqliteAnnotationDbMixin:
         num = 0
         for table_name in self.table_names:
             sql, values = _count_records_sql(table_name, conditions=kwargs)
-            result = list(self._execute_sql(sql, values=values).fetchone())[0]
+            result = next(iter(self._execute_sql(sql, values=values).fetchone()))
             num += result
         return num
 
-    StrOrBool = typing.Union[str, bool]
+    StrOrBool = str | bool
 
     def count_distinct(
         self,
@@ -1035,9 +1034,9 @@ class SqliteAnnotationDbMixin:
                 data.extend(tuple(r) for r in result)
 
         return Table(
-            header=header + ["count"],
+            header=[*header, "count"],
             data=data,
-            column_templates=dict(count=lambda x: f"{x:,}"),
+            column_templates={"count": lambda x: f"{x:,}"},
         )
 
     @property
@@ -1066,7 +1065,7 @@ class SqliteAnnotationDbMixin:
                 "": list(data.keys()) + [f"num_rows({t!r})" for t in self.table_names],
                 "count": list(data.values()) + row_counts,
             },
-            column_templates=dict(count=lambda x: f"{x:,}"),
+            column_templates={"count": lambda x: f"{x:,}"},
         )
 
     def biotype_counts(self) -> dict:
@@ -1113,7 +1112,8 @@ class SqliteAnnotationDbMixin:
             mine
         """
         if not isinstance(other_db, SupportsFeatures):
-            raise TypeError(f"{type(other_db)} does not support features")
+            msg = f"{type(other_db)} does not support features"
+            raise TypeError(msg)
         mine = set(self.table_names)
         theirs = set(other_db.table_names)
         return mine <= theirs or mine > theirs if symmetric else mine >= theirs
@@ -1126,14 +1126,16 @@ class SqliteAnnotationDbMixin:
     ) -> None:
         """update records with those from an instance of the same type"""
         if not isinstance(annot_db, SupportsFeatures):
-            raise TypeError(f"{type(annot_db)} does not satisfy SupportsFeatures")
+            msg = f"{type(annot_db)} does not satisfy SupportsFeatures"
+            raise TypeError(msg)
         if not self.compatible(annot_db, symmetric=False):
-            raise TypeError(f"{type(self)} cannot be updated from {type(annot_db)}")
+            msg = f"{type(self)} cannot be updated from {type(annot_db)}"
+            raise TypeError(msg)
 
         if not annot_db or not len(annot_db):
             return
 
-        self._update_db_from_other_db(annot_db, seqids=seqids)
+        self._update_db_from_other_db(annot_db, seqids=seqids, **kwargs)
 
     def union(self, annot_db: SupportsFeatures) -> SupportsFeatures:
         """returns a new instance with merged records with other
@@ -1149,7 +1151,8 @@ class SqliteAnnotationDbMixin:
         The class whose schema contains the other
         """
         if annot_db and not isinstance(annot_db, SupportsFeatures):
-            raise TypeError(f"{type(annot_db)} does not satisfy SupportsFeatures")
+            msg = f"{type(annot_db)} does not satisfy SupportsFeatures"
+            raise TypeError(msg)
         if not annot_db:
             return copy.deepcopy(self)
 
@@ -1158,8 +1161,9 @@ class SqliteAnnotationDbMixin:
         elif self.compatible(annot_db, symmetric=True):
             cls = type(annot_db)
         else:
+            msg = f"cannot make a union between {type(self)} and {type(annot_db)}"
             raise TypeError(
-                f"cannot make a union between {type(self)} and {type(annot_db)}",
+                msg,
             )
 
         db = cls()
@@ -1168,14 +1172,14 @@ class SqliteAnnotationDbMixin:
         return db
 
     @classmethod
-    def from_dict(cls, data: dict):
+    def from_dict(cls, data: dict) -> AnnotationDbABC:
         # make an empty db
         init_args = data.pop("init_args")
         db = cls(**init_args)
         db._update_db_from_rich_dict(data)
         return db
 
-    def _update_db_from_rich_dict(self, data: dict, seqids: OptionalStr = None):
+    def _update_db_from_rich_dict(self, data: dict, seqids: OptionalStr = None) -> None:
         data.pop("type", None)
         data.pop("version")
         if isinstance(seqids, str):
@@ -1199,7 +1203,7 @@ class SqliteAnnotationDbMixin:
         self,
         other_db: SupportsFeatures,
         seqids: OptionalStrContainer = None,
-    ):
+    ) -> None:
         if other_db == self:
             return
 
@@ -1236,9 +1240,9 @@ class SqliteAnnotationDbMixin:
         self,
         *,
         source: PathType = ":memory:",
-        biotype: str = None,
-        seqid: str = None,
-        name: str = None,
+        biotype: str | None = None,
+        seqid: str | None = None,
+        name: str | None = None,
         start: OptionalInt = None,
         stop: OptionalInt = None,
         strand: OptionalStr = None,
@@ -1263,27 +1267,30 @@ class SqliteAnnotationDbMixin:
             ]
             pos = ", ".join("?" * len(cols))
             sql = f"INSERT INTO {table_name} ({','.join(cols)}) VALUES ({pos});"
-            records = []
-            for record in self._get_records_matching(table_name=table_name, **kwargs):
-                records.append(tuple(record[c] for c in cols))
-
+            records = [
+                tuple(record[c] for c in cols)
+                for record in self._get_records_matching(
+                    table_name=table_name,
+                    **kwargs,
+                )
+            ]
             with result.db as cursor:
                 cursor.executemany(sql, records)
                 cursor.commit()
 
         return result
 
-    def close(self):
+    def close(self) -> None:
         """closes the db"""
         self.db.close()
 
-    def _make_index(self, *, table_name: str, col_names: tuple[str, ...]):
+    def _make_index(self, *, table_name: str, col_names: tuple[str, ...]) -> None:
         """index columns for faster search"""
         sql = f"CREATE INDEX IF NOT EXISTS %s on {table_name}(%s)"
         for col in col_names:
             self._execute_sql(sql % (col, col))
 
-    def make_indexes(self):
+    def make_indexes(self) -> None:
         """adds db indexes for core attributes"""
         for table_name in self.table_names:
             self._make_index(
@@ -1301,15 +1308,15 @@ class BasicAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
     This is the default db on Sequence, SequenceCollection and Alignment
     """
 
-    _table_names = ("user",)
+    _table_names: typing.ClassVar = ("user",)
 
     def __init__(
         self,
         *,
         data: T = None,
         db: SupportsFeatures = None,
-        source=":memory:",
-    ):
+        source: PathType = ":memory:",
+    ) -> None:
         """
         Parameters
         ----------
@@ -1358,9 +1365,9 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
     """Support for annotations from gff files. Records that span multiple
     rows in the gff are merged into a single record."""
 
-    _table_names = "gff", "user"
+    _table_names: typing.ClassVar = "gff", "user"
     # We are relying on an attribute name structured as _<table name>_schema
-    _gff_schema = {
+    _gff_schema: typing.ClassVar = {
         "seqid": "TEXT",
         "source": "TEXT",
         "biotype": "TEXT",  # type in GFF
@@ -1382,8 +1389,8 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         *,
         data: T = None,
         db: SupportsFeatures = None,
-        source=":memory:",
-    ):
+        source: PathType = ":memory:",
+    ) -> None:
         data = data or []
         # note that data is destroyed
         self._num_fakeids = 0
@@ -1466,9 +1473,9 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
     Extended attributes are stored as json in the gb, attributes column.
     """
 
-    _table_names = "gb", "user"
+    _table_names: typing.ClassVar = "gb", "user"
     # We are relying on an attribute name structured as _<table name>_schema
-    _gb_schema = {
+    _gb_schema: typing.ClassVar = {
         "seqid": "TEXT",
         "source": "TEXT",
         "biotype": "TEXT",  # type in GFF
@@ -1490,9 +1497,9 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         data: T = None,
         seqid: OptionalStr = None,
         db: SupportsFeatures = None,
-        source=":memory:",
-        namer: typing.Callable = None,
-    ):
+        source: PathType = ":memory:",
+        namer: typing.Callable | None = None,
+    ) -> None:
         """
         seqid
             name of the sequence data is associated with
@@ -1513,7 +1520,7 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         self._namer = namer if callable(namer) else self._default_namer
         self.add_records(data, seqid)
 
-    def add_records(self, records, seqid):
+    def add_records(self, records: typing.Sequence[dict], seqid: str) -> None:
         col_order = [
             r["name"] for r in self.db.execute("PRAGMA table_info(gb)").fetchall()
         ]
@@ -1670,17 +1677,17 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
 
 
 @register_deserialiser(get_object_provenance(BasicAnnotationDb))
-def deserialise_basic_db(data: dict):
+def deserialise_basic_db(data: dict) -> BasicAnnotationDb:
     return BasicAnnotationDb.from_dict(data)
 
 
 @register_deserialiser(get_object_provenance(GffAnnotationDb))
-def deserialise_gff_db(data: dict):
+def deserialise_gff_db(data: dict) -> GffAnnotationDb:
     return GffAnnotationDb.from_dict(data)
 
 
 @register_deserialiser(get_object_provenance(GenbankAnnotationDb))
-def deserialise_gb_db(data: dict):
+def deserialise_gb_db(data: dict) -> GenbankAnnotationDb:
     return GenbankAnnotationDb.from_dict(data)
 
 
@@ -1693,7 +1700,7 @@ def convert_annotation_to_annotation_db(data: dict) -> SupportsFeatures:
     seqid = data.pop("name", data.pop("seqid", None))
     anns = data.pop("data")
     for ann in anns:
-        ann = ann.pop("annotation_construction")
+        ann = ann.pop("annotation_construction")  # noqa: PLW2901
         m = deserialise_map_spans(ann.pop("map"))
         spans = m.get_coordinates()
         strand = "-" if any(s.reverse for s in m.spans) else "+"
@@ -1714,9 +1721,9 @@ def convert_annotation_to_annotation_db(data: dict) -> SupportsFeatures:
 def _db_from_genbank(
     path: PathType,
     db: SupportsFeatures | None,
-    write_path,
-    **kwargs,
-):
+    write_path: PathType,
+    **kwargs: dict[str, typing.Any],
+) -> AnnotationDbABC:
     from cogent3.parse.genbank import minimal_parser
 
     paths = pathlib.Path(path)
@@ -1724,8 +1731,8 @@ def _db_from_genbank(
 
     ui = kwargs.pop("ui")
     one_valid_path = False
-    for path in ui.series(paths):
-        rec = list(minimal_parser(path))[0]
+    for path in ui.series(paths):  # noqa: PLR1704
+        rec = next(iter(minimal_parser(path)))
         db = GenbankAnnotationDb(
             source=write_path,
             data=rec.pop("features", None),
@@ -1735,13 +1742,14 @@ def _db_from_genbank(
         one_valid_path = True
 
     if not one_valid_path:
-        raise OSError(f"{str(path)!r} not found")
+        msg = f"{str(path)!r} not found"
+        raise OSError(msg)
 
     db.make_indexes()
     return db
 
 
-def _leave_attributes(*attrs):
+def _leave_attributes(*attrs: tuple[str, ...]) -> str:
     return attrs[0]
 
 
@@ -1752,7 +1760,7 @@ def _db_from_gff(
     db: SupportsFeatures | None,
     write_path: PathType,
     num_lines: OptionalInt,
-    **kwargs,
+    **kwargs: dict[str, typing.Any],
 ) -> SupportsFeatures:
     from cogent3.parse.gff import gff_parser, is_gff3
 
@@ -1762,7 +1770,7 @@ def _db_from_gff(
     ui = kwargs.pop("ui")
     one_valid_path = False
     seen_ids = set()
-    for path in ui.series(paths):
+    for path in ui.series(paths):  # noqa: PLR1704
         num_fake_ids = 0
         gff3 = is_gff3(path)
         db = GffAnnotationDb(source=write_path, db=db)
@@ -1784,7 +1792,8 @@ def _db_from_gff(
             db.add_records(data)
         one_valid_path = True
     if not one_valid_path:
-        raise OSError(f"{str(path)!r} not found")
+        msg = f"{str(path)!r} not found"
+        raise OSError(msg)
 
     db.make_indexes()
     return db
@@ -1866,8 +1875,7 @@ def _update_array_format(data: bytes) -> bytes:
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        new_data = array_to_sqlite(sqlite_to_array(data))
-    return new_data
+        return array_to_sqlite(sqlite_to_array(data))
 
 
 def update_file_format(
@@ -1892,29 +1900,33 @@ def update_file_format(
 
     Parameters
     ----------
-    source_path : PathType
+    source_path
         The database file to reformat.
-    db_class : typing.Union[ type[BasicAnnotationDb], type[GenbankAnnotationDb], type[GffAnnotationDb], ]
+    db_class[GenbankAnnotationDb], type[GffAnnotationDb], ]
         The type of database the file is.
-    backup : bool, optional
+    backup
         If True (default), performs a backup of the database before updating.
         Otherwise does not perform a backup prior to update (not recommended).
     """
     source_path = pathlib.Path(source_path).expanduser()
 
     if not source_path.exists():
-        raise OSError(f"File {source_path} does not exist.")
+        msg = f"File {source_path} does not exist."
+        raise OSError(msg)
 
     anno_db = db_class(source=source_path)
 
     if backup:
         backup_path = source_path.parent / f"{source_path.name}.bak"
         if backup_path.exists():
-            raise FileExistsError(
+            msg = (
                 f"Backup file already exists for {source_path}. "
                 f"If there was a problem with the conversion process, "
                 f"update_file_format should be run on the backed up file. "
-                f"Ensure update_file_format is run on the same OS used to generate the file.",
+                f"Ensure update_file_format is run on the same OS used to generate the file."
+            )
+            raise FileExistsError(
+                msg,
             )
         anno_db.write(backup_path)
 

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -186,8 +186,6 @@ class SupportsWriteFeatures(typing.Protocol):  # pragma: no cover
         self,
         *,
         records: typing.Sequence[dict],
-        # seqid required for genbank
-        seqid: OptionalStr = None,
         **kwargs: dict[str, typing.Any],
     ) -> None: ...
 
@@ -300,7 +298,12 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
     def add_feature(self, **kwargs: dict[str, typing.Any]) -> None: ...
 
     @abc.abstractmethod
-    def add_records(self, **kwargs: dict[str, typing.Any]) -> None: ...
+    def add_records(self,
+        *,
+        records: typing.Sequence[dict],
+        **kwargs: dict[str, typing.Any],
+    ) -> None: ...
+
 
     @abc.abstractmethod
     def update(

--- a/src/cogent3/util/io.py
+++ b/src/cogent3/util/io.py
@@ -10,7 +10,7 @@ from lzma import open as lzma_open
 from os import PathLike, remove
 from pathlib import Path, PurePath
 from tempfile import mkdtemp
-from typing import IO, Optional, Union
+from typing import IO
 from urllib.parse import ParseResult, urlparse
 from urllib.request import urlopen
 from zipfile import ZipFile
@@ -19,7 +19,7 @@ from chardet import detect
 
 from cogent3.util.misc import _wout_period
 
-PathType = Union[str, PathLike, PurePath]
+PathType = str | PathLike | PurePath | Path
 
 
 @functools.singledispatch
@@ -331,7 +331,7 @@ class atomic_write:
         self.__exit__(None, None, None)
 
 
-T = Optional[str]
+T = str | None
 
 
 def get_format_suffixes(filename: PathType) -> tuple[T, T]:


### PR DESCRIPTION
## Summary by Sourcery

Refactor type hinting to use modern Python syntax, improving code readability and maintainability. Update test cases to use more concise patterns and simplify parameterization. Adjust build configuration to ignore specific linting rules in Ruff.

Enhancements:
- Refactor type hinting to use Python 3.10+ syntax, replacing typing.Optional and typing.Union with the new union operator (|).
- Improve code readability by replacing list and tuple comprehensions with more concise syntax.
- Enhance error messages by storing them in variables before raising exceptions.

Build:
- Update pyproject.toml to ignore additional linting rules in Ruff, including rules related to naming conventions and positional boolean arguments.

Tests:
- Refactor test cases to use the next(iter(...)) pattern instead of list indexing for fetching single elements from iterators.
- Simplify pytest parameterization by using lists instead of tuples for test parameters.