### PR TITLE
API: make new_alignment.Alignment.get_gapped_seq() match API of old class

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -4171,14 +4171,35 @@ class Alignment(SequenceCollection):
         reason="naming consistency",
         old_new=[("seq_name", "seqname")],
     )
-    def get_gapped_seq(self, seqname: str) -> new_sequence.Sequence:
+    def get_gapped_seq(
+        self,
+        seqname: str,
+        recode_gaps: bool = False,
+    ) -> new_sequence.Sequence:
         """Return a gapped Sequence object for the specified seqname.
+
+
+        Parameters
+        ----------
+        seqname
+            sequence name
+        recode_gaps
+            if True, gap characters are replaced by the most general
+            ambiguity code, e.g. N for DNA and RNA
 
         Notes
         -----
         This method breaks the connection to the annotation database.
         """
-        return self.seqs[seqname].gapped_seq
+        s = self.seqs[seqname].gapped_seq
+        if recode_gaps:
+            s = str(s)
+            non_ambig = list(self.moltype)
+            ambig = self.moltype.degenerate_from_seq(non_ambig)
+            for gapchar in self.moltype.gaps:
+                s = s.replace(gapchar, ambig)
+
+        return self.moltype.make_seq(seq=s, name=seqname)
 
     def rc(self):
         """Returns the reverse complement of all sequences in the alignment.

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4960,6 +4960,23 @@ def test_get_gapped_seq_with_sliced_aln(name):
 
 
 @pytest.mark.parametrize("name", ("s1", "s2", "s3"))
+def test_get_gapped_seq_recode_gaps(name):
+    seqs = {
+        "s1": "G-TG--?TAGTAGAAGTTCCAAATAATGAA",
+        "s2": "GTG??----GTAGAAGTTCCAAATAATGAA",
+        "s3": "GC--AAGTAGTGGAAGTTGCAAAT--?GAA",
+    }
+    aln = new_alignment.make_aligned_seqs(seqs, moltype="dna")
+    start, stop = 1, 10
+    a1 = aln[start:stop]
+
+    seq = a1.get_gapped_seq(name, recode_gaps=True)
+    got = str(seq)
+    expect = seqs[name][start:stop].replace("?", "N").replace("-", "N")
+    assert got == expect, (got, expect)
+
+
+@pytest.mark.parametrize("name", ("s1", "s2", "s3"))
 def test_aln_rev_slice(name):
     seqs = {
         "s1": "AAGGTTCC",

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4960,19 +4960,23 @@ def test_get_gapped_seq_with_sliced_aln(name):
 
 
 @pytest.mark.parametrize("name", ("s1", "s2", "s3"))
-def test_get_gapped_seq_recode_gaps(name):
+@pytest.mark.parametrize("moltype", ("dna", "protein"))
+def test_get_gapped_seq_recode_gaps(name, moltype):
+    mt = new_moltype.get_moltype(moltype)
+    degen = mt.degenerate_from_seq(list(mt))
     seqs = {
         "s1": "G-TG--?TAGTAGAAGTTCCAAATAATGAA",
         "s2": "GTG??----GTAGAAGTTCCAAATAATGAA",
         "s3": "GC--AAGTAGTGGAAGTTGCAAAT--?GAA",
     }
-    aln = new_alignment.make_aligned_seqs(seqs, moltype="dna")
+    aln = new_alignment.make_aligned_seqs(seqs, moltype=moltype)
+
     start, stop = 1, 10
     a1 = aln[start:stop]
 
     seq = a1.get_gapped_seq(name, recode_gaps=True)
     got = str(seq)
-    expect = seqs[name][start:stop].replace("?", "N").replace("-", "N")
+    expect = seqs[name][start:stop].replace("?", degen).replace("-", degen)
     assert got == expect, (got, expect)
 
 


### PR DESCRIPTION
[FIXED] required for molevol code

## Summary by Sourcery

Update the get_gapped_seq() method in the new_alignment.Alignment class to match the API of the old class, including a new recode_gaps parameter for replacing gap characters with ambiguity codes. Add corresponding tests for the new functionality.

Bug Fixes:
- Fix the API of new_alignment.Alignment.get_gapped_seq() to match the old class, ensuring compatibility with existing code.

Enhancements:
- Add a recode_gaps parameter to the get_gapped_seq() method to allow gap characters to be replaced by the most general ambiguity code.

Tests:
- Add tests for the new recode_gaps functionality in the get_gapped_seq() method to ensure correct behavior.