### PR TITLE
DEV: preparing for full integration of new_type classes

### DIFF
--- a/src/cogent3/align/pairwise.py
+++ b/src/cogent3/align/pairwise.py
@@ -478,7 +478,7 @@ class AlignablePOG(_Alignable):
         return make_aligned_seqs(self.aligneds)
 
     def _calcAligneds(self, children):
-        word_length = self.alphabet.get_motif_len()
+        word_length = self.alphabet.motif_len
         (starts, ends, maps) = map_traceback(self.pog.get_full_aligned_positions())
         aligneds = []
         for dim, child in enumerate(children):
@@ -1166,7 +1166,7 @@ class LocalViterbiPath(_ViterbiPath):
     def get_alignment(self):
         """The alignment as a standard PyCogent Alignment object"""
         seqs = self.pair_hmm.emission_probs.pair.get_seq_name_pairs()
-        word_length = self.pair_hmm.emission_probs.pair.alphabet.get_motif_len()
+        word_length = self.pair_hmm.emission_probs.pair.alphabet.motif_len
         aligned_positions = [posn for (bin, posn) in self.aligned_positions]
         return alignment_traceback(seqs, aligned_positions, word_length)
 

--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -1,15 +1,19 @@
 from cogent3 import get_app, get_model, make_unaligned_seqs
-from cogent3.core.alignment import ArrayAlignment, SequenceCollection
+from cogent3.core import alignment as old_alignment
+from cogent3.core import new_alignment
 from cogent3.core.tree import TreeNode
 from cogent3.evolve.distance import EstimateDistances
 from cogent3.phylo import nj as NJ
 from cogent3.util import progress_display as UI
 
+SeqCollType = old_alignment.SequenceCollection | new_alignment.SequenceCollection
+AlignType = old_alignment.ArrayAlignment | new_alignment.Alignment
+
 
 @UI.display_wrap
 def tree_align(
     model: str,
-    seqs: SequenceCollection,
+    seqs: SeqCollType,
     tree: TreeNode | None = None,
     indel_rate: float = 1e-10,
     indel_length: float = 1e-1,
@@ -18,7 +22,7 @@ def tree_align(
     param_vals: dict = None,
     iters: int | None = None,
     approx_dists: bool = True,
-) -> tuple[ArrayAlignment, TreeNode]:
+) -> tuple[AlignType, TreeNode]:
     """Returns a multiple sequence alignment and tree.
 
     Parameters

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -20,11 +20,8 @@ from typing import Union
 from scitrack import get_text_hexdigest
 
 from cogent3.app.typing import TabularType
-from cogent3.core.alignment import (
-    Alignment,
-    ArrayAlignment,
-    SequenceCollection,
-)
+from cogent3.core import alignment as old_alignment
+from cogent3.core import new_alignment
 from cogent3.util.deserialise import deserialise_object
 from cogent3.util.io import get_format_suffixes, open_
 from cogent3.util.parallel import is_master_process
@@ -744,18 +741,28 @@ def get_data_source(data) -> str:
 
 
 @get_data_source.register
-def _(data: SequenceCollection):
+def _(data: old_alignment.SequenceCollection):
     return get_data_source(data.info)
 
 
 @get_data_source.register
-def _(data: ArrayAlignment):
+def _(data: old_alignment.ArrayAlignment):
     return get_data_source(data.info)
 
 
 @get_data_source.register
-def _(data: Alignment):
+def _(data: old_alignment.Alignment):
     return get_data_source(data.info)
+
+
+@get_data_source.register
+def _(data: new_alignment.Alignment):
+    return get_data_source(data.source)
+
+
+@get_data_source.register
+def _(data: new_alignment.SequenceCollection):
+    return get_data_source(data.source)
 
 
 @get_data_source.register

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -13,7 +13,8 @@ from pathlib import Path
 import numpy
 
 import cogent3
-from cogent3.core.moltype import MolType, get_moltype
+from cogent3.core import moltype as old_moltype
+from cogent3.core import new_moltype
 from cogent3.core.profile import (
     make_motif_counts_from_tabular,
     make_motif_freqs_from_tabular,
@@ -47,6 +48,8 @@ from .typing import (
 )
 
 _datastore_reader_map = {}
+
+MolTypes = old_moltype.MolType | new_moltype.MolType
 
 
 class register_datastore_reader:
@@ -297,7 +300,7 @@ class load_aligned:
         --------
         See https://cogent3.org/doc/app/app_cookbook/load-aligned.html
         """
-        self.moltype = moltype if moltype is None else get_moltype(moltype)
+        self.moltype = moltype if moltype is None else cogent3.get_moltype(moltype)
         self._parser = PARSERS[format.lower()]
 
     T = SerialisableType | AlignedSeqsType
@@ -314,7 +317,7 @@ class load_unaligned:
     def __init__(
         self,
         *,
-        moltype: str | MolType | None = None,
+        moltype: str | MolTypes | None = None,
         format: str = "fasta",
     ):
         """
@@ -329,7 +332,7 @@ class load_unaligned:
         --------
         See https://cogent3.org/doc/app/app_cookbook/load-unaligned.html
         """
-        self.moltype = moltype if moltype is None else get_moltype(moltype)
+        self.moltype = moltype if moltype is None else cogent3.get_moltype(moltype)
         self._parser = PARSERS[format.lower()]
 
     T = SerialisableType | UnalignedSeqsType

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -1,15 +1,20 @@
 from collections import defaultdict
 from typing import Union
 
-from cogent3.core.alignment import SequenceCollection
-from cogent3.core.genetic_code import GeneticCode, get_code
-from cogent3.core.moltype import Alphabet, MolType, get_moltype
+import cogent3
+from cogent3.core import alphabet as old_alphabet
+from cogent3.core import genetic_code as old_genetic_code
+from cogent3.core import moltype as old_moltype
+from cogent3.core import new_alphabet, new_genetic_code, new_moltype
 
 from .composable import NotCompleted, define_app
 from .typing import SeqsCollectionType, SeqType, SerialisableType
 
-GeneticCodeTypes = Union[str, int, GeneticCode]
-MolTypes = Union[str, MolType]
+GeneticCodeTypes = (
+    str | int | old_genetic_code.GeneticCode | new_genetic_code.GeneticCode
+)
+MolTypes = str | old_moltype.MolType | new_moltype.MolType
+AlphabetTypes = old_alphabet.Alphabet | new_alphabet.CharAlphabet
 
 
 def best_frame(
@@ -43,9 +48,9 @@ def best_frame(
     ------
     ValueError
         if the minimum number of stop codons across all frames exceeds 1,
-        or the the stop codon is not at the sequence end
+        or the stop codon is not at the sequence end
     """
-    gc = get_code(gc)
+    gc = cogent3.get_code(gc)
     translations = gc.sixframes(seq)
     if not allow_rc:
         translations = translations[:3]
@@ -103,9 +108,9 @@ def translate_frames(
     [(frame, translation), ..]
     Reverse complement frame numbers are negative
     """
-    gc = get_code(gc)
+    gc = cogent3.get_code(gc)
     if moltype:
-        moltype = get_moltype(moltype)
+        moltype = cogent3.get_moltype(moltype)
         seq = moltype.make_seq(seq)
 
     translations = gc.sixframes(seq)
@@ -117,7 +122,7 @@ def translate_frames(
 
 def get_fourfold_degenerate_sets(
     gc: GeneticCodeTypes,
-    alphabet: Alphabet | None = None,
+    alphabet: AlphabetTypes | None = None,
     as_indices: bool = True,
 ):
     """returns set() of codons that are 4-fold degenerate for genetic code gc
@@ -232,7 +237,7 @@ class select_translatable:
         >>> result.to_dict()
         {'s2': 'TATGAC'}
         """
-        moltype = get_moltype(moltype)
+        moltype = cogent3.get_moltype(moltype)
         assert moltype.label.lower() in ("dna", "rna"), "Invalid moltype"
 
         if frame is not None:
@@ -240,7 +245,7 @@ class select_translatable:
         self._frame = frame
 
         self._moltype = moltype
-        self._gc = get_code(gc)
+        self._gc = cogent3.get_code(gc)
         self._allow_rc = allow_rc
         self._trim_terminal_stop = trim_terminal_stop
 
@@ -284,7 +289,7 @@ class select_translatable:
                 error_log.append([seq.name, msg.args[0]])
 
         if translatable:
-            translatable = SequenceCollection(
+            translatable = cogent3.make_unaligned_seqs(
                 data=translatable,
                 moltype=self._moltype,
                 info=seqs.info,
@@ -340,11 +345,11 @@ class translate_seqs:
         s1    MR
         s2    .-
         """
-        moltype = get_moltype(moltype)
+        moltype = cogent3.get_moltype(moltype)
         assert moltype.label.lower() in ("dna", "rna"), "Invalid moltype"
 
         self._moltype = moltype
-        self._gc = get_code(gc)
+        self._gc = cogent3.get_code(gc)
         self._trim_terminal_stop = trim_terminal_stop
 
     T = Union[SerialisableType, SeqsCollectionType]

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1369,7 +1369,7 @@ class _SequenceCollectionBase:
         counts = {}
         for seq_name in self.names:
             sequence = self.named_seqs[seq_name]
-            motif_len = alphabet.get_motif_len()
+            motif_len = alphabet.motif_len
             if motif_len > 1:
                 posns = list(range(0, len(sequence) + 1 - motif_len, motif_len))
                 sequence = [sequence[i : i + motif_len] for i in posns]

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -512,12 +512,16 @@ class Alphabet(Enumeration):
         """
         return self._gapmotif
 
+    @property
+    def gap_char(self):  # pragma: no cover
+        return self._gapmotif
+
     def includes_gap_motif(self):
         """Returns True if self includes the gap motif, False otherwise."""
         return self._gapmotif in self
 
     def _with(self, motifset):
-        """Returns a new Alphabet object with same class and moltype as self.
+        self.same__ = """Returns a new Alphabet object with same class and moltype as self.
 
         Will always return a new Alphabet object even if the motifset is the
         same.
@@ -532,7 +536,7 @@ class Alphabet(Enumeration):
         if self.includes_gap_motif():
             return self
         if not hasattr(self, "gapped"):
-            self.gapped = self._with(list(self) + [self.get_gap_motif()])
+            self.gapped = self._with(list(self) + [self.gap_char])
         return self.gapped
 
     def get_subset(self, motif_subset, excluded=False):

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -267,6 +267,10 @@ class Enumeration(tuple):
             moltype = None
         return JointEnumeration([self, other], moltype=moltype)
 
+    @property
+    def motif_len(self):  # pragma: no cover
+        return self._motiflen
+
 
 class JointEnumeration(Enumeration):
     """Holds an enumeration composed of subenumerations. Immutable.

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -18,7 +18,7 @@ from typing import Any, Optional, Union
 import numba
 import numpy
 
-from cogent3 import get_app
+import cogent3
 from cogent3._version import __version__
 from cogent3.core import (
     new_alphabet,
@@ -4227,7 +4227,7 @@ class Alignment(SequenceCollection):
         -------
         float or a NotCompleted instance if the score could not be computed
         """
-        app = get_app(app_name, **kwargs)
+        app = cogent3.get_app(app_name, **kwargs)
         return app(self)
 
     def rename_seqs(self, renamer: Callable[[str], str]):

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -599,6 +599,17 @@ class MolType:
         seq = "" if seq is None else seq
         return self._make_seq(moltype=self, seq=seq, name=name, **kwargs)
 
+    def make_array_seq(
+        self,
+        *args,
+        **kwargs,
+    ) -> new_sequence.Sequence:
+        # TODO: add deprecation warning when new_type=True is default
+        if args:
+            kwargs["seq"] = args[0]
+
+        return self.make_seq(**kwargs)
+
     @functools.singledispatchmethod
     def complement(self, seq: StrORBytesORArray, validate: bool = True) -> str:
         """converts a string or bytes into it's nucleic acid complement

--- a/src/cogent3/evolve/best_likelihood.py
+++ b/src/cogent3/evolve/best_likelihood.py
@@ -131,7 +131,7 @@ def BestLogLikelihood(
     # need to use the alphabet, so we can enforce character compliance
     if alphabet:
         kwargs = dict(moltype=alphabet.moltype)
-        motif_length = alphabet.get_motif_len()
+        motif_length = alphabet.motif_len
     else:
         kwargs = {}
 

--- a/src/cogent3/evolve/coevolution.py
+++ b/src/cogent3/evolve/coevolution.py
@@ -24,7 +24,6 @@ from numpy.linalg import norm
 
 from cogent3 import PROTEIN, make_aligned_seqs
 from cogent3.core import new_alphabet
-from cogent3.core.alignment import ArrayAlignment
 from cogent3.core.alphabet import CharAlphabet
 from cogent3.core.moltype import IUPAC_gap, IUPAC_missing
 from cogent3.core.sequence import Sequence
@@ -1880,6 +1879,8 @@ def get_ancestral_seqs(
          to be what what described in Tuffery 2000, although they're
          not perfectly clear about it.
     """
+    from cogent3.core.alignment import ArrayAlignment
+
     sm = sm or Parametric(aln.alphabet, recode_gaps=True)
     lf = sm.make_likelihood_function(tree, sm.motif_probs)
     lf.set_alignment(aln, motif_pseudocount=pseudocount)

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -6,9 +6,9 @@ import numpy
 from numpy import array, diag, dot, eye, float64, int32, log, sqrt, zeros
 from numpy.linalg import det, inv
 
+import cogent3
 from cogent3._version import __version__
 from cogent3.core import new_moltype
-from cogent3.core.moltype import DNA, RNA, get_moltype
 from cogent3.util.dict_array import DictArray
 from cogent3.util.misc import get_object_provenance
 from cogent3.util.progress_display import display_wrap
@@ -320,7 +320,7 @@ class _PairwiseDistance:
 
     def __init__(self, moltype, invalid=-9, alignment=None, invalid_raises=False):
         super().__init__()
-        moltype = get_moltype(moltype)
+        moltype = cogent3.get_moltype(moltype)
         if moltype.label not in self.valid_moltypes:
             name = self.__class__.__name__
             msg = (
@@ -580,8 +580,11 @@ class _NucleicSeqPair(_PairwiseDistance):
 
     def __init__(self, moltype="dna", *args, **kwargs):
         super().__init__(moltype, *args, **kwargs)
-        if not _same_moltype(DNA, self.moltype) and not _same_moltype(
-            RNA,
+        if not _same_moltype(
+            cogent3.get_moltype("dna"),
+            self.moltype,
+        ) and not _same_moltype(
+            cogent3.get_moltype("rna"),
             self.moltype,
         ):
             raise RuntimeError("Invalid MolType for this metric")

--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -5,8 +5,10 @@ from copy import deepcopy
 
 import numpy
 
+import cogent3
 from cogent3._version import __version__
-from cogent3.core.alignment import ArrayAlignment
+from cogent3.core import alignment as old_alignment
+from cogent3.core import new_alignment
 from cogent3.core.tree import PhyloNode
 from cogent3.evolve import substitution_model
 from cogent3.evolve.simulate import AlignmentEvolver, random_sequence
@@ -27,6 +29,8 @@ from cogent3.util.misc import adjusted_gt_minprob, get_object_provenance
 # recalculation Calculator.  It adds methods which are useful for examining
 # the parameter, psub, mprob and likelihood values after the optimisation is
 # complete.
+
+AlignType = old_alignment.ArrayAlignment | new_alignment.Alignment
 
 
 def _get_keyed_rule_indices(rules):
@@ -456,7 +460,7 @@ class LikelihoodFunction(ParameterController):
             )
         return result
 
-    def likely_ancestral_seqs(self, locus=None) -> ArrayAlignment:
+    def likely_ancestral_seqs(self, locus=None) -> AlignType:
         """Returns the most likely reconstructed ancestral sequences as an
         alignment.
 
@@ -473,7 +477,11 @@ class LikelihoodFunction(ParameterController):
                 by_p = [(p, state) for state, p in list(row.items())]
                 seq.append(max(by_p)[1])
             seqs += [(edge, self.model.moltype.make_seq("".join(seq)))]
-        return ArrayAlignment(data=seqs, moltype=self.model.moltype)
+        return cogent3.make_aligned_seqs(
+            data=seqs,
+            moltype=self.model.moltype,
+            array_align=True,
+        )
 
     def get_bin_probs(self, locus=None):
         hmm = self.get_param_value("bindex", locus=locus)
@@ -1153,7 +1161,11 @@ class LikelihoodFunction(ParameterController):
 
         simulated_sequences = evolver(self._tree, root_sequence)
 
-        return ArrayAlignment(data=simulated_sequences, moltype=self._model.moltype)
+        return cogent3.make_aligned_seqs(
+            data=simulated_sequences,
+            moltype=self._model.moltype,
+            array_align=True,
+        )
 
     def all_psubs_DLC(self):
         """Returns True if every Psub matrix is Diagonal Largest in Column"""

--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -1151,7 +1151,7 @@ class LikelihoodFunction(ParameterController):
         if root_sequence is not None:  # we convert to a vector of motifs
             if isinstance(root_sequence, str):
                 root_sequence = self._model.moltype.make_seq(root_sequence)
-            motif_len = self._model.get_alphabet().get_motif_len()
+            motif_len = self._model.get_alphabet().motif_len
             root_sequence = root_sequence.get_in_motif_size(motif_len)
         else:
             mprobs = self.get_param_value("mprobs", locus=locus, edge="root")

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -222,7 +222,7 @@ def get_matched_array(alphabet, moltype, motifs, dtype=float) -> numpy.ndarray:
 
 
 def make_likelihood_tree_leaf(sequence, alphabet, seq_name):
-    motif_len = alphabet.get_motif_len()
+    motif_len = alphabet.motif_len
     sequence2 = sequence.get_in_motif_size(motif_len)
 
     # Convert sequence to indexed list of unique motifs

--- a/src/cogent3/evolve/models.py
+++ b/src/cogent3/evolve/models.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 """A collection of pre-defined models.  These are provided for convenience so that
 users do not need to keep reconstructing the standard models.  We encourage users
 to think about the assumptions in these models and consider if their problem could
@@ -13,7 +12,7 @@ from itertools import permutations
 # The models are constructed in a strait forward manner with no attempt to condense
 import numpy
 
-from cogent3 import DNA
+import cogent3
 from cogent3.evolve import ns_substitution_model, substitution_model
 from cogent3.evolve.predicate import MotifChange, omega
 from cogent3.evolve.solved_models import _solved_nucleotide
@@ -106,7 +105,7 @@ def DT(optimise_motif_probs=True, motif_length=1, **kw):
     motif_length=2 makes this a dinucleotide model, motif_length=3 a
     trinucleotide model.
     """
-    alpha = DNA.alphabet.get_word_alphabet(motif_length)
+    alpha = cogent3.get_moltype("dna").alphabet.get_word_alphabet(motif_length)
     kw["optimise_motif_probs"] = optimise_motif_probs
     kw["mprob_model"] = "tuple"
     kw["name"] = kw.get("name", f"DT-{motif_length}")

--- a/src/cogent3/evolve/motif_prob_model.py
+++ b/src/cogent3/evolve/motif_prob_model.py
@@ -101,7 +101,7 @@ class ComplexMotifProbModel(MotifProbModel):
         self.mask = mask
         self.tuple_alphabet = tuple_alphabet
         self.monomer_alphabet = monomers = tuple_alphabet.moltype.alphabet
-        self.word_length = length = tuple_alphabet.get_motif_len()
+        self.word_length = length = tuple_alphabet.motif_len
         size = len(tuple_alphabet)
 
         # m2w[AC, 1] = C

--- a/src/cogent3/evolve/predicate.py
+++ b/src/cogent3/evolve/predicate.py
@@ -223,10 +223,10 @@ class DirectedMotifChange(predicate):
         # may be looking for a 2nt pattern in a 3nt alphabet, but not
         # 3nt pattern in dinucleotide alphabet.
         alphabet = model.get_alphabet()
-        if alphabet.get_motif_len() < self.motiflen:
+        if alphabet.motif_len < self.motiflen:
             raise ValueError(
                 "alphabet motifs (%s) too short for %s (%s)"
-                % (alphabet.get_motif_len(), repr(self), self.motiflen),
+                % (alphabet.motif_len, repr(self), self.motiflen),
             )
 
         resolve = model.moltype.ambiguities.__getitem__

--- a/src/cogent3/evolve/predicate.py
+++ b/src/cogent3/evolve/predicate.py
@@ -31,7 +31,7 @@ class _CallablePredicate:
         return self.name
 
     def ascii_art(self):
-        l = len(self.alphabet.get_gap_motif())
+        l = len(self.alphabet.gap_char)
         rows = []
         for i in range(l):
             row = [a[i] for a in list(self.alphabet)]

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -39,8 +39,8 @@ from copy import deepcopy
 import numpy
 from numpy.linalg import svd
 
+import cogent3
 from cogent3._version import __version__
-from cogent3.core import genetic_code, moltype
 from cogent3.core.tree import PhyloNode
 from cogent3.evolve import motif_prob_model, parameter_controller, predicate
 from cogent3.evolve.likelihood_tree import make_likelihood_tree_leaf
@@ -975,7 +975,7 @@ class TimeReversibleNucleotide(_TimeReversibleNucleotide):
     """A nucleotide substitution model."""
 
     def __init__(self, *args, **kw):
-        kw["alphabet"] = kw.get("alphabet", moltype.DNA.alphabet)
+        kw["alphabet"] = kw.get("alphabet", cogent3.get_moltype("dna").alphabet)
         _TimeReversibleNucleotide.__init__(self, *args, **kw)
 
 
@@ -983,7 +983,7 @@ class TimeReversibleDinucleotide(_TimeReversibleNucleotide):
     """A dinucleotide substitution model."""
 
     def __init__(self, *args, **kw):
-        kw["alphabet"] = kw.get("alphabet", moltype.DNA.alphabet)
+        kw["alphabet"] = kw.get("alphabet", cogent3.get_moltype("dna").alphabet)
         kw["motif_length"] = 2
         _TimeReversibleNucleotide.__init__(self, *args, **kw)
 
@@ -992,7 +992,7 @@ class TimeReversibleTrinucleotide(_TimeReversibleNucleotide):
     """A trinucleotide substitution model."""
 
     def __init__(self, *args, **kw):
-        kw["alphabet"] = kw.get("alphabet", moltype.DNA.alphabet)
+        kw["alphabet"] = kw.get("alphabet", cogent3.get_moltype("dna").alphabet)
         kw["motif_length"] = 3
         _TimeReversibleNucleotide.__init__(self, *args, **kw)
 
@@ -1001,7 +1001,7 @@ class TimeReversibleProtein(TimeReversible):
     """base protein substitution model."""
 
     def __init__(self, with_selenocysteine=False, *args, **kw):
-        alph = moltype.PROTEIN.alphabet
+        alph = cogent3.get_moltype("protein").alphabet
         if not with_selenocysteine:
             alph = alph.get_subset("U", excluded=True)
 
@@ -1016,7 +1016,7 @@ def EmpiricalProteinMatrix(
     recode_gaps=True,
     **kw,
 ):
-    alph = moltype.PROTEIN.alphabet.get_subset("U", excluded=True)
+    alph = cogent3.get_moltype("protein").alphabet.get_subset("U", excluded=True)
     return Empirical(
         alph,
         rate_matrix=matrix,
@@ -1078,6 +1078,6 @@ class TimeReversibleCodon(_Codon, _TimeReversibleNucleotide):
     # TODO deprecate alphabet argument
     @extend_docstring_from(_TimeReversibleNucleotide.__init__)
     def __init__(self, alphabet=None, gc=None, **kw):
-        self.gc = genetic_code.get_code(gc)
+        self.gc = cogent3.get_code(gc)
         kw["alphabet"] = self.gc.get_alphabet()
         _TimeReversibleNucleotide.__init__(self, **kw)

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -191,7 +191,7 @@ class _SubstitutionModel:
         if motifs is not None:
             alphabet = alphabet.get_subset(motifs)
         self.alphabet = alphabet
-        self.gapmotif = alphabet.get_gap_motif()
+        self.gapmotif = alphabet.gap_char
         self._word_length = alphabet.motif_len
 
         # MOTIF PROB ALPHABET MAPPING
@@ -361,7 +361,7 @@ class _SubstitutionModel:
             klass = parameter_controller.AlignmentLikelihoodFunction
         else:
             alphabet = self.get_alphabet()
-            assert alphabet.get_gap_motif() not in alphabet
+            assert alphabet.gap_char not in alphabet
             klass = parameter_controller.SequenceLikelihoodFunction
 
         result = klass(self, tree, default_length=default_length, **kw)

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -192,7 +192,7 @@ class _SubstitutionModel:
             alphabet = alphabet.get_subset(motifs)
         self.alphabet = alphabet
         self.gapmotif = alphabet.get_gap_motif()
-        self._word_length = alphabet.get_motif_len()
+        self._word_length = alphabet.motif_len
 
         # MOTIF PROB ALPHABET MAPPING
         if mprob_model is None:

--- a/src/cogent3/format/clustal.py
+++ b/src/cogent3/format/clustal.py
@@ -5,7 +5,7 @@ Writer for Clustal format.
 
 from copy import copy
 
-from cogent3.core.alignment import SequenceCollection
+import cogent3
 
 
 def clustal_from_alignment(aln, wrap=None):
@@ -32,7 +32,7 @@ def clustal_from_alignment(aln, wrap=None):
         order = list(aln.keys())
         order.sort()
 
-    seqs = SequenceCollection(aln)
+    seqs = cogent3.make_unaligned_seqs(aln, moltype="text")
     clustal_list = ["CLUSTAL\n"]
 
     if seqs.is_ragged():

--- a/src/cogent3/parse/cigar.py
+++ b/src/cogent3/parse/cigar.py
@@ -17,7 +17,7 @@ the aligned sequence will be:
 
 import re
 
-from cogent3 import DNA, make_aligned_seqs
+import cogent3
 from cogent3.core.location import IndelMap, LostSpan, Span
 
 _pattern = re.compile("([0-9]*)([DM])")
@@ -51,8 +51,9 @@ def cigar_to_map(cigar_text):
     return IndelMap.from_spans(spans=spans, parent_length=posn)
 
 
-def aligned_from_cigar(cigar_text, seq, moltype=DNA):
+def aligned_from_cigar(cigar_text, seq, moltype="dna"):
     """returns an Aligned sequence from a cigar string, sequence and moltype"""
+    moltype = cogent3.get_moltype(moltype)
     if isinstance(seq, str):
         seq = moltype.make_seq(seq)
     map = cigar_to_map(cigar_text)
@@ -112,7 +113,7 @@ def CigarParser(
     ref_seqname=None,
     start=None,
     end=None,
-    moltype=DNA,
+    moltype="dna",
 ):
     """return an alignment from raw sequences and cigar strings
     if sliced, will return an alignment correspondent to ref sequence start to end
@@ -122,9 +123,10 @@ def CigarParser(
         seqs - raw sequences as {seqname: seq}
         cigars - corresponding cigar text as {seqname: cigar_text}
         cigars and seqs should have the same seqnames
-        moltype - optional default to DNA
+        moltype - optional default to 'dna'
 
     """
+    moltype = cogent3.get_moltype(moltype)
     data = {}
     if not sliced:
         for seqname in list(seqs.keys()):
@@ -153,5 +155,5 @@ def CigarParser(
                     seq = moltype.make_seq(seq)
                 data[seqname] = seq.gapped_by_map(m)
             else:
-                data[seqname] = DNA.make_seq("-" * (aln_loc[1] - aln_loc[0]))
-    return make_aligned_seqs(data)
+                data[seqname] = moltype.make_seq("-" * (aln_loc[1] - aln_loc[0]))
+    return cogent3.make_aligned_seqs(data, moltype=moltype)

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -36,7 +36,6 @@ from cogent3.app.sqlite_data_store import DataStoreSqlite
 from cogent3.app.translate import select_translatable
 from cogent3.app.tree import quick_tree
 from cogent3.app.typing import AlignedSeqsType, PairwiseDistanceType
-from cogent3.core.alignment import Alignment, SequenceCollection
 from cogent3.util.union_dict import UnionDict
 
 
@@ -293,7 +292,7 @@ def test_as_completed(DATA_DIR):
     path = str(Path(dstore[0].data_store.source) / dstore[0].unique_id)
     got = list(proc.as_completed(path, show_progress=False))
     assert len(got) == 1
-    assert isinstance(got[0].obj, SequenceCollection)
+    assert got[0].obj.__class__.__name__.endswith("SequenceCollection")
 
 
 @pytest.mark.parametrize("data", [(), ("", "")])
@@ -313,12 +312,16 @@ def test_as_completed_empty_data(data):
     [
         dict(a=2),
         UnionDict(a=2, source="blah.txt"),
-        Alignment(data=dict(a="ACGT"), info=dict(source="blah.txt")),
+        make_aligned_seqs(
+            data=dict(a="ACGT"),
+            info=dict(source="blah.txt"),
+            moltype="dna",
+        ),
     ],
 )
 def test_as_completed_w_wout_source(data):
     @define_app
-    def pass_through(val: dict | UnionDict | Alignment) -> dict:
+    def pass_through(val: dict | UnionDict | AlignedSeqsType) -> dict:
         return val
 
     app = pass_through()  # pylint: disable=not-callable,no-value-for-parameter
@@ -645,7 +648,7 @@ def test_user_function_multiple():
 
     aln_1 = make_aligned_seqs(data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")])
     data = dict([("s1", "ACGTACGTA"), ("s2", "GTGTACGTA")])
-    aln_2 = Alignment(data=data, moltype="dna")
+    aln_2 = make_aligned_seqs(data=data, moltype="dna")
 
     got_1 = u_function_1(aln_1)
     got_2 = u_function_2(aln_2)

--- a/tests/test_app/test_result.py
+++ b/tests/test_app/test_result.py
@@ -1,7 +1,7 @@
 import pathlib
 from unittest import TestCase
 
-from cogent3 import make_aligned_seqs, make_table
+import cogent3
 from cogent3.app import evo as evo_app
 from cogent3.app.data_store import DataMember
 from cogent3.app.result import (
@@ -18,8 +18,7 @@ from cogent3.util.dict_array import DictArray
 class TestGenericResult(TestCase):
     def test_deserialised_values(self):
         """correctly deserialises values"""
-        from cogent3 import DNA
-
+        DNA = cogent3.get_moltype("dna")
         data = {"type": "cogent3.core.moltype.MolType", "moltype": "dna"}
         result = generic_result(source="blah.json")
         result["key"] = data
@@ -67,7 +66,7 @@ class TestGenericResult(TestCase):
         """flexible handling of data source"""
         # works for string
         source = pathlib.Path("path/blah.fasta")
-        aln = make_aligned_seqs(
+        aln = cogent3.make_aligned_seqs(
             {"A": "ACGT"},
             info=dict(source=str(source), random_key=1234),
         )
@@ -97,7 +96,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             show_progress=False,
@@ -115,7 +114,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             show_progress=False,
@@ -132,7 +131,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             name="blah",
@@ -149,7 +148,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             split_codons=True,
@@ -169,7 +168,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             split_codons=True,
@@ -186,7 +185,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             split_codons=True,
@@ -206,7 +205,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         mod = evo_app.model(
             "F81",
             split_codons=True,
@@ -226,7 +225,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         model1 = evo_app.model(
             "BH",
             opt_args=dict(max_evaluations=25, limit_action="ignore"),
@@ -253,7 +252,7 @@ class TestModelResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         with self.assertRaises(TypeError):
             r["name"] = aln
 
@@ -282,7 +281,7 @@ class TestModelCollectionResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         model1 = evo_app.model(
             "F81",
             opt_args=dict(max_evaluations=25, limit_action="ignore"),
@@ -381,7 +380,7 @@ class TestHypothesisResult(TestCase):
             "Mouse": "ATGCCCGGCGCCAAGGCAGCGCTGGCGGAG",
             "Opossum": "ATGCCAGTGAAAGTGGCGGCGGTGGCTGAG",
         }
-        aln = make_aligned_seqs(data=_data, moltype="dna")
+        aln = cogent3.make_aligned_seqs(data=_data, moltype="dna")
         model1 = evo_app.model(
             "F81",
             opt_args=dict(max_evaluations=25, limit_action="ignore"),
@@ -405,7 +404,7 @@ class TestTabularResult(TestCase):
     def test_valid_setitem(self):
         """tabular_result works when set correct item type"""
         tr = tabular_result("null")
-        tr["result"] = make_table(data={"A": [0, 1]})
+        tr["result"] = cogent3.make_table(data={"A": [0, 1]})
         darr = DictArray({"A": [0, 1]})
         tr["result2"] = darr
         js = tr.to_json()

--- a/tests/test_app/test_tree.py
+++ b/tests/test_app/test_tree.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import pytest
 
-from cogent3 import DNA, load_aligned_seqs, make_aligned_seqs, make_tree
+import cogent3
 from cogent3.app import dist
 from cogent3.app import tree as tree_app
 from cogent3.app.composable import NotCompleted
@@ -12,6 +12,8 @@ from cogent3.evolve.fast_distance import DistanceMatrix
 
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
 
+DNA = cogent3.get_moltype("dna")
+
 
 class TestTree(TestCase):
     def test_scale_tree_lengths(self):
@@ -19,7 +21,7 @@ class TestTree(TestCase):
         with self.assertRaises(AssertionError):
             _ = tree_app.scale_branches(nuc_to_codon=True, codon_to_nuc=True)
 
-        tree = make_tree(treestring="(a:3,b:6,c:9)")
+        tree = cogent3.make_tree(treestring="(a:3,b:6,c:9)")
         scale_to_codon = tree_app.scale_branches(nuc_to_codon=True)
         d = scale_to_codon(tree)
         got = {e.name: e.length for e in d.get_edge_vector(include_root=False)}
@@ -40,7 +42,7 @@ class TestTree(TestCase):
 
         # handle case where a length is not defined, setting to minimum
         min_length = tree_app.scale_branches(min_length=66)
-        tree = make_tree(treestring="(a:3,b:6,c)")
+        tree = cogent3.make_tree(treestring="(a:3,b:6,c)")
         new = min_length(tree)
         got = {e.name: e.length for e in new.get_edge_vector(include_root=False)}
         expect = {"a": 3.0, "b": 6.0, "c": 66.0}
@@ -49,7 +51,7 @@ class TestTree(TestCase):
     def test_quick_tree(self):
         """correctly calc a nj tree"""
         path = DATA_DIR / "brca1_5.paml"
-        aln = load_aligned_seqs(path, moltype=DNA)
+        aln = cogent3.load_aligned_seqs(path, moltype=DNA)
         fast_slow_dist = dist.fast_slow_dist(fast_calc="hamming", moltype="dna")
         dist_matrix = fast_slow_dist(aln)
         quick1 = tree_app.quick_tree()
@@ -59,7 +61,7 @@ class TestTree(TestCase):
     def test_composable_apps(self):
         """checks the ability of these two apps(fast_slow_dist and quick_tree) to communicate"""
         path = DATA_DIR / "brca1_5.paml"
-        aln1 = load_aligned_seqs(path, moltype=DNA)
+        aln1 = cogent3.load_aligned_seqs(path, moltype=DNA)
         calc_dist = dist.fast_slow_dist(fast_calc="hamming", moltype="dna")
         quick = tree_app.quick_tree(drop_invalid=False)
         proc = calc_dist + quick
@@ -81,7 +83,7 @@ class TestTree(TestCase):
         data = dict(
             seq1="AGGGGGGGGGGCCCCCCCCCCCCCCCCCGGGGGGGGGGGGGGGCGGTTTTTTTTTTTTTTTTTT",
         )
-        aln2 = make_aligned_seqs(data=data, moltype=DNA)
+        aln2 = cogent3.make_aligned_seqs(data=data, moltype=DNA)
         tree2 = proc(aln2)
         self.assertIsInstance(tree2, NotCompleted)
 
@@ -225,8 +227,8 @@ class TestTree(TestCase):
 
     def test_uniformize_tree(self):
         """equivalent topologies should be the same"""
-        a = make_tree(treestring="(a,(b,c),(d,e))")
-        b = make_tree(treestring="(e,d,(a,(b,c)))")
+        a = cogent3.make_tree(treestring="(a,(b,c),(d,e))")
+        b = cogent3.make_tree(treestring="(e,d,(a,(b,c)))")
         make_uniform = tree_app.uniformize_tree(
             root_at="c",
             ordered_names=list("abcde"),
@@ -235,7 +237,7 @@ class TestTree(TestCase):
         u_b = make_uniform(b).get_newick()
         self.assertTrue(u_a == u_b)
         # but different ones different
-        c = make_tree(treestring="(e,c,(a,(b,d)))")
+        c = cogent3.make_tree(treestring="(e,c,(a,(b,d)))")
         u_c = make_uniform(c).get_newick()
         self.assertFalse(u_a == u_c)
 
@@ -250,7 +252,7 @@ def test_interpret_tree_arg_none():
         DATA_DIR / "brca1_5.tree",
         str(DATA_DIR / "brca1_5.tree"),
         "(a,b,c)",
-        make_tree(tip_names=["a", "b", "c"]),
+        cogent3.make_tree(tip_names=["a", "b", "c"]),
     ),
 )
 def test_interpret_tree_arg_valid(tree):
@@ -262,7 +264,7 @@ def test_interpret_tree_arg_valid(tree):
     "tree",
     (
         1,
-        make_tree,
+        cogent3.make_tree,
     ),
 )
 def test_interpret_tree_arg_invalid(tree):

--- a/tests/test_core/test_annotation.py
+++ b/tests/test_core/test_annotation.py
@@ -8,7 +8,6 @@ from cogent3 import (
     make_aligned_seqs,
     make_unaligned_seqs,
 )
-from cogent3.core.alignment import Alignment, SequenceCollection
 from cogent3.core.location import FeatureMap, Span
 
 DNA = get_moltype("dna")
@@ -331,12 +330,16 @@ def test_features_survives_seq_rename(rev):  # ported
     assert str(got) == domain_expect
 
 
+def make_aligned(**kwargs):
+    return make_aligned_seqs(array_align=False, **kwargs)
+
+
 @pytest.mark.parametrize("rev", (False, True))
-@pytest.mark.parametrize("make_cls", (make_unaligned_seqs, Alignment))
+@pytest.mark.parametrize("make_cls", (make_unaligned_seqs, make_aligned))
 def test_features_survives_aligned_seq_rename(rev, make_cls):  # ported
     segments = ["A" * 10, "C" * 10, "T" * 5, "C" * 5, "A" * 5]
 
-    seqs = make_cls({"original": "".join(segments)}, moltype="dna")
+    seqs = make_cls(data={"original": "".join(segments)}, moltype="dna")
     seqs.annotation_db.add_feature(
         seqid="original",
         biotype="gene",
@@ -360,11 +363,11 @@ def test_features_survives_aligned_seq_rename(rev, make_cls):  # ported
     assert sliced == "C" * 15
 
 
-@pytest.mark.parametrize("cls", (SequenceCollection, Alignment))
-def test_features_invalid_seqid(cls):  # ported
+@pytest.mark.parametrize("make", (make_unaligned_seqs, make_aligned))
+def test_features_invalid_seqid(make):  # ported
     segments = ["A" * 10, "C" * 10, "T" * 5, "C" * 5, "A" * 5]
 
-    seqs = cls({"original": "".join(segments)}, moltype="dna")
+    seqs = make(data={"original": "".join(segments)}, moltype="dna")
     seqs.annotation_db.add_feature(
         seqid="original",
         biotype="domain",

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -4,7 +4,7 @@ import warnings
 import numpy
 import pytest
 
-from cogent3 import DNA, SequenceCollection, _Table, load_seq
+import cogent3
 from cogent3.core.annotation_db import (
     BasicAnnotationDb,
     GenbankAnnotationDb,
@@ -18,6 +18,8 @@ from cogent3.core.annotation_db import (
 from cogent3.core.sequence import Sequence
 from cogent3.parse import genbank
 from cogent3.util import deserialise
+
+DNA = cogent3.get_moltype("dna")
 
 
 @pytest.fixture
@@ -34,7 +36,10 @@ def gff_small_db(DATA_DIR):
 
 @pytest.fixture
 def seq_db(DATA_DIR):
-    seq = load_seq(DATA_DIR / "c_elegans_WS199_dna_shortened.fasta", moltype="dna")
+    seq = cogent3.load_seq(
+        DATA_DIR / "c_elegans_WS199_dna_shortened.fasta",
+        moltype="dna",
+    )
     db = load_annotations(path=DATA_DIR / "c_elegans_WS199_shortened_gff.gff3")
 
     seq.annotation_db = db
@@ -127,8 +132,10 @@ def test_constructor_db_connection_works(db_name, cls, request):
 
 
 def test_gff_describe(gff_db):
+    from cogent3.util.table import Table
+
     result = gff_db.describe
-    assert isinstance(result, _Table)
+    assert isinstance(result, Table)
 
 
 def test_count_distinct(gff_db):
@@ -775,7 +782,7 @@ def test_sequence_collection_annotate_from_gff(DATA_DIR):
     to the same AnnotationDb instance
     """
     seqs = {"test_seq": "ATCGATCGATCG", "test_seq2": "GATCGATCGATC"}
-    seq_coll = SequenceCollection(seqs)
+    seq_coll = cogent3.make_unaligned_seqs(seqs, moltype="dna")
     seq_coll.annotate_from_gff(DATA_DIR / "simple.gff", seq_ids="test_seq")
 
     # the seq for which the seqid was provided is annotated
@@ -802,7 +809,7 @@ def test_sequence_collection_annotate_from_gff(DATA_DIR):
 def test_seq_coll_query(DATA_DIR):
     """obtain same results when querying from collection as from seq"""
     seqs = {"test_seq": "ATCGATCGATCG", "test_seq2": "GATCGATCGATC"}
-    seq_coll = SequenceCollection(seqs)
+    seq_coll = cogent3.make_unaligned_seqs(seqs, moltype="dna")
     seq_coll.annotate_from_gff(DATA_DIR / "simple.gff", seq_ids="test_seq")
 
     seq = seq_coll.get_seq("test_seq")

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -3,13 +3,15 @@ from unittest import TestCase
 import numpy
 import pytest
 
-from cogent3 import ASCII, DNA, get_moltype, make_aligned_seqs
-from cogent3.core.alignment import Alignment, SequenceCollection
+import cogent3
 from cogent3.core.annotation import Feature
 from cogent3.core.annotation_db import BasicAnnotationDb, GffAnnotationDb
 
 # Complete version of manipulating sequence annotations
 from cogent3.util.deserialise import deserialise_object
+
+ASCII = cogent3.get_moltype("text")
+DNA = cogent3.get_moltype("dna")
 
 
 class FeaturesTest(TestCase):
@@ -111,9 +113,10 @@ class FeaturesTest(TestCase):
 
 def test_copy_annotations():
     """copying features from a db"""
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAAAAA"], ["y", "TTTT--CCCT"]],
         array_align=False,
+        moltype="dna",
     )
     db = GffAnnotationDb()
     db.add_feature(seqid="y", biotype="exon", name="A", spans=[(5, 8)])
@@ -124,9 +127,10 @@ def test_copy_annotations():
 
 def test_copy_annotations_onto_seq():
     """copying features onto a sequence"""
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAAAAA"], ["y", "TTTT--CCCT"]],
         array_align=False,
+        moltype="dna",
     )
     db = BasicAnnotationDb()
     db.add_feature(seqid="y", biotype="exon", name="A", spans=[(5, 8)])
@@ -141,7 +145,7 @@ def test_feature_residue():
     # In this case, only those residues included within the feature are
     # covered - note the omission of the T in y opposite the gap in x.
 
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "C-CCCAAAAA"], ["y", "-T----TTTT"]],
         moltype=DNA,
         array_align=False,
@@ -241,7 +245,7 @@ def test_feature_query_parent_seq():
 
 
 def test_feature_query_child_aln():
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAGGGGGAAC-CT"], ["y", "TTTT--TTTTAGGGA"]],
         array_align=False,
         moltype="dna",
@@ -256,7 +260,7 @@ def test_feature_query_child_aln():
 
 
 def test_feature_query_parent_aln():
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAGGGGGAAC-CT"], ["y", "TTTT--TTTTAGGGA"]],
         array_align=False,
         moltype="dna",
@@ -275,9 +279,10 @@ def test_aln_feature_lost_spans():
     db = GffAnnotationDb(data=[])
     db.add_feature(seqid="y", biotype="repeat", name="A", spans=[(12, 14)])
     # If the sequence is shorter, again you get a lost span.
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data={"x": "-AAAAAAAAA", "y": "TTTT--TTTT"},
         array_align=False,
+        moltype="dna",
     )
     aln.annotation_db = db
     copied = list(aln.get_features(seqid="y", biotype="repeat"))
@@ -291,17 +296,19 @@ def test_terminal_gaps():
     db = GffAnnotationDb()
     feat = dict(seqid="x", biotype="exon", name="fred", spans=[(3, 8)])
     db.add_feature(**feat)
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAAAAA"], ["y", "------TTTT"]],
         array_align=False,
+        moltype="dna",
     )
     aln.annotation_db = db
     aln_exons = list(aln.get_features(seqid="x", biotype="exon"))
     assert "biotype='exon', name='fred', map=[4:9]/10" in str(aln_exons)
     assert aln_exons[0].get_slice().to_dict() == dict(x="AAAAA", y="--TTT")
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAAAAA"], ["y", "TTTT--T---"]],
         array_align=False,
+        moltype="dna",
     )
     aln.annotation_db = db
     aln_exons = list(aln.get_features(seqid="x", biotype="exon"))
@@ -328,7 +335,7 @@ def test_annotated_region_masks():  # ported to test_new_aln_annotation.py
         seqid="x",
     )
     db.add_feature(seqid="y", biotype="repeat", name="frog", spans=[(5, 7)])
-    aln = make_aligned_seqs(data=orig_data, array_align=False, moltype="dna")
+    aln = cogent3.make_aligned_seqs(data=orig_data, array_align=False, moltype="dna")
     aln.annotation_db = db
 
     assert aln.to_dict() == {"x": "C-CCCAAAAAGGGAA", "y": "-T----TTTTG-GTT"}
@@ -427,9 +434,10 @@ def test_nested_annotated_region_masks():  # ported to test_new_aln_annotation.p
     db.add_feature(seqid="x", biotype="gene", name="norwegian", spans=[(0, 4)])
     db.add_feature(seqid="x", biotype="repeat", name="blue", spans=[(1, 3)])
     db.add_feature(seqid="y", biotype="repeat", name="frog", spans=[(1, 4)])
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "C-GGCAAAAATTTAA"], ["y", "-T----TTTTG-GTT"]],
         array_align=False,
+        moltype="dna",
     )
     aln.annotation_db = db
     gene = list(aln.get_seq("x").get_features(biotype="gene"))[0]
@@ -459,9 +467,10 @@ def test_feature_from_alignment():
 
     # Sequence features can be accessed via a containing Alignment:
     db = GffAnnotationDb()
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data={"x": "-AAAAAAAAA", "y": "TTTT--TTTT"},
         array_align=False,
+        moltype="dna",
     )
     db.add_feature(seqid="x", biotype="exon", name="fred", spans=[(3, 8)])
     aln.annotation_db = db
@@ -514,7 +523,7 @@ def test_roundtrip_annotated_seq():
 def test_roundtrip_rc_annotated_align():
     """should work for an alignment that has been reverse complemented"""
     # the key that exposed the bug was a gap in the middle of the sequence
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAGGGGGAAC-CT"], ["y", "TTTT--TTTTAGGGA"]],
         array_align=False,
         moltype="dna",
@@ -562,7 +571,7 @@ def test_masking_strand_agnostic_aln():
         name="gene",
         spans=[(2, 6), (10, 15), (25, 35)],
     )
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         {
             "x": "AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA",
             "y": "AAGGGGAAAACCCCCGGGGGGGGGGTTTTTTTTTTAAA",
@@ -606,9 +615,10 @@ def test_roundtrip_json():
 def test_roundtripped_alignment():
     """Alignment with annotations roundtrips correctly"""
     # annotations just on member sequences
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAAAAA"], ["y", "TTTT--TTTT"]],
         array_align=False,
+        moltype="dna",
     )
     db = GffAnnotationDb()
     db.add_feature(seqid="x", biotype="exon", name="fred", spans=[(3, 8)])
@@ -622,9 +632,10 @@ def test_roundtripped_alignment():
     assert got_exons.get_slice().to_dict() == expect.to_dict()
 
     # annotations just on alignment
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAGGGG"], ["y", "TTTT--CCCC"]],
         array_align=False,
+        moltype="dna",
     )
 
     f = aln.add_feature(biotype="generic", name="no name", spans=[(1, 4), (6, 10)])
@@ -634,9 +645,10 @@ def test_roundtripped_alignment():
     got = list(new.get_features(biotype="generic"))[0]
     assert got.get_slice().to_dict() == expect
     # annotations on both alignment and sequence
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAAAGGGG"], ["y", "TTTT--CCCC"]],
         array_align=False,
+        moltype="dna",
     )
     db = GffAnnotationDb()
     db.add_feature(
@@ -667,7 +679,11 @@ def test_roundtripped_alignment():
 
 def test_feature_out_range():
     """features no longer included in an alignment will not be returned"""
-    aln = make_aligned_seqs(data=[["x", "-AAAA"], ["y", "TTTTT"]], array_align=False)
+    aln = cogent3.make_aligned_seqs(
+        data=[["x", "-AAAA"], ["y", "TTTTT"]],
+        array_align=False,
+        moltype="dna",
+    )
     db = GffAnnotationDb()
     db.add_feature(seqid="x", biotype="exon", name="A", spans=[(5, 8)])
     f = list(aln.get_features(seqid="x", biotype="exon"))
@@ -692,9 +708,10 @@ def test_search_with_ints(cast):
 def test_roundtripped_alignment_with_slices():
     """Sliced Alignment with annotations roundtrips correctly"""
     # annotations just on member sequences
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data=[["x", "-AAAGGGGGAACCCT"], ["y", "TTTT--TTTTAGGGA"]],
         array_align=False,
+        moltype="dna",
     )
     db = GffAnnotationDb()
     db.add_feature(seqid="x", biotype="exon", name="E1", spans=[(3, 8)])
@@ -739,7 +756,7 @@ def test_feature_reverse():
 
 @pytest.mark.parametrize("moltype", ("protein", "bytes", "text"))
 def test_rc_feature_on_wrong_moltype(moltype):
-    moltype = get_moltype(moltype)
+    moltype = cogent3.get_moltype(moltype)
     seq = moltype.make_seq(seq="AAGGGGAAAACCCCCAAAAAAAAAATTTTTTTTTTAAA", name="s1")
     cds = seq.add_feature(
         biotype="CDS",
@@ -803,10 +820,15 @@ def test_seq_degap_preserves_annotations():
     assert len(s1.annotation_db) == len(dg.annotation_db)
 
 
-@pytest.mark.parametrize("cls", (SequenceCollection, Alignment))
-def test_align_degap_preserves_annotations(cls):
+@pytest.mark.parametrize("aligned", [True, False])
+def test_align_degap_preserves_annotations(aligned):
     """get translation works on incomplete codons"""
-    coll = cls(data={"seq1": "GATN--", "seq2": "?GATCT"}, moltype=DNA)
+    kwargs = dict(data={"seq1": "GATN--", "seq2": "?GATCT"}, moltype=DNA)
+    coll = (
+        cogent3.make_aligned_seqs(array_align=aligned, **kwargs)
+        if aligned
+        else cogent3.make_unaligned_seqs(**kwargs)
+    )
     db = BasicAnnotationDb()
     db.add_feature(biotype="exon", name="exon1", spans=[(1, 2)], seqid="seq1")
     coll.annotation_db = db

--- a/tests/test_core/test_maps.py
+++ b/tests/test_core/test_maps.py
@@ -1,7 +1,9 @@
 import unittest
 
-from cogent3 import DNA, make_aligned_seqs
+import cogent3
 from cogent3.core.location import FeatureMap, Span
+
+DNA = cogent3.get_moltype("dna")
 
 
 class MapTest(unittest.TestCase):
@@ -47,9 +49,10 @@ class MapTest(unittest.TestCase):
 
 
 def test_get_by_seq_annotation_allow_gaps():
-    aln = make_aligned_seqs(
+    aln = cogent3.make_aligned_seqs(
         data={"a": "ATCGAAATCGAT", "b": "ATCGA--TCGAT"},
         array_align=False,
+        moltype="dna",
     )
     # original version was putting annotation directly on seq
     f = aln.add_feature(

--- a/tests/test_core/test_profile.py
+++ b/tests/test_core/test_profile.py
@@ -6,7 +6,10 @@ from unittest import TestCase
 from numpy import array, log2, nan, vstack
 from numpy.testing import assert_allclose
 
+import cogent3
 from cogent3.core.profile import PSSM, MotifCountsArray, MotifFreqsArray
+
+DNA = cogent3.get_moltype("dna")
 
 
 class MotifCountsArrayTests(TestCase):
@@ -524,7 +527,6 @@ class PSSMTests(TestCase):
 
     def test_score_seq_obj(self):
         """produce correct score from seq"""
-        from cogent3 import DNA
 
         data = [
             [0.1, 0.3, 0.5, 0.1],

--- a/tests/test_core/test_seq_aln_integration.py
+++ b/tests/test_core/test_seq_aln_integration.py
@@ -256,8 +256,3 @@ class AllTests(TestCase):
         assert_equal(model1._data, [0, 4, 1, 4, 2, 4, 3, 4])
         # ArraySequence should maybe have the same degap method as normal seq
         self.assertEqual(str(model1.degap()), "UCAG")
-
-    def test_the_rest_of_ModelSequence(self):
-        """The class ArraySequence has 14 methods, but only 2 unittests.
-        You might want to add some tests there..."""
-        # note: mostly these are tested in derived classes, for convenience.

--- a/tests/test_draw/test_dotplot.py
+++ b/tests/test_draw/test_dotplot.py
@@ -3,8 +3,8 @@ from unittest import TestCase
 import numpy
 import pytest
 
-from cogent3 import get_moltype, make_unaligned_seqs
-from cogent3.core.alignment import Aligned, ArrayAlignment
+from cogent3 import get_moltype, make_aligned_seqs, make_unaligned_seqs
+from cogent3.core.alignment import Aligned
 from cogent3.core.location import IndelMap
 from cogent3.draw.dotplot import Dotplot, _convert_input, _prep_seqs, get_align_coords
 
@@ -79,8 +79,8 @@ class TestUtilFunctions(TestCase):
 
     def test_align_without_gaps(self):
         """dotplot has alignment coordinates if no gaps"""
-        aln = ArrayAlignment(
-            {"seq1": "ACGG", "seq2": "CGCA", "seq3": "CCG-"},
+        aln = make_aligned_seqs(
+            data={"seq1": "ACGG", "seq2": "CGCA", "seq3": "CCG-"},
             moltype="dna",
         )
         aln_plot = aln.dotplot("seq1")

--- a/tests/test_evolve/test_best_likelihood.py
+++ b/tests/test_evolve/test_best_likelihood.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from numpy.testing import assert_allclose
 
-from cogent3 import DNA, make_aligned_seqs
+import cogent3
 from cogent3.evolve.best_likelihood import (
     BestLogLikelihood,
     _take,
@@ -15,6 +15,7 @@ from cogent3.evolve.best_likelihood import (
 )
 
 IUPAC_DNA_ambiguities = "NRYWSKMBDHV"
+DNA = cogent3.get_moltype("dna")
 
 
 def makeSampleAlignment(gaps=False, ambiguities=False):
@@ -25,7 +26,7 @@ def makeSampleAlignment(gaps=False, ambiguities=False):
     else:
         seqs_list = ["AAACCCGGGTTTA", "CCCGGGTTTAAAC", "GGGTTTAAACCCG"]
     seqs = list(zip("abc", seqs_list, strict=False))
-    return make_aligned_seqs(data=seqs)
+    return cogent3.make_aligned_seqs(data=seqs, moltype="dna")
 
 
 class TestGoldman93(TestCase):

--- a/tests/test_evolve/test_ns_substitution_model.py
+++ b/tests/test_evolve/test_ns_substitution_model.py
@@ -5,7 +5,7 @@ import numpy
 from numpy import array, dot, empty
 from numpy.testing import assert_allclose
 
-from cogent3 import DNA, make_aligned_seqs, make_tree
+import cogent3
 from cogent3.evolve.ns_substitution_model import (
     DiscreteSubstitutionModel,
     General,
@@ -19,6 +19,8 @@ from cogent3.evolve.ns_substitution_model import (
 )
 from cogent3.evolve.predicate import MotifChange
 from cogent3.evolve.substitution_model import TimeReversibleNucleotide
+
+DNA = cogent3.get_moltype("dna")
 
 
 def _make_likelihood(model, tree, results, is_discrete=False):
@@ -56,7 +58,7 @@ class MakeCachedObjects:
         self.lf.set_motif_probs(dict(A=0.1, C=0.2, G=0.3, T=0.4))
         self.aln = self.lf.simulate_alignment(seq_length)
         self.results = dict(aln=self.aln)
-        self.discrete_tree = make_tree(tip_names=self.aln.names)
+        self.discrete_tree = cogent3.make_tree(tip_names=self.aln.names)
         self.opt_args = {**opt_args, "show_progress": False}
         self.tree = tree
 
@@ -137,7 +139,7 @@ class MakeCachedObjects:
 class NonStatMarkov(TestCase):
     """test discrete and general markov"""
 
-    tree = make_tree(treestring="(a:0.4,b:0.4,c:0.6)")
+    tree = cogent3.make_tree(treestring="(a:0.4,b:0.4,c:0.6)")
     opt_args = dict(max_restarts=1, local=True, show_progress=False)
     make_cached = MakeCachedObjects(TimeReversibleNucleotide(), tree, 100000, opt_args)
 
@@ -223,9 +225,9 @@ class NonStatMarkov(TestCase):
         """StrandSymmetric should fit a strand symmetric model"""
         warnings.filterwarnings("ignore", "Model not reversible", UserWarning)
         taxa = "Human", "Mouse", "Opossum"
-        aln = make_aligned_seqs(data=_aln, moltype=DNA)
+        aln = cogent3.make_aligned_seqs(data=_aln, moltype=DNA)
         aln = aln[2::3].no_degenerates()
-        tree = make_tree(tip_names=taxa)
+        tree = cogent3.make_tree(tip_names=taxa)
         model = StrandSymmetric(optimise_motif_probs=True)
         lf = model.make_likelihood_function(tree)
         lf.set_alignment(aln)

--- a/tests/test_parse/test_cigar.py
+++ b/tests/test_parse/test_cigar.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cogent3 import DNA, make_aligned_seqs
+import cogent3
 from cogent3.core.annotation_db import GffAnnotationDb
 from cogent3.parse.cigar import (
     CigarParser,
@@ -9,6 +9,8 @@ from cogent3.parse.cigar import (
     map_to_cigar,
     slice_cigar,
 )
+
+DNA = cogent3.get_moltype("dna")
 
 
 class TestCigar(unittest.TestCase):
@@ -19,9 +21,10 @@ class TestCigar(unittest.TestCase):
         self.map, self.seq = self.aln_seq.parse_out_gaps()
         self.map1, self.seq1 = self.aln_seq1.parse_out_gaps()
         self.slices = [(1, 4), (0, 8), (7, 12), (0, 1), (3, 5)]
-        self.aln = make_aligned_seqs(
+        self.aln = cogent3.make_aligned_seqs(
             {"FAKE01": self.aln_seq, "FAKE02": self.aln_seq1},
             array_align=False,
+            moltype="dna",
         )
         self.cigars = {"FAKE01": self.cigar_text, "FAKE02": map_to_cigar(self.map1)}
         self.seqs = {"FAKE01": str(self.seq), "FAKE02": str(self.seq1)}
@@ -89,7 +92,3 @@ class TestCigar(unittest.TestCase):
                 end=end,
             )
             assert cmp_aln.to_dict() == slice_aln.to_dict(), (start, end)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_util/test_dictarray.py
+++ b/tests/test_util/test_dictarray.py
@@ -7,7 +7,7 @@ import numpy
 import pytest
 from numpy.testing import assert_allclose
 
-from cogent3 import DNA
+import cogent3
 from cogent3.util.dict_array import (
     DictArray,
     DictArrayTemplate,
@@ -18,6 +18,8 @@ from cogent3.util.dict_array import (
     convert_for_dictarray,
     convert_series,
 )
+
+DNA = cogent3.get_moltype("dna")
 
 
 class DictArrayTest(TestCase):

--- a/tests/test_util/test_misc.py
+++ b/tests/test_util/test_misc.py
@@ -8,6 +8,7 @@ import pytest
 from numpy import array
 from numpy.testing import assert_allclose
 
+import cogent3
 from cogent3.util.misc import (
     ClassChecker,
     ConstrainedContainer,
@@ -388,15 +389,14 @@ class UtilsTests(TestCase):
 
     def test_get_object_provenance(self):
         """correctly deduce object provenance"""
-        from cogent3 import DNA, SequenceCollection, get_model
-
         result = get_object_provenance("abncd")
         self.assertEqual(result, "str")
 
+        DNA = cogent3.get_moltype("dna")
         got = get_object_provenance(DNA)
-        self.assertEqual(got, "cogent3.core.moltype.MolType")
+        self.assertEqual(got, f"{DNA.__module__}.MolType")
 
-        sm = get_model("HKY85")
+        sm = cogent3.get_model("HKY85")
         got = get_object_provenance(sm)
         self.assertEqual(
             got,
@@ -404,10 +404,13 @@ class UtilsTests(TestCase):
         )
 
         # handle a type
-        instance = SequenceCollection(dict(a="ACG", b="GGG"))
+        instance = cogent3.make_unaligned_seqs(
+            data=dict(a="ACG", b="GGG"),
+            moltype="dna",
+        )
         instance_prov = get_object_provenance(instance)
-        self.assertEqual(instance_prov, "cogent3.core.alignment.SequenceCollection")
-        type_prov = get_object_provenance(SequenceCollection)
+        self.assertEqual(instance_prov, f"{instance.__module__}.SequenceCollection")
+        type_prov = get_object_provenance(type(instance))
         self.assertEqual(instance_prov, type_prov)
 
     def test_get_object_provenance_builtins(self):


### PR DESCRIPTION
[CHANGED] don't explicitly import old alignment, moltype, genetic code
    etc.. Use the cogent3 top-level functions `make_(un)aligned_seqs` etc...

[CHANGED] modify some tests outside the old class tests specific modules
    to facilitate using the COGENT3_NEW_TYPE environment variable

[CHANGED] use of isinstance(obj, ArrayAlignment) etc.. changed to check
    the class name for compatability with new class names. These should be
    reverted when new_type is the default.

## Summary by Sourcery

Refactor codebase to utilize cogent3 top-level functions for sequence creation, enhancing compatibility with new class names and preparing for full integration of new_type classes. Update tests accordingly to ensure they align with the refactored code.

Enhancements:
- Refactor code to use cogent3 top-level functions for sequence creation, improving compatibility with new class names.

Tests:
- Update tests to use cogent3.make_aligned_seqs and cogent3.make_unaligned_seqs functions, ensuring compatibility with new class names.