### PR TITLE
BUG: slicing alignment no longer forgets selected seqs

### DIFF
--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5470,3 +5470,15 @@ def test_load_from_url():
         new_type=True,
     )
     assert isinstance(aln, new_alignment.Alignment)
+
+
+def test_slice_preserves_selected_names(DATA_DIR):
+    aln = load_aligned_seqs(
+        DATA_DIR / "brca1.fasta",
+        moltype="dna",
+        new_type=True,
+    )
+    seqnames = ["Chimpanzee", "Rhesus", "Orangutan", "Human"]
+    aln = aln.take_seqs(seqnames)
+    aln = aln[:1000]
+    assert set(aln.names) == set(seqnames)


### PR DESCRIPTION
[FIXED] preserve effect of take_seqs on slice operations

[CHANGED] use self._get_init_kwargs() nearly always and change
    the keys that shouyld be modified for all Alignment methods
    that return a new alignment.

## Summary by Sourcery

Fix the bug where slicing operations on alignments would lose the effect of take_seqs, ensuring selected sequences are preserved. Refactor alignment methods to consistently use self._get_init_kwargs() for initialization, and add a test to confirm the fix.

Bug Fixes:
- Fix the issue where slicing operations on alignments would forget the sequences selected by take_seqs.

Enhancements:
- Refactor alignment methods to use self._get_init_kwargs() for initializing new alignment objects, ensuring consistent handling of initialization parameters.

Tests:
- Add a test to verify that slicing operations preserve the selected sequence names after using take_seqs.