### PR TITLE
MAINT: misc patches

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -97,7 +97,6 @@ def testdocs(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_new_type(session):
-    py = pathlib.Path(session.bin_paths[0]) / "python"
     session.install(".[test]")
     session.env["COGENT3_NEW_TYPE"] = "1"
     session.chdir("tests")

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def test_slow(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    session.install("-e.[test]")
+    session.install(".[test]")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
     session.run(
@@ -93,3 +93,38 @@ def testdocs(session):
             "rst",
             external=True,
         )
+
+
+@nox.session(python=[f"3.{v}" for v in _py_versions])
+def test_new_type(session):
+    py = pathlib.Path(session.bin_paths[0]) / "python"
+    session.install(".[test]")
+    session.env["COGENT3_NEW_TYPE"] = "1"
+    session.chdir("tests")
+    session.run(
+        "pytest",
+        "-s",
+        "--ignore",
+        "test_app_mpi.py",
+        "--ignore",
+        "test_core/test_alignment.py",
+        "--ignore",
+        "test_core/test_alphabet.py",
+        "--ignore",
+        "test_core/test_annotation.py",
+        "--ignore",
+        "test_core/test_genetic_code.py",
+        "--ignore",
+        "test_core/test_moltype.py",
+        "--ignore",
+        "test_core/test_sequence.py",
+        "--ignore",
+        "test_core/test_seq_aln_integration.py",
+        "--ignore",
+        "test_core/test_core_standalone.py",
+        "--ignore",
+        "test_util/test_recode_alignment.py",
+        "-m",
+        "not slow",
+        *session.posargs,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,9 @@ filterwarnings = [
     'ignore:Model not reversible',
 ]
 
+[tool.uv]
+reinstall-package = ["cogent3"]
+
 [tool.ruff]
 exclude = [
     ".bzr",

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -944,7 +944,6 @@ class SequenceCollection:
             data[name] = self.moltype.degap(seq)
 
         init_kwargs = self._get_init_kwargs()
-        init_kwargs.pop("annotation_db", None)
         init_kwargs["seqs_data"] = self._seqs_data.from_seqs(
             data=data,
             alphabet=self._seqs_data.alphabet,
@@ -4799,6 +4798,7 @@ class Alignment(SequenceCollection):
             if step < 0
             else data
         )
+        kwargs["annotation_db"] = self.annotation_db
         return make_unaligned_seqs(data, moltype=self.moltype, info=self.info, **kwargs)
 
     def get_degapped_relative_to(self, name: str):

--- a/tests/test_align/test_align.py
+++ b/tests/test_align/test_align.py
@@ -27,6 +27,7 @@ dna_model = cogent3.evolve.substitution_model.TimeReversibleNucleotide(
 )
 
 DNA = get_moltype("dna")
+PROTEIN = get_moltype("protein")
 seq1 = DNA.make_seq(seq="AAACCGGACATTACGTGCGTA", name="FAKE01")
 seq2 = DNA.make_seq(seq="CCGGTCAGGTTACGTACGTT", name="FAKE02")
 
@@ -60,8 +61,6 @@ class AlignmentTestCase(unittest.TestCase):
 
     def test_pwise_protein(self):
         """works for pairwise protein alignment"""
-        from cogent3 import PROTEIN
-
         S = make_generic_scoring_dict(1, PROTEIN)
         seq1 = PROTEIN.make_seq(seq="MAYPFQLGLQD", name="seq1")
         seq2 = PROTEIN.make_seq(seq="MAYPFGLQD", name="seq2")

--- a/tests/test_app/test_align.py
+++ b/tests/test_app/test_align.py
@@ -6,7 +6,6 @@ from numpy import log2
 from numpy.testing import assert_allclose
 
 from cogent3 import (
-    DNA,
     get_app,
     get_moltype,
     load_aligned_seqs,
@@ -34,6 +33,7 @@ from cogent3.app.composable import NotCompleted
 from cogent3.core.alignment import Aligned
 from cogent3.core.location import gap_coords_to_map
 
+DNA = get_moltype("dna")
 _seqs = {
     "Human": "GCCAGCTCATTACAGCATGAGAACAGCAGTTTATTACTCACT",
     "Bandicoot": "NACTCATTAATGCTTGAAACCAGCAGTTTATTGTCCAAC",
@@ -673,7 +673,10 @@ def test_progressive_align_iters(seqs):
 
 def test_smith_waterman_matches_local_pairwise(seqs):
     aligner = smith_waterman()
-    coll = make_unaligned_seqs(data=[seqs.get_seq("Human"), seqs.get_seq("Bandicoot")])
+    coll = make_unaligned_seqs(
+        data=[seqs.get_seq("Human"), seqs.get_seq("Bandicoot")],
+        moltype="dna",
+    )
     got = aligner(coll)
     s = make_dna_scoring_dict(10, -1, -8)
     insertion = 20
@@ -726,7 +729,10 @@ def test_smith_waterman_no_moltype(seqs):
     default moltype ('dna') should be used.
     """
     aligner = smith_waterman()
-    coll = make_unaligned_seqs(data=[seqs.get_seq("Human"), seqs.get_seq("Bandicoot")])
+    coll = make_unaligned_seqs(
+        data=[seqs.get_seq("Human"), seqs.get_seq("Bandicoot")],
+        moltype="dna",
+    )
     aln = aligner(coll)
     assert aln.moltype.label == "dna"
 

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -616,7 +616,7 @@ def foo_without_arg_kwargs(val: AlignedSeqsType) -> AlignedSeqsType:
 
 @define_app
 def bar(val: AlignedSeqsType, num=3) -> PairwiseDistanceType:
-    return val.distance_matrix(calc="hamming", show_progress=False)
+    return val.distance_matrix(calc="hamming")
 
 
 def test_user_function():
@@ -624,7 +624,10 @@ def test_user_function():
 
     u_function = foo()
 
-    aln = make_aligned_seqs(data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")])
+    aln = make_aligned_seqs(
+        data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")],
+        moltype="dna",
+    )
     got = u_function(aln)
 
     assert got.to_dict() == {"a": "GCAA", "b": "GCTT"}
@@ -635,7 +638,10 @@ def test_user_function_without_arg_kwargs():
 
     u_function = foo_without_arg_kwargs()
 
-    aln = make_aligned_seqs(data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")])
+    aln = make_aligned_seqs(
+        data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")],
+        moltype="dna",
+    )
     got = u_function(aln)
 
     assert got.to_dict() == {"a": "GCAA", "b": "GCTT"}
@@ -646,7 +652,10 @@ def test_user_function_multiple():
     u_function_1 = foo()
     u_function_2 = bar()
 
-    aln_1 = make_aligned_seqs(data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")])
+    aln_1 = make_aligned_seqs(
+        data=[("a", "GCAAGCGTTTAT"), ("b", "GCTTTTGTCAAT")],
+        moltype="dna",
+    )
     data = dict([("s1", "ACGTACGTA"), ("s2", "GTGTACGTA")])
     aln_2 = make_aligned_seqs(data=data, moltype="dna")
 

--- a/tests/test_app/test_dist.py
+++ b/tests/test_app/test_dist.py
@@ -335,10 +335,10 @@ def test_approx_jc69(moltype):
     jc_dist_app = approx_jc69()
     got = jc_dist_app(dm)
 
-    assert got[("s1", "s2")] == expected[("s1", "s2")]
-    assert got[("s2", "s1")] == expected[("s2", "s1")]
-    assert got[("s1", "s1")] == expected[("s1", "s1")]
-    assert got[("s2", "s2")] == expected[("s2", "s2")]
+    assert_allclose(got[("s1", "s2")], expected[("s1", "s2")])
+    assert_allclose(got[("s2", "s1")], expected[("s2", "s1")])
+    assert_allclose(got[("s1", "s1")], expected[("s1", "s1")])
+    assert_allclose(got[("s2", "s2")], expected[("s2", "s2")])
 
 
 @pytest.mark.parametrize("moltype", ("dna", "rna"))
@@ -365,7 +365,8 @@ def test_approx_pdist_same_diff(moltype):
         ],
     )
     pdist_app = jaccard_dist(k=3) + approx_pdist()
-    collection = make_unaligned_seqs(data=data, moltype=moltype)
+    collection = make_unaligned_seqs(data=data, moltype="text")
+    collection = collection.to_moltype(moltype)
     dists = pdist_app(collection)
 
     # comparisons with one position different should be smaller than those with two

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -186,7 +186,10 @@ class TestModel(TestCase):
             upper=upper,
         )
 
-        aln = make_aligned_seqs(data=dict(s1="ACGT", s2="ACGC", s3="AAGT"))
+        aln = make_aligned_seqs(
+            data=dict(s1="ACGT", s2="ACGC", s3="AAGT"),
+            moltype="dna",
+        )
         result = app(aln)
         rules = result.lf.get_param_rules()
         kappa_bounds = {
@@ -975,7 +978,7 @@ def test_model_bounds_allpar():
         upper=upper,
     )
 
-    aln = make_aligned_seqs(data=dict(s1="ACGT", s2="ACGC", s3="AAGT"))
+    aln = make_aligned_seqs(data=dict(s1="ACGT", s2="ACGC", s3="AAGT"), moltype="dna")
     result = app(aln)
     rules = result.lf.get_param_rules()
     par_bounds = {
@@ -998,7 +1001,7 @@ def test_model_bounds_kappa():
         param_rules=[{"par_name": "kappa", "upper": upper_kappa, "lower": lower_kappa}],
     )
 
-    aln = make_aligned_seqs(data=dict(s1="ACGT", s2="ACGC", s3="AAGT"))
+    aln = make_aligned_seqs(data=dict(s1="ACGT", s2="ACGC", s3="AAGT"), moltype="dna")
     result = app(aln)
     rules = result.lf.get_param_rules()
     kappa_bounds = {(r["lower"], r["upper"]) for r in rules if r["par_name"] == "kappa"}

--- a/tests/test_app/test_result.py
+++ b/tests/test_app/test_result.py
@@ -69,6 +69,7 @@ class TestGenericResult(TestCase):
         aln = cogent3.make_aligned_seqs(
             {"A": "ACGT"},
             info=dict(source=str(source), random_key=1234),
+            moltype="dna",
         )
         gr = generic_result(aln)
         self.assertEqual(gr.source, source.name)

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 
 import pytest

--- a/tests/test_app/test_sample.py
+++ b/tests/test_app/test_sample.py
@@ -520,6 +520,7 @@ class TranslateTests(TestCase):
                 "g": "YAAA",
                 "h": "GGGG",
             },
+            moltype="dna",
         )
         seqs2 = seqs1.take_seqs(["a", "c", "e", "g", "h"])
 
@@ -676,10 +677,14 @@ def test_omit_bad_seqs_ambigs(bad_ambig_gap_data):
     assert set(got.to_dict().keys()) == {"s4", "s5", "s6"}
 
 
+@pytest.mark.skipif(
+    os.getenv("COGENT3_NEW_TYPE") is not None,
+    reason="Skipping test because COGENT3_NEW_TYPE is defined",
+)
 def test_omit_bad_seqs_ambigs_old_aln(bad_ambig_gap_data):
     # ambig_fraction should be ignored if using old style alignment
 
-    aln = cogent3.make_aligned_seqs(bad_ambig_gap_data, moltype=DNA)
+    aln = cogent3.make_aligned_seqs(bad_ambig_gap_data, moltype=DNA, new_type=False)
     dropbad = sample.omit_bad_seqs(gap_fraction=0.5, ambig_fraction=0.5)
 
     got = dropbad(aln)

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -764,7 +764,7 @@ def test_rc_feature_on_wrong_moltype(moltype):
         spans=[(2, 6), (10, 15), (25, 35)],
         strand="-",
     )
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, AttributeError)):
         cds.get_slice()
 
 
@@ -822,7 +822,6 @@ def test_seq_degap_preserves_annotations():
 
 @pytest.mark.parametrize("aligned", [True, False])
 def test_align_degap_preserves_annotations(aligned):
-    """get translation works on incomplete codons"""
     kwargs = dict(data={"seq1": "GATN--", "seq2": "?GATCT"}, moltype=DNA)
     coll = (
         cogent3.make_aligned_seqs(array_align=aligned, **kwargs)

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -406,6 +406,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         aln = make_aligned_seqs(
             data=dict(a="AAACGGTTT", b="CAA--GTAA"),
             array_align=False,
+            moltype="dna",
         )
         db = GffAnnotationDb()
         db.add_feature(seqid="b", biotype="domain", name="1", spans=[(1, 5)])

--- a/tests/test_evolve/test_distance.py
+++ b/tests/test_evolve/test_distance.py
@@ -1035,7 +1035,7 @@ def test_get_raw_estimates(al):
 
 def test_no_calc():
     """returns None if no calculation done"""
-    al = cogent3.load_aligned_seqs("data/brca1_5.paml")
+    al = cogent3.load_aligned_seqs("data/brca1_5.paml", moltype="dna")
     d = EstimateDistances(al, submodel=HKY85())
     assert d.get_pairwise_distances() is None
 

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -12,6 +12,7 @@ tests to do:
 
 import json
 import os
+import re
 import warnings
 from unittest import TestCase
 
@@ -167,7 +168,7 @@ class LikelihoodCalcs(TestCase):
         aln = aln.to_dict()
         one = aln.pop("Mouse")
         aln["root"] = one
-        aln = make_aligned_seqs(data=aln)
+        aln = make_aligned_seqs(data=aln, moltype="dna")
         submod = get_model("TN93")
         tree = make_tree(f"{tuple(aln.names)!s}")
         lf = submod.make_likelihood_function(tree)
@@ -323,7 +324,7 @@ class LikelihoodCalcs(TestCase):
     def test_get_param_interval(self):
         """get param interval succeeds"""
         tree = load_tree("data/primate_brca1.tree")
-        aln = load_aligned_seqs("data/primate_brca1.fasta")
+        aln = load_aligned_seqs("data/primate_brca1.fasta", moltype="dna")
         sm = get_model("HKY85")
         lf = sm.make_likelihood_function(tree)
         lf.set_alignment(aln)
@@ -528,7 +529,7 @@ DogFaced   root      1.00  1.00
 
     def test_simulate_alignment1(self):
         "Simulate alignment when no alignment set"
-        al = make_aligned_seqs(data={"a": "ggaatt", "c": "cctaat"})
+        al = make_aligned_seqs(data={"a": "ggaatt", "c": "cctaat"}, moltype="dna")
         t = make_tree("(a,c);")
         sm = get_model("F81")
         lf = sm.make_likelihood_function(t)
@@ -847,6 +848,7 @@ DogFaced     root      1.0000    1.0000
         """correctly return rules from multilocus lf"""
         data = load_aligned_seqs(
             filename=os.path.join(os.getcwd(), "data", "brca1_5.paml"),
+            moltype="dna",
         )
         half = len(data) // 2
         aln1 = data[:half]
@@ -2156,7 +2158,7 @@ class ComparisonTests(TestCase):
         """recap multiple-loci"""
         from cogent3.recalculation.scope import ALL, EACH
 
-        aln = load_aligned_seqs("data/long_testseqs.fasta")
+        aln = load_aligned_seqs("data/long_testseqs.fasta", moltype="dna")
         half = len(aln) // 2
         aln1 = aln[:half]
         aln2 = aln[half:]
@@ -2308,6 +2310,7 @@ def test_simulate_alignment3():
             "c": "-A-C-CTAT-",
             "d": "-A-C-CTAT-",
         },
+        moltype="dna",
     )
     sm = TimeReversibleNucleotide(recode_gaps=True)
     lf = sm.make_likelihood_function(t)
@@ -2316,9 +2319,8 @@ def test_simulate_alignment3():
 
     simulated = lf.simulate_alignment()
     assert len(simulated.names) == 4
-    import re
 
-    assert re.sub("[ATCG]", "x", simulated.to_dict()["a"]) == "x??xxxxxx?"
+    assert re.sub("[ATCG]", "x", simulated.to_dict()["a"]) == "xNNxxxxxxN"
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -529,7 +529,6 @@ DogFaced   root      1.00  1.00
 
     def test_simulate_alignment1(self):
         "Simulate alignment when no alignment set"
-        al = make_aligned_seqs(data={"a": "ggaatt", "c": "cctaat"}, moltype="dna")
         t = make_tree("(a,c);")
         sm = get_model("F81")
         lf = sm.make_likelihood_function(t)

--- a/tests/test_evolve/test_parameter_controller.py
+++ b/tests/test_evolve/test_parameter_controller.py
@@ -112,6 +112,7 @@ class test_parameter_controller(TestCase):
         # test with consideration of ambiguous states
         al = make_aligned_seqs(
             data={"seq1": "ACGTAAGNA", "seq2": "ACGTANGTC", "seq3": "ACGTACGTG"},
+            moltype="dna",
         )
         lf.set_motif_probs_from_data(al, include_ambiguity=True, is_constant=True)
         motif_probs = dict(lf.get_motif_probs())


### PR DESCRIPTION
## Summary by Sourcery

Enhance test configurations by adding a new Nox session and updating test cases to specify 'moltype' for sequence data. Improve test assertions for floating-point comparisons.

Enhancements:
- Add a new Nox session 'test_new_type' to run tests with a specific environment variable set.

Tests:
- Update test cases to specify 'moltype' as 'dna' for sequence data, ensuring consistency across tests.
- Replace direct equality assertions with 'assert_allclose' for floating-point comparisons in test cases.