### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: "nox -db uv -s test-${{ matrix.python-version }}"
 
   docbuild:
-    name: "Build docs"
+    name: "Test the docs"
     runs-on: ubuntu-latest
     steps:
       - uses: "actions/checkout@v4"
@@ -44,10 +44,8 @@ jobs:
           pip install --upgrade pip uv
           python -m uv pip install ".[doc]"
 
-      - name: "making docs"
-        run: |
-          cd doc
-          make html
+      - name: "test the docs code"
+        run: "nox -db uv -s testdocs-3.12"
 
   build:
     name: Build wheel and sdist

--- a/changelog.d/20241218_084956_Gavin.Huttley.md
+++ b/changelog.d/20241218_084956_Gavin.Huttley.md
@@ -1,0 +1,49 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Contributors
+
+- @GavinHuttley
+
+### ENH
+
+- Improved load balancing in parallel execution of new_alignment.Alignment.distance_matrix
+  calculations. This can deliver pretty substantial speedups for large numbers of sequences.
+
+- Major effort in improving compatability of new_type core objects with the
+  rest of the codebase. There remain some missing capabilities, and some edge-case
+  test failures. However, the core functionality is now working.
+
+<!--
+### BUG
+
+- A bullet item for the BUG category.
+
+-->
+<!--
+### DOC
+
+- A bullet item for the DOC category.
+
+-->
+
+### Deprecations
+
+- The nominated release for setting new_type=True as the default for new
+  core objects has been pushed back to 2025.1. This will allow time for
+  the remaining issues to be resolved.
+
+- All annotate_from_gff() methods are deprecated, they will be removed in 2025.6.
+  Users should assign the result of cogent3.load_annotations() to the object's
+  annotation_db attribute, or provide the annotation_path argument to the standard
+  load_(un)aligned_seqs() functions.
+
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/doc/cookbook/annotation_db.rst
+++ b/doc/cookbook/annotation_db.rst
@@ -174,7 +174,7 @@ For example, the adhesin protein of *M. genitalium* is organised in an operon be
     :raises:
 
     operon_cds = list(
-        gff_db.get_features_matching(start=220600, end=229067, biotype="CDS")
+        gff_db.get_features_matching(start=220600, stop=229067, biotype="CDS")
     )
     operon_cds
 

--- a/doc/cookbook/features.rst
+++ b/doc/cookbook/features.rst
@@ -10,6 +10,8 @@ Features
 
 This guide provides instructions on creating, querying, and utilising features to manipulate biological sequence data.
 
+.. note:: The ``new_type`` Alignment class directly supports annotations, and more efficient alignment operations. Try it with ``load_aligned_seqs(..., new_type=True)`` or ``make_aligned_seqs(..., new_type=True)``.
+
 How to create a custom ``Feature``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -202,50 +204,28 @@ Because the names above are different, for FASTA its ``"I dna:chromosome chromos
 How to load features and associate them with an existing sequence
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-We can use the ``annotate_from_gff()`` method to associate the features from a GFF file with the existing ``Sequence``.
+We load with the ``load_annotations()`` function and directly assign to the ``.annotation_db`` attribute.
 
 If we know that the features and the sequence share the same coordinate space, then we only need to provide the path to the annotation file.
 
 .. jupyter-execute::
-    :hide-code:
+    :raises:
 
-    from cogent3 import load_seq
+    from cogent3 import load_seq, load_annotations
 
     loaded_seq = load_seq(
         "data/C-elegans-chromosome-I.fa",
         label_to_name=lambda x: x.split()[0],
         moltype="dna",
     )
-
-.. jupyter-execute::
-    :raises:
-
-    # loaded_seq = < loaded / created the seq>
-    loaded_seq.annotate_from_gff("data/C-elegans-chromosome-I.gff")
+    db = load_annotations(path="data/C-elegans-chromosome-I.gff")
+    loaded_seq.annotation_db = db
     loaded_seq.annotation_db
-
-If the feature coordinates precede the sequence, for example, a sequence corresponds to a gene that starts 600 base pairs from the beginning of chromosome, but the annotation file is for the entire chromosome, we need to provide an offset to the ``annotate_from_gff()`` method.
-
-.. jupyter-execute::
-    :hide-code:
-
-    from cogent3 import make_seq
-
-    sub_seq = make_seq(
-        "GCCTAATACTAAGCCTAAGCCTAAGACTAAGCCTAATACTAAGCCTAAGCCTAAGACTAAGCCTAAGACTAAGCCTAAGA",
-        name="I",
-        moltype="dna",
-    )
-
-.. jupyter-execute::
-    :raises:
-
-    # sub_seq = <genomic region starting at the 600th nt>
-    sub_seq.annotate_from_gff("data/C-elegans-chromosome-I.gff", offset=600)
-    sub_seq.annotation_db
 
 How to load features and associate them with sequences in an existing alignment
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. note:: ``annotate_from_gff()`` methods are being deprecated. The ``new_type`` objects will provide a different approach.
 
 To annotate one or more ``Sequence`` in an ``Alignment``, call ``annotate_from_gff()`` on the ``Alignment`` instance, passing in the path to the GFF annotation file and a list of sequence names to annotate to the ``seq_ids`` argument.
 
@@ -276,7 +256,7 @@ Note that the ``AnnotationDb`` is accessible via the ``Alignment`` (above) and `
 
     brca1_aln.get_seq("Human").annotation_db
 
-.. note:: ``Alignment.annotate_from_gff()`` does not support setting an offset. If you need to set the offset for a sequence within an alignment, you can do so directly using the ``Sequence.annotation_offset`` attribute.
+.. note:: ``Alignment.annotate_from_gff()`` does not support setting an offset and the method is being discontinued. The solution is to use the ``new_type`` classes where you can provide offsets directly.
 
 .. _query_for_features:
 

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -416,10 +416,10 @@ def load_seq(
         data = _load_seqs(file_format, filename, format, parser_kw)
         name, seq = data[0]
 
+    name = label_to_name(name) if label_to_name else name
+
     if annotation_path is not None:
         db = load_annotations(path=annotation_path, seqids=[name])
-
-    name = label_to_name(name) if label_to_name else name
 
     result = make_seq(
         seq,

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1895,11 +1895,16 @@ class SequenceCollection(_SequenceCollectionBase):
             # sequences
             self.annotation_db = self.annotation_db.union(seq_db)
 
+    @c3warn.deprecated_callable(
+        "2025.6",
+        is_discontinued=True,
+        reason="directly assign the annotation_db instead",
+    )
     def annotate_from_gff(
         self,
         f: os.PathLike,
         seq_ids: list[str] | str | None = None,
-    ) -> None:  # will not port
+    ) -> None:  # pragma: no cover
         """copies annotations from a gff file to a sequence in self
 
         Parameters

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -1838,7 +1838,7 @@ def load_annotations(
     """
     if seqids is not None:
         seqids = {seqids} if isinstance(seqids, str) else set(seqids)
-    path = pathlib.Path(path)
+    path = pathlib.Path(path).expanduser()
     return (
         _db_from_genbank(
             path,

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -43,6 +43,7 @@ from cogent3.core.location import (
 from cogent3.format.fasta import seqs_to_fasta
 from cogent3.maths.stats.contingency import CategoryCounts
 from cogent3.maths.stats.number import CategoryCounter
+from cogent3.util import warning as c3warn
 from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.dict_array import DictArrayTemplate
 from cogent3.util.misc import (
@@ -1161,7 +1162,16 @@ class Sequence:
         feature.pop("seqid", None)
         return Feature(parent=self, seqid=self.name, map=fmap, **feature)
 
-    def annotate_from_gff(self, f: os.PathLike, offset=None) -> None:
+    @c3warn.deprecated_callable(
+        "2025.6",
+        is_discontinued=True,
+        reason="directly assign the annotation_db instead",
+    )
+    def annotate_from_gff(
+        self,
+        f: os.PathLike,
+        offset: int | None = None,
+    ) -> None:  # pragma: no cover
         """copies annotations from a gff file to self,
 
         Parameters

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -58,6 +58,7 @@ from cogent3.core.location import FeatureMap, IndelMap, LostSpan
 from cogent3.format.fasta import seqs_to_fasta
 from cogent3.maths.stats.contingency import CategoryCounts
 from cogent3.maths.stats.number import CategoryCounter
+from cogent3.util import warning as c3warn
 from cogent3.util.dict_array import DictArrayTemplate
 from cogent3.util.misc import (
     DistanceFromMatrix,
@@ -1093,7 +1094,16 @@ class Sequence(SequenceI):
         feature.pop("seqid", None)
         return Feature(parent=self, seqid=self.name, map=fmap, **feature)
 
-    def annotate_from_gff(self, f: os.PathLike, offset=None) -> None:
+    @c3warn.deprecated_callable(
+        "2025.6",
+        is_discontinued=True,
+        reason="directly assign the annotation_db instead",
+    )
+    def annotate_from_gff(
+        self,
+        f: os.PathLike,
+        offset: int | None = None,
+    ) -> None:  # pragma: no cover
         """copies annotations from a gff file to self,
 
         Parameters
@@ -1112,7 +1122,8 @@ class Sequence(SequenceI):
         )
 
         if offset:
-            self.annotation_offset = offset
+            # ugly hack until new_type is available
+            self._seq.offset = offset
 
     def add_feature(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,15 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def DATA_DIR():
+def DATA_DIR() -> pathlib.Path:
     return pathlib.Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def HOME_TMP_DIR(DATA_DIR) -> pathlib.Path:
+    """makes a temporary directory"""
+    import tempfile
+
+    HOME = pathlib.Path("~")
+    with tempfile.TemporaryDirectory(dir=HOME.expanduser()) as dn:
+        yield HOME / dn

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -16,6 +16,7 @@ from cogent3 import (
     get_code,
     get_moltype,
     load_aligned_seqs,
+    load_annotations,
     load_seq,
     load_unaligned_seqs,
     make_aligned_seqs,
@@ -2104,7 +2105,7 @@ def test_annotate_from_gff3(cls):  # will not port
 
     # using annotate_from_gff will nest annotations
     seq_coll = cls({seq.name: seq})
-    seq_coll.annotate_from_gff(gff3_path)
+    seq_coll.annotation_db = load_annotations(path=gff3_path)
     member_seq = seq_coll.get_seq(seq.name)
 
     matches = list(member_seq.get_features())
@@ -2124,7 +2125,7 @@ def seqcoll_db():
     gff3_path = os.path.join("data/c_elegans_WS199_shortened_gff.gff3")
     seq = load_seq(fasta_path, moltype="dna")
     seq_coll = SequenceCollection({seq.name: seq})
-    seq_coll.annotate_from_gff(gff3_path)
+    seq_coll.annotation_db = load_annotations(path=gff3_path)
     return seq_coll
 
 
@@ -2237,15 +2238,11 @@ def test_annotate_matches_to():  # ported
 
 @pytest.fixture
 def gb_db(DATA_DIR):
-    from cogent3.core.annotation_db import load_annotations
-
     return load_annotations(path=DATA_DIR / "annotated_seq.gb")
 
 
 @pytest.fixture
 def gff_db(DATA_DIR):
-    from cogent3.core.annotation_db import load_annotations
-
     return load_annotations(path=DATA_DIR / "simple.gff")
 
 

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -1,4 +1,5 @@
 import io
+import pathlib
 import warnings
 
 import numpy
@@ -1407,3 +1408,18 @@ def test_db_repr(request, db):
     ann_db = request.getfixturevalue(db)
     got = repr(ann_db)
     assert isinstance(got, str)
+
+
+@pytest.fixture
+def home_gff(HOME_TMP_DIR, DATA_DIR) -> str:
+    gff = DATA_DIR / "simple.gff"
+    hgff = HOME_TMP_DIR / "simple.gff"
+    hgff.expanduser().write_text(gff.read_text())
+    return f"~/{HOME_TMP_DIR.name}/simple.gff"
+
+
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_load_annotations_home_dir(home_gff, transform):
+    got = load_annotations(path=transform(home_gff))
+    assert len(got) == 6
+    assert isinstance(got, GffAnnotationDb)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -62,7 +62,7 @@ def anno_db() -> BasicAnnotationDb:
 @pytest.fixture
 def simple_seq_gff_db(DATA_DIR) -> Sequence:
     seq = Sequence("ATTGTACGCCTTTTTTATTATT", name="test_seq")
-    seq.annotate_from_gff(DATA_DIR / "simple.gff")
+    seq.annotation_db = load_annotations(path=DATA_DIR / "simple.gff")
     return seq
 
 
@@ -515,7 +515,7 @@ def test_get_features_matching_matching_features(anno_db: GffAnnotationDb, seq):
 
 
 def test_annotate_from_gff(DATA_DIR, seq):
-    seq.annotate_from_gff(DATA_DIR / "simple.gff")
+    seq.annotation_db = load_annotations(path=DATA_DIR / "simple.gff")
 
     got = list(seq.get_features(biotype="exon"))
     assert len(got) == 2
@@ -528,7 +528,7 @@ def test_annotate_from_gff(DATA_DIR, seq):
 
 
 def test_get_features_matching_start_stop(DATA_DIR, seq):
-    seq.annotate_from_gff(DATA_DIR / "simple.gff")
+    seq.annotation_db = load_annotations(path=DATA_DIR / "simple.gff")
     got = list(seq.get_features(start=2, stop=10, allow_partial=True))
     assert len(got) == 4
 
@@ -617,7 +617,7 @@ def test_get_features_matching_multiple_biotype_set(
 
 def test_get_features_matching_start_stop_seqview(DATA_DIR, seq):
     """testing that get_features_matching adjusts"""
-    seq.annotate_from_gff(DATA_DIR / "simple.gff")
+    seq.annotation_db = load_annotations(path=DATA_DIR / "simple.gff")
     seq_features = list(seq.get_features(start=0, stop=3, allow_partial=True))
     assert len(seq_features) == 3
 
@@ -770,13 +770,6 @@ def test__getitem__(simple_seq_gff_db):
     assert seq_sliced.annotation_db is simple_seq_gff_db.annotation_db
 
 
-def test_annotate_from_gff_multiple_calls(DATA_DIR, seq):
-    """5 records in each gff file, total features on seq should be 10"""
-    seq.annotate_from_gff(DATA_DIR / "simple.gff")
-    seq.annotate_from_gff(DATA_DIR / "simple2.gff")
-    assert len(list(seq.get_features())) == 10
-
-
 def test_sequence_collection_annotate_from_gff(DATA_DIR):
     """providing a seqid to SequenceCollection.annotate_from_gff will
     annotate the SequenceCollection, and the Sequence. Both of these will point
@@ -784,7 +777,7 @@ def test_sequence_collection_annotate_from_gff(DATA_DIR):
     """
     seqs = {"test_seq": "ATCGATCGATCG", "test_seq2": "GATCGATCGATC"}
     seq_coll = cogent3.make_unaligned_seqs(seqs, moltype="dna")
-    seq_coll.annotate_from_gff(DATA_DIR / "simple.gff", seq_ids="test_seq")
+    seq_coll.annotation_db = cogent3.load_annotations(path=DATA_DIR / "simple.gff")
 
     # the seq for which the seqid was provided is annotated
     seq = seq_coll.get_seq("test_seq")
@@ -811,7 +804,7 @@ def test_seq_coll_query(DATA_DIR):
     """obtain same results when querying from collection as from seq"""
     seqs = {"test_seq": "ATCGATCGATCG", "test_seq2": "GATCGATCGATC"}
     seq_coll = cogent3.make_unaligned_seqs(seqs, moltype="dna")
-    seq_coll.annotate_from_gff(DATA_DIR / "simple.gff", seq_ids="test_seq")
+    seq_coll.annotation_db = cogent3.load_annotations(path=DATA_DIR / "simple.gff")
 
     seq = seq_coll.get_seq("test_seq")
     # the seq for which the seqid was provided is annotated

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -2273,8 +2273,7 @@ def test_annotate_gff_nested_features(DATA_DIR):
         name="22",
     )
     gff3_path = DATA_DIR / "ensembl_sample.gff3"
-    # TODO: directly assign an annotation_db, annotate_from_gff to be discontinued
-    seq.annotate_from_gff(gff3_path)
+    seq.annotation_db = cogent3.load_annotations(path=gff3_path)
     # we have 8 records in the gff file
     assert seq.annotation_db.num_matches() == 8
 

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -2069,22 +2069,6 @@ def worm_gff_path(DATA_DIR):
     return DATA_DIR / "c_elegans_WS199_shortened_gff.gff3"
 
 
-def test_annotate_from_gff(worm_seq_path, worm_gff_path):
-    """correctly annotates a Sequence from a gff file"""
-    # duplicated in test_alignment on seq collection
-    seq = cogent3.load_seq(worm_seq_path, moltype="dna")
-
-    seq.annotate_from_gff(worm_gff_path)
-    matches = list(seq.get_features())
-    assert len(matches) == 11
-    matches = list(seq.get_features(biotype="gene"))
-    assert len(matches) == 1
-    matches = list(matches[0].get_children(biotype="mRNA"))
-    assert len(matches) == 1
-    matches = list(matches[0].get_children(biotype="exon"))
-    assert len(matches) == 3
-
-
 @pytest.mark.parametrize("rc", [False, True])
 def test_seq_repr(one_seq, rc):  # ported
     pat = re.compile("[ACGT]+")
@@ -2280,7 +2264,7 @@ def test_annotate_gff_nested_features(DATA_DIR):  # ported
     # ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC...
     seq = DNA.make_seq(seq="ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC", name="22")
     gff3_path = DATA_DIR / "ensembl_sample.gff3"
-    seq.annotate_from_gff(gff3_path)
+    seq.annotation_db = cogent3.load_annotations(path=gff3_path)
     # we have 8 records in the gff file
     assert seq.annotation_db.num_matches() == 8
 
@@ -2383,7 +2367,7 @@ def test_offset_with_multiple_slices(DATA_DIR):  # ported
 
     seq = DNA.make_seq(seq="ACCCCGGAAAATTTTTTTTTAAGGGGGAAAAAAAAACCCCCCC", name="22")
     gff3_path = DATA_DIR / "ensembl_sample.gff3"
-    seq.annotate_from_gff(gff3_path)
+    seq.annotation_db = cogent3.load_annotations(path=gff3_path)
     rd = seq[2:].to_rich_dict()
     s1 = deserialise_object(rd)
     assert s1.annotation_offset == 2

--- a/tests/test_util/test_io.py
+++ b/tests/test_util/test_io.py
@@ -28,17 +28,12 @@ def tmp_dir(tmp_path_factory):
 
 
 @pytest.fixture
-def home_file(DATA_DIR) -> str:
+def home_file(DATA_DIR, HOME_TMP_DIR) -> str:
     """makes a temporary directory with file"""
-    import tempfile
-
-    HOME = pathlib.Path("~")
     fn = "sample.tsv"
     contents = (DATA_DIR / fn).read_text()
-    with tempfile.TemporaryDirectory(dir=HOME.expanduser()) as dn:
-        outpath = HOME / pathlib.Path(dn).name / fn
-        outpath.expanduser().write_text(contents)
-        yield str(outpath)
+    (HOME_TMP_DIR / fn).expanduser().write_text(contents)
+    return str(HOME_TMP_DIR / fn)
 
 
 @pytest.mark.parametrize("transform", [str, pathlib.Path])


### PR DESCRIPTION
## Summary by Sourcery

Deprecate annotate_from_gff methods and replace them with direct assignment to annotation_db using load_annotations. Update tests and documentation to reflect these changes.

Enhancements:
- Replaced the use of annotate_from_gff with direct assignment to annotation_db using load_annotations for improved clarity and consistency.

Documentation:
- Updated documentation to reflect the deprecation of annotate_from_gff methods.

Tests:
- Modified tests to use load_annotations instead of annotate_from_gff, ensuring compatibility with the updated annotation handling.

Chores:
- Deprecated annotate_from_gff methods across the codebase, scheduled for removal in 2025.6.