### PR TITLE
Revert "Bump numpy from 2.0.1 to 2.2.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 chardet==5.2.0
 pillow==11.0.0
 psutil==6.1.0
-numpy==2.2.0
+numpy==2.0.1
 numba>0.48.0;python_version<'3.9'
 numba>0.53; python_version>='3.9'
 numba>0.54; python_version>='3.10'


### PR DESCRIPTION
Reverts cogent3/cogent3#2160

numba needs <= 2.10

## Summary by Sourcery

Bug Fixes:
- Revert numpy version from 2.2.0 to 2.0.1 to maintain compatibility with numba requirements.