### PR TITLE
DEV: don't use uv with python 3.13 yet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           pip install nox uv
 
       - name: "Run nox for Python ${{ matrix.python-version }}"
-        run: "nox -db uv -s test-${{ matrix.python-version }}"
+        run: "nox -s test-${{ matrix.python-version }}"
 
   docbuild:
     name: "Test the docs"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           python -m uv pip install ".[doc]"
 
       - name: "test the docs code"
-        run: "nox -db uv -s testdocs-3.13"
+        run: "nox -s testdocs-3.13"
 
   build:
     name: Build wheel and sdist


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove the use of 'uv' with Python 3.13 in the GitHub Actions workflow for testing documentation.