### PR TITLE
BUG: KmerAlphabet.to_indices uses alphabet dtype

### DIFF
--- a/src/cogent3/core/new_alphabet.py
+++ b/src/cogent3/core/new_alphabet.py
@@ -980,7 +980,7 @@ class KmerAlphabet(tuple, AlphabetABC, KmerAlphabetABC):
         size = len(seq) - self.k + 1
         if independent_kmer:
             size = int(numpy.ceil(size / self.k))
-        result = numpy.zeros(size, dtype=get_array_type(size))
+        result = numpy.zeros(size, dtype=self.dtype)
         gap_char_index = self.monomers.gap_index or -1
         gap_index = self.gap_index or -1
         return seq_to_kmer_indices(

--- a/tests/test_core/test_new_alphabet.py
+++ b/tests/test_core/test_new_alphabet.py
@@ -771,3 +771,18 @@ def test_pickling_alphabet(alpha):
     ser = pickle.dumps(alpha)
     got = pickle.loads(ser)
     assert got == alpha
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        new_moltype.DNA.alphabet.get_kmer_alphabet(k=3),
+        new_genetic_code.DEFAULT.get_alphabet(include_stop=False),
+    ],
+)
+def test_trinucs_to_indices_dtype(alpha):
+    s = numpy.array([2, 0, 3] * 1000, dtype=numpy.uint8)
+    small = alpha.to_indices(s[:24])
+    assert len(small) == len(small.tobytes())
+    full = alpha.to_indices(s)
+    assert len(full) == len(full.tobytes())


### PR DESCRIPTION
## Summary by Sourcery

Fix KmerAlphabet.to_indices to use the alphabet's dtype and add tests to ensure correct dtype handling for sequences.

Bug Fixes:
- Fix KmerAlphabet.to_indices to use the alphabet's dtype instead of a dynamically determined array type.

Tests:
- Add test to verify that KmerAlphabet.to_indices maintains the correct dtype for both small and full sequences.