### PR TITLE
DEV: update for numba released version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "numba>0.54; python_version>='3.10' and python_version <'3.12'",
     "numba>=0.57.0; python_version=='3.11'",
     "numba>=0.59.0; python_version=='3.12'",
-    "numba>=0.61.0rc2; python_version=='3.13'",
+    "numba>=0.61.0; python_version=='3.13'",
     "scipy",
     "scitrack",
     "stevedore",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Numba dependency to officially released 0.61.0 instead of the release candidate for Python 3.13.