### PR TITLE
ENH: support sequence collections with mixed reverse complement

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ _py_versions = range(10, 14)
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_slow(session):
-    session.install(".[test]")
+    session.install("-e .[test]")
     session.chdir("tests")
     session.run(
         "pytest",
@@ -18,7 +18,7 @@ def test_slow(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    session.install(".[test]")
+    session.install("-e .[test]")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
     session.run(
@@ -45,7 +45,7 @@ def test(session):
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_module_docs(session):
     """doctest examples in a module"""
-    session.install(".[test]")
+    session.install("-e .[test]")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
     session.run(
@@ -58,7 +58,7 @@ def test_module_docs(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def testmpi(session):
-    session.install(".[test]")
+    session.install("-e .[test]")
     session.install("mpi4py")
     py = pathlib.Path(session.bin_paths[0]) / "python"
     session.chdir("tests")
@@ -80,7 +80,7 @@ def testmpi(session):
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def testdocs(session):
     py = pathlib.Path(session.bin_paths[0]) / "python"
-    session.install(".[doc]")
+    session.install("-e .[doc]")
     session.chdir("doc")
     for docdir in ("app", "cookbook", "draw", "examples"):
         session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ _py_versions = range(10, 14)
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_slow(session):
-    session.install("-e .[test]")
+    session.install("-e.[test]")
     session.chdir("tests")
     session.run(
         "pytest",
@@ -18,7 +18,7 @@ def test_slow(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    session.install("-e .[test]")
+    session.install("-e.[test]")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
     session.run(
@@ -45,7 +45,7 @@ def test(session):
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_module_docs(session):
     """doctest examples in a module"""
-    session.install("-e .[test]")
+    session.install("-e.[test]")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
     session.run(
@@ -58,7 +58,7 @@ def test_module_docs(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def testmpi(session):
-    session.install("-e .[test]")
+    session.install("-e.[test]")
     session.install("mpi4py")
     py = pathlib.Path(session.bin_paths[0]) / "python"
     session.chdir("tests")
@@ -80,7 +80,7 @@ def testmpi(session):
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def testdocs(session):
     py = pathlib.Path(session.bin_paths[0]) / "python"
-    session.install("-e .[doc]")
+    session.install("-e.[doc]")
     session.chdir("doc")
     for docdir in ("app", "cookbook", "draw", "examples"):
         session.run(

--- a/src/cogent3/core/annotation.py
+++ b/src/cogent3/core/annotation.py
@@ -34,8 +34,7 @@ class Feature:
     ) -> None:
         # _serialisable is used for creating derivative instances
         d = locals()
-        exclude = ("self", "__class__", "kw")
-        self._serialisable = {k: v for k, v in d.items() if k not in exclude}
+        self._serialisable = {k: v for k, v in d.items() if k not in ("self", "d")}
         self._parent = parent
         self._seqid = seqid
         assert map.parent_length == len(parent), (map, len(parent))

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -786,9 +786,9 @@ class SequenceCollection:
             msg = f"{names=} and {negate=} resulted in no names"
             raise ValueError(msg)
 
-        assert set(names) <= set(
-            self.names,
-        ), f"The following provided names not found in collection: {names - self.names}"
+        if diff := set(names) - set(self.names):
+            msg = f"The following provided names not found in collection: {diff}"
+            raise ValueError(msg)
 
         selected_name_map = {name: self._name_map[name] for name in names}
 

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -244,6 +244,17 @@ class SeqsDataABC(ABC):
 
     __slots__ = ()
 
+    @abstractmethod
+    def __init__(
+        self,
+        *,
+        data: dict[str, StrORBytesORArray],
+        alphabet: new_alphabet.AlphabetABC,
+        offset: dict[str, int] | None = None,
+        check: bool = True,
+        reversed_seqs: set[str] | None = None,
+    ) -> None: ...
+
     @classmethod
     @abstractmethod
     def from_seqs(
@@ -3056,6 +3067,21 @@ class AlignedSeqsDataABC(SeqsDataABC):
         gaps: dict[str, numpy.ndarray],
         alphabet: new_alphabet.AlphabetABC,
     ) -> typing_extensions.Self: ...
+
+    @abstractmethod
+    def __init__(
+        self,
+        *,
+        gapped_seqs: numpy.ndarray,
+        names: tuple[str],
+        alphabet: new_alphabet.AlphabetABC,
+        ungapped_seqs: dict[str, numpy.ndarray] | None = None,
+        gaps: dict[str, numpy.ndarray] | None = None,
+        offset: DictStrInt | None = None,
+        align_len: OptInt = None,
+        check: bool = True,
+        reversed_seqs: set[str] | None = None,
+    ) -> None: ...
 
     @abstractmethod
     def get_view(

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -487,8 +487,8 @@ class SeqsData(SeqsDataABC):
     def add_seqs(
         self,
         seqs: dict[str, StrORBytesORArray],
-        force_unique_keys=True,
-        offset=None,
+        force_unique_keys: bool = True,
+        offset: dict[str, int] | None = None,
     ) -> SeqsData:
         """Returns a new SeqsData object with added sequences. If force_unique_keys
         is True, raises ValueError if any names already exist in the collection."""
@@ -575,7 +575,6 @@ class SeqsData(SeqsDataABC):
             "data": self._data,
             "alphabet": self._alphabet,
             "offset": self._offset,
-            "reversed_seqs": self._reversed,
             **kwargs,
         }
         return self.__class__(**init_args)
@@ -1084,7 +1083,7 @@ class SequenceCollection:
             **kwargs,
         )
 
-    def rc(self):
+    def rc(self) -> typing_extensions.Self:
         """Returns the reverse complement of all sequences in the collection.
         A synonym for reverse_complement.
         """
@@ -1092,7 +1091,7 @@ class SequenceCollection:
         init_kwargs["is_reversed"] = not self._is_reversed
         return self.__class__(**init_kwargs)
 
-    def reverse_complement(self):
+    def reverse_complement(self) -> typing_extensions.Self:
         """Returns the reverse complement of all sequences in the collection.
         A synonym for rc.
         """
@@ -1330,7 +1329,7 @@ class SequenceCollection:
         """
         return seqs_to_fasta(self.to_dict(), block_size=block_size)
 
-    def to_phylip(self):
+    def to_phylip(self) -> str:
         """
         Return collection in PHYLIP format and mapping to sequence ids
 
@@ -2870,7 +2869,7 @@ class Aligned:
         # to the underlying aligned seq data container because the gaps are
         # not going to be modulo the step.
         if self.data.slice_record.plus_step == 1:
-            # to complement or not handled by seq view
+            # to complement or not handled by the view
             seq = self.data.get_seq_view()
         elif self.data.slice_record.step > 1:
             # we have a step, but no complementing will be required
@@ -3056,7 +3055,7 @@ class AlignedSeqsDataABC(SeqsDataABC):
         seqs: dict[str, StrORBytesORArray],
         gaps: dict[str, numpy.ndarray],
         alphabet: new_alphabet.AlphabetABC,
-    ): ...
+    ) -> typing_extensions.Self: ...
 
     @classmethod
     @abstractmethod
@@ -3066,7 +3065,7 @@ class AlignedSeqsDataABC(SeqsDataABC):
         names: list[str],
         data: numpy.ndarray,
         alphabet: new_alphabet.AlphabetABC,
-    ): ...
+    ) -> typing_extensions.Self: ...
 
     @property
     @abstractmethod
@@ -3317,7 +3316,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
         data: dict[str, StrORArray],
         alphabet: new_alphabet.AlphabetABC,
         **kwargs,
-    ):
+    ) -> typing_extensions.Self:
         """Construct an AlignedSeqsData object from a dict of aligned sequences
 
         Parameters
@@ -3362,7 +3361,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
         gaps: dict[str, numpy.ndarray],
         alphabet: new_alphabet.AlphabetABC,
         **kwargs,
-    ):
+    ) -> typing_extensions.Self:
         """Construct an AlignedSeqsData object from a dict of ungapped sequences
         and a corresponding dict of gap data.
 
@@ -3412,7 +3411,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
         names: PySeq[str],
         data: numpy.ndarray,
         alphabet: new_alphabet.AlphabetABC,
-    ):
+    ) -> typing_extensions.Self:
         """Construct an AlignedSeqsData object from a list of names and a numpy
         array of aligned sequence data.
 
@@ -3692,7 +3691,11 @@ class AlignedSeqsData(AlignedSeqsDataABC):
             align_len=self.align_len,
         )
 
-    def to_alphabet(self, alphabet: new_alphabet.AlphabetABC, check_valid: bool = True):
+    def to_alphabet(
+        self,
+        alphabet: new_alphabet.AlphabetABC,
+        check_valid: bool = True,
+    ) -> typing_extensions.Self:
         """Returns a new AlignedSeqsData object with the same underlying data
         with a new alphabet."""
         if (
@@ -4229,6 +4232,7 @@ class Alignment(SequenceCollection):
 
             arr_seqs.flags.writeable = False  # make sure data is immutable
             self._array_seqs = arr_seqs
+
         return self._array_seqs
 
     @property

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -56,6 +56,8 @@ from cogent3.util.transform import for_seq, per_shortest
 if typing.TYPE_CHECKING:
     import os
 
+    from cogent3.core.new_genetic_code import GeneticCode
+
 OptGeneticCodeType = typing.Optional[typing.Union[int, str, "GeneticCode"]]
 OptStr = typing.Optional[str]
 OptInt = typing.Optional[int]
@@ -187,7 +189,10 @@ class Sequence:
         self._annotation_db = annotation_db
 
     def __str__(self) -> str:
-        result = str(self._seq)
+        # using the str_value attribute means we can have
+        # a aligned or seq data view here and the outcome will be the
+        # same -- just the sequence is returned
+        result = self._seq.str_value
         if self._seq.is_reversed:
             with contextlib.suppress(TypeError):
                 result = self.moltype.complement(result)

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -997,6 +997,20 @@ def test_sequence_collection_take_seqs_empty_names(
 
 
 @pytest.mark.parametrize(
+    "collection_maker",
+    [new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs],
+)
+def test_sequence_collection_take_seqs_wrong_name(
+    ragged_padded_dict,
+    collection_maker,
+):
+    """take_seqs should raise ValueError if no seqs are selected."""
+    orig = new_alignment.make_unaligned_seqs(ragged_padded_dict, moltype="dna")
+    with pytest.raises(ValueError):
+        _ = orig.take_seqs(["a", "mouse"])
+
+
+@pytest.mark.parametrize(
     "mk_cls",
     [new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs],
 )

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5596,13 +5596,17 @@ def test_make_with_mixed_rc_plus_gaps(dna_moltype):
     raw_minus = "AA---AAATGCC"
     minus = dna_moltype.make_seq(seq=raw_minus, name="minus")
     data = {"plus": raw_plus, "minus": raw_minus}
-    aln = new_alignment.make_aligned_seqs(data, moltype="dna", reversed_seqs={"minus"})
-    minus = aln.seqs["minus"]
-    assert str(minus) == raw_minus
-    assert str(minus.seq) == raw_minus.replace("-", "")
+    asd = new_alignment.AlignedSeqsData.from_seqs(
+        data=data,
+        alphabet=dna_moltype.most_degen_alphabet(),
+        reversed_seqs={"minus"},
+    )
+    minus = asd["minus"]
+    assert str(minus.gapped_str_value) == raw_minus
+    assert str(minus.str_value) == raw_minus.replace("-", "")
 
 
-def test_make_asd_revd(dna_alphabet, dna_moltype):
+def test_make_asd_revd(dna_alphabet):
     data = {
         "a": dna_alphabet.to_indices("T--CA"),
         "b": dna_alphabet.to_indices("TAAC-"),
@@ -5618,8 +5622,8 @@ def test_make_asd_revd(dna_alphabet, dna_moltype):
     )
     # the gapped sequences should be as input
     assert (asd.get_gapped_seq_array(seqid="a") == data["a"]).all()
-    # the ungapped sequence should be as if it was in its forward orientation
-    expect = dna_alphabet.to_indices("TGA")
+    # the ungapped sequence should be too
+    expect = dna_alphabet.to_indices("TCA")
     got = asd.get_seq_array(seqid="a")
     assert (got == expect).all()
     # this should work on a data view too
@@ -5629,6 +5633,9 @@ def test_make_asd_revd(dna_alphabet, dna_moltype):
     # with the gapped seq as before
     got = view.gapped_array_value
     assert (got == data["a"]).all()
+    # getting the seqview should behave consistently
+    sv = view.get_seq_view()
+    assert (sv.array_value == expect).all()
 
 
 @pytest.mark.parametrize("aligned", [False, True])

--- a/tests/test_core/test_new_sequence.py
+++ b/tests/test_core/test_new_sequence.py
@@ -273,7 +273,9 @@ def test_sequence_complement():
 def test_sequence_rc():
     """Sequence.rc() should correctly reverse-complement sequence"""
     # no longer preserves case!
-    assert new_moltype.DNA.make_seq(seq="TATCG-NR").rc() == "YN-CGATA"
+    s = new_moltype.DNA.make_seq(seq="TATCG-NR")
+    s = s.rc()
+    assert s == "YN-CGATA"
     assert new_moltype.RNA.make_seq(seq="").rc() == ""
     assert new_moltype.RNA.make_seq(seq="UAUCG-NR").rc() == "YN-CGAUA"
     assert new_moltype.RNA.make_seq(seq="A").rc() == "U"


### PR DESCRIPTION
## Summary by Sourcery

Allow mixed reversed and not reversed sequences in sequence collections.

New Features:
- Support for mixed reverse complement sequence collections.

Tests:
- Added tests for mixed reverse complement sequence collections.