### PR TITLE
Add identity function with DeprecationWarning

### DIFF
--- a/identity.py
+++ b/identity.py
@@ -1,0 +1,8 @@
+import warnings
+
+def identity():
+    """
+    This function is marked for removal in cogent3 version 3.1.0.
+    A DeprecationWarning is raised to inform users that it will be removed.
+    """
+    warnings.warn("This function will be removed in cogent3 version 3.1.0", DeprecationWarning)


### PR DESCRIPTION
Summary
Added an identity function that is marked for removal in cogent3 version 3.1.0. This function now raises a `DeprecationWarning` to inform users of its future removal.

Changes
Implemented `identity()` function with a deprecation warning.
The function will be removed in version 3.1.0.

Testing
Ensure that a `DeprecationWarning` is raised when the function is called.


Issue 1740 mark identity() function for removal

## Summary by Sourcery

Chores:
- Mark the identity() function for removal in cogent3 version 3.1.0.