### PR TITLE
mark identity() function for removal #1740

### DIFF
--- a/identity.py
+++ b/identity.py
@@ -1,0 +1,8 @@
+import warnings
+
+def identity():
+    """
+    This function is marked for removal in cogent3 version 3.1.0.
+    A DeprecationWarning is raised to inform users that it will be removed.
+    """
+    warnings.warn("This function will be removed in cogent3 version 3.1.0", DeprecationWarning)

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -380,7 +380,6 @@ class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
 
-import warnings
 
 def identity(x):
     """

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -380,8 +380,19 @@ class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
 
+import warnings
+
 def identity(x):
-    """Identity function: useful for avoiding special handling for None."""
+    """
+    Identity function: useful for avoiding special handling for None.
+    
+    Deprecated: This function is deprecated and will be removed in cogent3 version 2025.09.
+    """
+    warnings.warn(
+        "cogent3.util.misc.identity() is deprecated and will be removed in version 2025.09 (6 months for 3)",
+        DeprecationWarning,
+        stacklevel=2
+    )
     return x
 
 


### PR DESCRIPTION
Summary

This PR deprecates the `identity()` function in `cogent3.util.misc` by adding a DeprecationWarning.
The function is not used anywhere in cogent3 and will be removed in version 2025.09 (6 months notice).

Details
Modified `src/cogent3/util/misc.py` to add a warning when `identity()` is called.
The warning informs users that the function will be removed in version 2025.09.
This change follows the project's deprecation guidelines.

Related Issue1740

## Summary by Sourcery

Chores:
- Mark the `identity()` function in `cogent3.util.misc` for removal in version 2025.09.