### PR TITLE
DOC: added docstring for new_moltype.MolType.get_degenerate_positions, fixes #2218

### DIFF
--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -858,26 +858,16 @@ class MolType:
         include_gap: bool = True,
         validate: bool = True,
     ) -> list[int]: 
-        """_summary_
-
+        """Return List of position indexs of degenerate characters in the sequence.
+    
         Parameters
         ----------
         seq : StrORBytesORArray
-            _description_
+            the sequence to be used for getting degenerate positions
         include_gap : bool, optional
-            _description_, by default True
+            if False, add 1 to the index
         validate : bool, optional
-            _description_, by default True
-
-        Returns
-        -------
-        list[int]
-            _description_
-
-        Raises
-        ------
-        new_alphabet.AlphabetError
-            _description_
+            if True, checks the sequence is validated
         """  
         if validate and not self.is_valid(seq):
             msg = f"{seq[:4]!r} not valid for moltype {self.name!r}"

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -857,18 +857,18 @@ class MolType:
         seq: StrORBytesORArray,
         include_gap: bool = True,
         validate: bool = True,
-    ) -> list[int]: 
+    ) -> list[int]:
         """Return List of position indexs of degenerate characters in the sequence.
-    
+
         Parameters
         ----------
         seq : StrORBytesORArray
             the sequence to be used for getting degenerate positions
         include_gap : bool, optional
-            if False, add 1 to the index
+            if True, then the gap state together with ’canonical’ sates (A,C,G,T for DNA) will be considered non-ambiguous.
         validate : bool, optional
-            if True, checks the sequence is validated
-        """  
+            if True, checks the sequence is validated for the alphabet
+        """
         if validate and not self.is_valid(seq):
             msg = f"{seq[:4]!r} not valid for moltype {self.name!r}"
             raise new_alphabet.AlphabetError(

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -857,7 +857,28 @@ class MolType:
         seq: StrORBytesORArray,
         include_gap: bool = True,
         validate: bool = True,
-    ) -> list[int]:  # refactor: docstring
+    ) -> list[int]: 
+        """_summary_
+
+        Parameters
+        ----------
+        seq : StrORBytesORArray
+            _description_
+        include_gap : bool, optional
+            _description_, by default True
+        validate : bool, optional
+            _description_, by default True
+
+        Returns
+        -------
+        list[int]
+            _description_
+
+        Raises
+        ------
+        new_alphabet.AlphabetError
+            _description_
+        """  
         if validate and not self.is_valid(seq):
             msg = f"{seq[:4]!r} not valid for moltype {self.name!r}"
             raise new_alphabet.AlphabetError(


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Adds a docstring to the `get_degenerate_positions` method, including parameter descriptions, return type, and potential exceptions.