### PR TITLE
mark identity() function for removal #1740

### DIFF
--- a/identity.py
+++ b/identity.py
@@ -1,0 +1,8 @@
+import warnings
+
+def identity():
+    """
+    This function is marked for removal in cogent3 version 3.1.0.
+    A DeprecationWarning is raised to inform users that it will be removed.
+    """
+    warnings.warn("This function will be removed in cogent3 version 3.1.0", DeprecationWarning)

--- a/identity.py
+++ b/identity.py
@@ -1,8 +1,0 @@
-import warnings
-
-def identity():
-    """
-    This function is marked for removal in cogent3 version 3.1.0.
-    A DeprecationWarning is raised to inform users that it will be removed.
-    """
-    warnings.warn("This function will be removed in cogent3 version 3.1.0", DeprecationWarning)

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -380,7 +380,6 @@ class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
 
-import warnings
 
 def identity(x):
     """

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -379,24 +379,15 @@ class FunctionWrapper:
 class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
-
 from cogent3.util import warning as c3warn
 
-def identity_new(x):
-    """
-    New identity function.
-    This is the replacement for cogent3.util.misc.identity().
-    """
-    return x
-
 @c3warn.deprecated_callable(
-    version="2025.09", 
-    reason="The function is not used in cogent3 and will be removed in 6 months notice.",
-    new="identity_new"
+    version="2025.09",
+    reason="The function is not used in cogent3 and will be removed in a future release."
 )
-def identity(x):  
-    """Deprecated: use identity_new instead."""
-    return identity_new(x)
+def identity(x):
+    """Deprecated: This function will be removed in a future release."""
+    return x
 
 
 class ConstrainedContainer:

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -383,7 +383,7 @@ class ConstraintError(Exception):
 
 
 @c3warn.deprecated_callable(
-    version="2025.09",
+    version="2025.06",
     reason="The function is not used in cogent3 and will be removed in a future release.",
 )
 def identity(x):

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -380,19 +380,23 @@ class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
 
+from cogent3.util import warning as c3warn
 
-def identity(x):
+def identity_new(x):
     """
-    Identity function: useful for avoiding special handling for None.
-    
-    Deprecated: This function is deprecated and will be removed in cogent3 version 2025.09.
+    New identity function.
+    This is the replacement for cogent3.util.misc.identity().
     """
-    warnings.warn(
-        "cogent3.util.misc.identity() is deprecated and will be removed in version 2025.09 (6 months for 3)",
-        DeprecationWarning,
-        stacklevel=2
-    )
     return x
+
+@c3warn.deprecated_callable(
+    version="2025.09", 
+    reason="The function is not used in cogent3 and will be removed in 6 months notice.",
+    new="identity_new"
+)
+def identity(x):  
+    """Deprecated: use identity_new instead."""
+    return identity_new(x)
 
 
 class ConstrainedContainer:

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -380,8 +380,19 @@ class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
 
+import warnings
+
 def identity(x):
-    """Identity function: useful for avoiding special handling for None."""
+    """
+    Identity function: useful for avoiding special handling for None.
+    
+    Deprecated: This function is deprecated and will be removed in cogent3 version 2025.09.
+    """
+    warnings.warn(
+        "cogent3.util.misc.identity() is deprecated and will be removed in version 2025.09 (6 months for 3)",
+        DeprecationWarning,
+        stacklevel=2
+    )
     return x
 
 

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -379,6 +379,7 @@ class FunctionWrapper:
 class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
+
 from cogent3.util import warning as c3warn
 
 @c3warn.deprecated_callable(
@@ -386,8 +387,14 @@ from cogent3.util import warning as c3warn
     reason="The function is not used in cogent3 and will be removed in a future release."
 )
 def identity(x):
-    """Deprecated: This function will be removed in a future release."""
+    """Deprecated: This function will be removed in a future release.
+    
+    Identity function: useful for avoiding special handling for None.
+    """
     return x
+
+
+
 
 
 class ConstrainedContainer:

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -16,6 +16,8 @@ from warnings import warn
 import numpy
 from numpy import array, finfo, float64, ndarray, zeros
 
+from cogent3.util import warning as c3warn
+
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -380,21 +382,16 @@ class ConstraintError(Exception):
     """Raised when constraint on a container is violated."""
 
 
-from cogent3.util import warning as c3warn
-
 @c3warn.deprecated_callable(
     version="2025.09",
-    reason="The function is not used in cogent3 and will be removed in a future release."
+    reason="The function is not used in cogent3 and will be removed in a future release.",
 )
 def identity(x):
     """Deprecated: This function will be removed in a future release.
-    
+
     Identity function: useful for avoiding special handling for None.
     """
     return x
-
-
-
 
 
 class ConstrainedContainer:


### PR DESCRIPTION
I Remove identity.py as it's not required AND use the guidelines way to do the job

## Summary by Sourcery

Enhancements:
- Deprecate the `identity` function and replace it with `identity_new`.