### PR TITLE
ENH: improve performance of SequenceCollection.get_ambiguous_positions

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1130,12 +1130,11 @@ class _SequenceCollectionBase:
         Used in likelihood calculations.
         """
         result = {}
-        alpha = self.moltype.most_degen_alphabet()
         for name in self.names:
             result[name] = ambig = {}
-            array = numpy.array(self.seqs[name])
-            for i in numpy.where(array > alpha.gap_index)[0]:
-                ambig[i] = alpha[array[i]]
+            for i, motif in enumerate(self.named_seqs[name]):
+                if self.moltype.is_ambiguity(motif):
+                    ambig[i] = motif
         return result
 
     def degap(self, **kwargs):  # ported

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1130,11 +1130,12 @@ class _SequenceCollectionBase:
         Used in likelihood calculations.
         """
         result = {}
+        alpha = self.moltype.most_degen_alphabet()
         for name in self.names:
             result[name] = ambig = {}
-            for i, motif in enumerate(self.named_seqs[name]):
-                if self.moltype.is_ambiguity(motif):
-                    ambig[i] = motif
+            array = numpy.array(self.seqs[name])
+            for i in numpy.where(array > alpha.gap_index)[0]:
+                ambig[i] = alpha[array[i]]
         return result
 
     def degap(self, **kwargs):  # ported

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -1575,13 +1575,13 @@ class SequenceCollection:
 
         Used in likelihood calculations.
         """
-        # refactor: performance
         result = {}
+        alpha = self.moltype.most_degen_alphabet()
         for name in self.names:
             result[name] = ambig = {}
-            for i, motif in enumerate(self.seqs[name]):
-                if self.moltype.is_ambiguity(motif):
-                    ambig[i] = motif
+            array = numpy.array(self.seqs[name])
+            for i in numpy.where(array > alpha.gap_index)[0]:
+                ambig[i] = alpha[array[i]]
         return result
 
     def trim_stop_codons(self, gc: Any = 1, strict: bool = False):


### PR DESCRIPTION
Fixes #2214
Changed to using the ability to cast each sequence to a numpy.array

## Summary by Sourcery

Enhancements:
- Improves performance of SequenceCollection.get_ambiguous_positions.