### PR TITLE
Deprecated tprob() and replaced with scipy.stats.t.sf()

### DIFF
--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -31,28 +31,20 @@ incbet = betai  # shouldn't have renamed it...
 
 # Probability integrals: low gives left-hand tail, high gives right-hand tail.
 
+import scipy.stats
 
+from cogent3.util import warning as c3warn
 def zprob(x):
     """Returns both tails of z distribution (-inf to -x, inf to x)."""
     return 2 * norm.sf(abs(x))
 
 
-import scipy.stats
-
-from cogent3.util import warning as c3warn
-
-
-def tprob_new(x, df):
-    """Returns both tails of t distribution (-infinity to -x, infinity to x)"""
-    return 2 * scipy.stats.t.sf(abs(x), df)
-
-
 @c3warn.deprecated_callable(
-    version="2025.3", reason="Use scipy.stats.t.sf() instead", new="tprob_new"
+    version="2025.6", reason="Use scipy.stats.t.sf() instead", is_discontinued=True
 )
-def tprob(x, df):  # pragma: no cover
+def tprob(x, df):  
     """deprecated, use new"""
-    return tprob_new(x, df)
+    return 2 * scipy.stats.t.sf(abs(x), df)
 
 
 def binomial_exact(successes, trials, prob):

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -37,9 +37,22 @@ def zprob(x):
     return 2 * norm.sf(abs(x))
 
 
-def tprob(x, df):
+import scipy.stats
+
+from cogent3.util import warning as c3warn
+
+
+def tprob_new(x, df):
     """Returns both tails of t distribution (-infinity to -x, infinity to x)"""
-    return 2 * t.sf(abs(x), df)
+    return 2 * scipy.stats.t.sf(abs(x), df)
+
+
+@c3warn.deprecated_callable(
+    version="2025.3", reason="Use scipy.stats.t.sf() instead", new="tprob_new"
+)
+def tprob(x, df):  # pragma: no cover
+    """deprecated, use new"""
+    return tprob_new(x, df)
 
 
 def binomial_exact(successes, trials, prob):

--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -32,7 +32,7 @@ from numpy.random import permutation, randint
 from scipy.stats import binom, f, norm, t
 from scipy.stats.distributions import chi2
 
-from cogent3.maths.stats.distribution import fprob, ndtri, tprob_new, zprob
+from cogent3.maths.stats.distribution import fprob, ndtri, zprob
 from cogent3.maths.stats.kendall import kendalls_tau, pkendall
 from cogent3.maths.stats.ks import pkstwo, psmirnov2x
 from cogent3.maths.stats.number import NumberCounter
@@ -1268,7 +1268,7 @@ def t_tailed_prob(x, df, tails):
         return t.sf(x, df)
     if tails == ALT_LOW:
         return t.cdf(x, df)
-    return tprob_new(x, df)
+    return 2 * scipy.stats.t.sf(abs(x), df)
 
 
 def reverse_tails(tails):

--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -32,7 +32,7 @@ from numpy.random import permutation, randint
 from scipy.stats import binom, f, norm, t
 from scipy.stats.distributions import chi2
 
-from cogent3.maths.stats.distribution import fprob, ndtri, tprob, zprob
+from cogent3.maths.stats.distribution import fprob, ndtri, tprob_new, zprob
 from cogent3.maths.stats.kendall import kendalls_tau, pkendall
 from cogent3.maths.stats.ks import pkstwo, psmirnov2x
 from cogent3.maths.stats.number import NumberCounter
@@ -1268,7 +1268,7 @@ def t_tailed_prob(x, df, tails):
         return t.sf(x, df)
     if tails == ALT_LOW:
         return t.cdf(x, df)
-    return tprob(x, df)
+    return tprob_new(x, df)
 
 
 def reverse_tails(tails):

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -24,7 +24,6 @@ from cogent3.maths.stats.distribution import (
     stdtr,
     stdtri,
     theoretical_quantiles,
-    tprob_new,
     zprob,
 )
 
@@ -63,65 +62,7 @@ class DistributionsTests(TestCase):
         for z, p in zip(self.negvalues, probs, strict=False):
             assert_allclose(zprob(z), p, rtol=1e-6)
 
-    def test_tprob_new(self):
-        """tprob_new should match twice the t_high probability for abs(t)"""
-
-        probs = {
-            1: [
-                2 * i
-                for i in [
-                    0.500000000,
-                    0.496817007,
-                    0.468274483,
-                    0.352416382,
-                    0.250000000,
-                    0.147583618,
-                    0.062832958,
-                    0.031725517,
-                    0.015902251,
-                    0.010606402,
-                    0.006365349,
-                    0.001591536,
-                ]
-            ],
-            10: [
-                2 * i
-                for i in [
-                    5.000000e-01,
-                    4.961090e-01,
-                    4.611604e-01,
-                    3.139468e-01,
-                    1.704466e-01,
-                    3.669402e-02,
-                    2.686668e-04,
-                    7.947766e-07,
-                    1.073031e-09,
-                    1.980896e-11,
-                    1.237155e-13,
-                    1.200254e-19,
-                ]
-            ],
-            100: [
-                2 * i
-                for i in [
-                    5.000000e-01,
-                    4.960206e-01,
-                    4.602723e-01,
-                    3.090868e-01,
-                    1.598621e-01,
-                    2.410609e-02,
-                    1.225087e-06,
-                    4.950844e-17,
-                    4.997134e-37,
-                    4.190166e-52,
-                    7.236082e-73,
-                    2.774197e-132,
-                ]
-            ],
-        }
-        for df in self.df:
-            for x, p in zip(self.values, probs[df], strict=False):
-                assert_almost_equal(tprob_new(x, df), p, decimal=4)
+    
 
     def test_binomial_series(self):
         """binomial_exact should match values from R on a whole series"""

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -24,7 +24,7 @@ from cogent3.maths.stats.distribution import (
     stdtr,
     stdtri,
     theoretical_quantiles,
-    tprob,
+    tprob_new,
     zprob,
 )
 
@@ -63,8 +63,8 @@ class DistributionsTests(TestCase):
         for z, p in zip(self.negvalues, probs, strict=False):
             assert_allclose(zprob(z), p, rtol=1e-6)
 
-    def test_tprob(self):
-        """tprob should match twice the t_high probability for abs(t)"""
+    def test_tprob_new(self):
+        """tprob_new should match twice the t_high probability for abs(t)"""
 
         probs = {
             1: [
@@ -121,7 +121,7 @@ class DistributionsTests(TestCase):
         }
         for df in self.df:
             for x, p in zip(self.values, probs[df], strict=False):
-                assert_almost_equal(tprob(x, df), p, decimal=4)
+                assert_almost_equal(tprob_new(x, df), p, decimal=4)
 
     def test_binomial_series(self):
         """binomial_exact should match values from R on a whole series"""


### PR DESCRIPTION
## Summary by Sourcery

Deprecates the tprob function, replacing it with a new tprob_new function that uses scipy.stats.t.sf() for improved statistical calculations.

Enhancements:
- Replaces the tprob function with tprob_new, utilising scipy.stats.t.sf() for enhanced statistical calculations.
- Adds a deprecated_callable decorator to the old tprob function, which will emit a warning when the old function is called, and directs users to the new function.
- Updates tests to use the new tprob_new function instead of the deprecated tprob function.
- Updates t_tailed_prob to use tprob_new instead of tprob.