### PR TITLE
MAINT: fix usages of deprecated code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
     "chardet",
-    "loky",
+    "loky<3.5",
     "numpy",
     "numba>0.54; python_version>='3.10' and python_version <'3.12'",
     "numba>=0.57.0; python_version=='3.11'",
@@ -25,7 +25,7 @@ dependencies = [
     "scitrack",
     "stevedore",
     "tqdm",
-    "typing_extensions"
+    "typing_extensions",
 ]
 # remember to update version in requires-python and classifiers
 requires-python = ">=3.10,<3.14"

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -371,8 +371,11 @@ class Delegator:
 class FunctionWrapper:
     """Wraps a function to hide it from a class so that it isn't a method."""
 
-    def __init__(self, Function) -> None:
-        self.Function = Function
+    def __init__(self, Function=None) -> None:
+        self.Function = Function if Function is not None else self._default
+
+    def _default(self, x):
+        return x
 
     def __call__(self, *args, **kwargs):
         return self.Function(*args, **kwargs)
@@ -409,7 +412,7 @@ class ConstrainedContainer:
     """
 
     _constraint = None
-    mask = FunctionWrapper(identity)
+    mask = FunctionWrapper()
 
     def _mask_for_new(self):
         """Returns self.mask only if different from class data."""
@@ -664,7 +667,7 @@ class ConstrainedDict(ConstrainedContainer, dict):
     ValueError instead) but which is surprisingly useful in practice.
     """
 
-    value_mask = FunctionWrapper(identity)
+    value_mask = FunctionWrapper()
 
     def _get_mask_and_valmask(self):
         """Helper method to check whether mask and value_mask were set."""

--- a/src/cogent3/util/misc.py
+++ b/src/cogent3/util/misc.py
@@ -389,11 +389,8 @@ class ConstraintError(Exception):
     version="2025.06",
     reason="The function is not used in cogent3 and will be removed in a future release.",
 )
-def identity(x):
-    """Deprecated: This function will be removed in a future release.
-
-    Identity function: useful for avoiding special handling for None.
-    """
+def identity(x):  # pragma: no cover
+    """Deprecated: This function will be removed in a future release."""
     return x
 
 

--- a/tests/test_util/test_misc.py
+++ b/tests/test_util/test_misc.py
@@ -34,7 +34,6 @@ from cogent3.util.misc import (
     get_run_start_indices,
     get_setting_from_environ,
     get_true_spans,
-    identity,
     is_char,
     is_char_or_noniterable,
     is_iterable,
@@ -96,12 +95,6 @@ class UtilsTests(TestCase):
 
         with pytest.raises(ValueError):
             got = adjusted_within_bounds(u - 4, l, u, eps=eps, action="raise")
-
-    def test_identity(self):
-        """should return same object"""
-        foo = [1, "a", lambda x: x]
-        exp = id(foo)
-        assert id(identity(foo)) == exp
 
     def test_iterable(self):
         """iterable(x) should return x or [x], always an iterable result"""


### PR DESCRIPTION
[CHANGED] somehow missed the fact the PR did not remove cogent3 usages

## Summary by Sourcery

Enhancements:
- Replaces usages of the deprecated identity function with a default function within the FunctionWrapper class.