### PR TITLE
BUG: fix regression from change to numpy element representation

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1565,7 +1565,7 @@ def available_moltypes():
 
     result = Table(header=header, data=rows, title=title, index_name="Abbreviation")
     result = result.sorted(columns=["Number of states", "Abbreviation"])
-    result.format_column("Abbreviation", repr)
+    result.format_column("Abbreviation", lambda x: repr(str(x)))
     return result
 
 

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -1440,9 +1440,8 @@ def available_moltypes():
     title = "Specify a moltype by the Abbreviation (case insensitive)."
 
     result = Table(header=header, data=rows, title=title, index_name="Abbreviation")
-    result = result.sorted(columns=["Number of states", "Abbreviation"])
-    result.format_column("Abbreviation", repr)
-    return result
+    result.format_column("Abbreviation", lambda x: repr(str(x)))
+    return result.sorted(columns=["Number of states", "Abbreviation"])
 
 
 # constant instances of the core molecular types

--- a/src/cogent3/util/table.py
+++ b/src/cogent3/util/table.py
@@ -780,7 +780,9 @@ class Table:
         return "\n".join(html)
 
     def _get_persistent_attrs(self):
-        return UnionDict(self._persistent_attrs.copy())
+        attrs = self._persistent_attrs.copy()
+        attrs["column_templates"] = self._column_templates
+        return UnionDict(**attrs)
 
     @property
     def title(self):

--- a/tests/test_core/test_new_moltype.py
+++ b/tests/test_core/test_new_moltype.py
@@ -69,6 +69,9 @@ def test_get_moltype(name):
 def test_available_moltypes():
     t = new_moltype.available_moltypes()
     assert t.shape[0] == 6
+    got = str(t)
+    assert "np." not in got
+    assert "'dna'" in got
 
 
 def test_str_moltype():


### PR DESCRIPTION
[FIXED] repr() of numpy elements now prefixed by `np.<type>_`.
    This screws up display of some table columns. Fixed by
    assigning column templates.

## Summary by Sourcery

Bug Fixes:
- Fixes a regression where the repr() of numpy elements was prefixed by `np.<type>_`, causing incorrect display of some table columns.