### PR TITLE
MAINT: robust assignment of source in app.io._load_seqs

### DIFF
--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -286,16 +286,8 @@ def _load_seqs(path, coll_maker, parser, moltype):
     data = _read_it(path)
     data = data.splitlines()
     data = dict(iter(parser(data)))
-    seqs = coll_maker(data=data, moltype=moltype)
-    path = str(path)
-    seqs.info.source = path
-
-    # TODO replace above statement with direct assignment in conditional
-    #   when new_type=True becomes default
-    if _NEW_TYPE:  # pragma: no cover
-        seqs.source = path
-
-    return seqs
+    unique_id = getattr(path, "unique_id", getattr(path, "name", str(path)))
+    return coll_maker(data=data, moltype=moltype, source=unique_id)
 
 
 @define_app(app_type=LOADER)

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -1,4 +1,3 @@
-import os
 from collections import defaultdict
 from typing import Union
 
@@ -16,10 +15,6 @@ GeneticCodeTypes = (
 )
 MolTypes = str | old_moltype.MolType | new_moltype.MolType
 AlphabetTypes = old_alphabet.Alphabet | new_alphabet.CharAlphabet
-
-_NEW_TYPE = "COGENT3_NEW_TYPE" in os.environ
-
-_NEW_TYPE = "COGENT3_NEW_TYPE" in os.environ
 
 
 def best_frame(
@@ -56,7 +51,7 @@ def best_frame(
         or the stop codon is not at the sequence end
     """
     gc = cogent3.get_code(gc)
-    if _NEW_TYPE:
+    if "new_" in gc.__module__:
         translations = [tr for *_, tr in gc.sixframes(str(seq))]
     else:
         translations = gc.sixframes(seq)
@@ -124,7 +119,7 @@ def translate_frames(
         moltype = cogent3.get_moltype(moltype)
         seq = moltype.make_seq(seq)
 
-    if _NEW_TYPE:
+    if "new_" in gc.__module__:
         translations = [tr for *_, tr in gc.sixframes(seq)]
     else:
         translations = gc.sixframes(seq)


### PR DESCRIPTION
[CHANGED] use the source argument rather than assigning to the
    returned value.

[CHANGED] in app.translate module, deleted usage of "COGENT3_NEW_TYPE" in os.environ
    and instead check the __module__ attribute of the genetic code object
    to determine if it is a new or old type.
    This has the advantage of not assuming the global environment setting
    so copes with cases where the object passed in was created explicitly.

## Summary by Sourcery

Refactor how sequence sources are assigned and how genetic code types are determined.

Enhancements:
- Assign sequence source during collection creation rather than as a separate step.
- Determine genetic code type by inspecting the __module__ attribute instead of relying on environment variables.