### PR TITLE
BUG: fixed a significant error in usage of IndelMap.merge_maps

### DIFF
--- a/changelog.d/20250314_131212_Gavin.Huttley.md
+++ b/changelog.d/20250314_131212_Gavin.Huttley.md
@@ -8,6 +8,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 - First time contributions from @c-jonesy, @Yixuan567, @Qinzi27
   and @je634 👏🚀🎉
+- @GavinHuttley bug fixes and maintenance
 
 ### ENH
 
@@ -30,11 +31,20 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   For example, `use_hook="my_package"` would invoke the one defined above. Set `use_hook="cogent3"`
   to force using the cogent3 default.
 
+- IndelMap.merge_maps(other: "IndelMap", alignd_indices: bool) handles case where
+  `other.gap_pos` are in alignment coordinates. This is essential for the case
+  of progressive alignments where the alignment coordinates are sequentially
+  adjusted as more profiles are aligned. This is the key change that fixes the
+  bug in the progressive aligner.
 
 ### BUG
 
 - Dotplot on new_type Alignments now show the alignment path 🎉
-
+- Fixed a MAJOR bug affecting the cogent3 progressive aligner. Gaps
+  were being incorrectly merged during the progressive steps. Users
+  are advised to re-run any analyses that used the progressive aligner.
+  This DOES NOT affect creating alignment objects from existing data,
+  e.g. alignments produced by other algorithms.
 
 <!--
 ### DOC
@@ -54,5 +64,3 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - new_alignment.Alignment.quick_tree() no longer supports doing bootstraps.
   This is because bootstrapping is not quick! If you want this, post a feature
   request and we will implement a separate app for this.
-
-

--- a/src/cogent3/align/pairwise.py
+++ b/src/cogent3/align/pairwise.py
@@ -494,6 +494,7 @@ class AlignablePOG(_Alignable):
                 new_map = aligned.map.merge_maps(
                     maps[dim] * word_length,
                     parent_length=maps[dim].parent_length * word_length,
+                    aligned_indices=True,
                 )
                 # Likewise, if the data is not modulo word_length,
                 # it is trimmed to match


### PR DESCRIPTION
[FIXED] The alignment code applies a merge operation to IndelMap objects
    progressively as it aligns sequences. This means the incoming IndelMap
    object is in alignment coordinates, not the original sequence
    coordinates. Introduced the aligned_indices parameter to IndelMap.merge_maps
    to handle this case.

    This will have caused significant errors in the output of the cogent3
    progressive aligners.

## Summary by Sourcery

Fixes a bug in the progressive aligner related to merging gaps in IndelMap objects during progressive alignment. Introduces the `aligned_indices` parameter to `IndelMap.merge_maps` to correctly handle alignment coordinates. Adds new tests to verify the fix.

Bug Fixes:
- Fixes a major bug in the cogent3 progressive aligner where gaps were being incorrectly merged during progressive steps. Users are advised to re-run any analyses that used the progressive aligner. This does not affect creating alignment objects from existing data, e.g. alignments produced by other algorithms.
- Fixes incorrect merging of gaps during progressive alignment by introducing the aligned_indices parameter to IndelMap.merge_maps to handle alignment coordinates correctly.

Enhancements:
- IndelMap.merge_maps(other: "IndelMap", alignd_indices: bool) handles case where `other.gap_pos` are in alignment coordinates.

Tests:
- Adds tests for indelmap merge with ending gap and aligned indices.