### PR TITLE
BUG: correctly creating seq data on renamed collections, FIXES #2268

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -5061,7 +5061,7 @@ class Alignment(SequenceCollection):
         new = self.array_seqs[:, indices]
 
         new_seq_data = self._seqs_data.from_names_and_array(
-            names=self.names,
+            names=self._name_map.values(),
             data=new,
             alphabet=self.moltype.most_degen_alphabet(),
         )
@@ -5215,10 +5215,11 @@ class Alignment(SequenceCollection):
 
             motif_valid = indices.reshape(num_motif, motif_length).all(axis=1).flatten()
             indices = numpy.repeat(motif_valid, motif_length)
+
         selected = array_pos[indices].T
 
         aligned_seqs_data = self._seqs_data.from_names_and_array(
-            names=self.names,
+            names=self._name_map.values(),
             data=selected,
             alphabet=self.moltype.most_degen_alphabet(),
         )
@@ -5313,7 +5314,7 @@ class Alignment(SequenceCollection):
         selected = positions[indices, :].T
 
         aligned_seqs_data = self._seqs_data.from_names_and_array(
-            names=self.names,
+            names=self._name_map.values(),
             data=selected,
             alphabet=alpha,
         )

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4682,7 +4682,8 @@ def test_filtered_drop_remainder():
     assert len(got) == 4
 
 
-def test_no_degenerates():
+@pytest.mark.parametrize("renamed", [True, False])
+def test_no_degenerates(renamed):
     """no_degenerates correctly excludes columns containing IUPAC ambiguity codes"""
     data = {
         "s1": "AAA CCC GGG TTT".replace(" ", ""),
@@ -4690,7 +4691,7 @@ def test_no_degenerates():
         "s3": "GGR YTT AAA CCC".replace(" ", ""),
     }
     aln = new_alignment.make_aligned_seqs(data, moltype="dna")
-
+    aln = aln.rename_seqs(lambda x: x.upper()) if renamed else aln
     # motif length of 1, defaults - no gaps allowed
     result = aln.no_degenerates().to_dict()
     expect = {
@@ -4698,6 +4699,7 @@ def test_no_degenerates():
         "s2": "CC GG TT AAA".replace(" ", ""),
         "s3": "GG TT AA CCC".replace(" ", ""),
     }
+    expect = {k.upper(): v for k, v in expect.items()} if renamed else expect
     assert result == expect
 
     # allow gaps
@@ -4707,6 +4709,7 @@ def test_no_degenerates():
         "s2": "CC GG T-T AAA".replace(" ", ""),
         "s3": "GG TT AAA CCC".replace(" ", ""),
     }
+    expect = {k.upper(): v for k, v in expect.items()} if renamed else expect
     assert result == expect
 
     # motif length of 3, defaults - no gaps allowed
@@ -4716,6 +4719,7 @@ def test_no_degenerates():
         "s2": "AAA".replace(" ", ""),
         "s3": "CCC".replace(" ", ""),
     }
+    expect = {k.upper(): v for k, v in expect.items()} if renamed else expect
     assert result == expect
 
     # allow gaps
@@ -4725,8 +4729,12 @@ def test_no_degenerates():
         "s2": "T-T AAA".replace(" ", ""),
         "s3": "AAA CCC".replace(" ", ""),
     }
+    expect = {k.upper(): v for k, v in expect.items()} if renamed else expect
     assert result == expect
 
+
+@pytest.mark.parametrize("renamed", [True, False])
+def test_no_degenerates_non_divisible_length(renamed):
     # for length non-divisible by motif_length
     data = {
         "s1": "AAA CCC GGG TTT T".replace(" ", ""),
@@ -4734,12 +4742,15 @@ def test_no_degenerates():
         "s3": "GGR YTT AAA CCC C".replace(" ", ""),
     }
     aln = new_alignment.make_aligned_seqs(data, moltype="dna")
+    aln = aln.rename_seqs(lambda x: x.upper()) if renamed else aln
     result = aln.no_degenerates(motif_length=3, allow_gap=False).to_dict()
     expect = {
         "s1": "TTT".replace(" ", ""),
         "s2": "AAA".replace(" ", ""),
         "s3": "CCC".replace(" ", ""),
     }
+    expect = {k.upper(): v for k, v in expect.items()} if renamed else expect
+    assert result == expect
 
 
 def test_no_degenerates_bad_moltype_raises():
@@ -4749,7 +4760,8 @@ def test_no_degenerates_bad_moltype_raises():
         _ = aln.no_degenerates()
 
 
-def test_omit_gap_pos_motif_length():
+@pytest.mark.parametrize("renamed", [True, False])
+def test_omit_gap_pos_motif_length(renamed):
     """consistency with different motif_length values"""
     data = {
         "seq1": "CAGGTCGACCTCGGC---------CACGAC",
@@ -4760,6 +4772,7 @@ def test_omit_gap_pos_motif_length():
         "seq6": "GCC---------------------------",
     }
     aln = new_alignment.make_aligned_seqs(data, moltype="dna")
+    aln = aln.rename_seqs(lambda x: x.upper()) if renamed else aln
     got1 = aln.omit_gap_pos(motif_length=1)
     got3 = aln.omit_gap_pos(motif_length=3)
     assert len(got3) == len(got1)


### PR DESCRIPTION
[CHANGED] constructing new seqs_data collections need to pass in
    self._name_map.values(), not self.names

## Summary by Sourcery

Fix sequence data creation for renamed collections by using renamed sequence names

Bug Fixes:
- Corrected sequence data creation methods to use renamed sequence names instead of original names when creating new sequence collections

Tests:
- Added parametrized tests to verify sequence operations work correctly with both renamed and non-renamed collections