### PR TITLE
BUG: fixing behaviour of masking annotations

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -6606,7 +6606,8 @@ class Alignment(SequenceCollection):
         biotypes: PySeqStr,
         mask_char: str = "?",
         shadow: bool = False,
-    ):
+        seqid: str | None = None,
+    ) -> typing_extensions.Self:
         """returns an alignment with regions replaced by mask_char
 
         Parameters
@@ -6628,9 +6629,12 @@ class Alignment(SequenceCollection):
         for seq in self.seqs:
             parent_name = self._name_map[seq.name]
             gaps[parent_name] = seq.map.array
-            ungapped[parent_name] = numpy.array(
-                seq.seq.with_masked_annotations(biotypes, mask_char, shadow),
-            )
+            if seqid is None or seq.name == seqid:
+                ungapped[parent_name] = numpy.array(
+                    seq.seq.with_masked_annotations(biotypes, mask_char, shadow),
+                )
+            else:
+                ungapped[parent_name] = numpy.array(seq.seq)
 
         seq_data = self._seqs_data.from_seqs_and_gaps(
             seqs=ungapped,

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1405,16 +1405,9 @@ class Sequence:
                 self.get_features(biotype=annot_type, allow_partial=True),
             )
         if not annotations:
-            region = Feature(
-                parent=self,
-                seqid=self.name,
-                name=None,
-                biotype=None,
-                map=FeatureMap.from_locations(locations=[], parent_length=len(self)),
-                strand="+",
-            )
-        else:
-            region = annotations[0].union(annotations[1:])
+            return self
+
+        region = annotations[0].union(annotations[1:])
 
         if shadow:
             region = region.shadow()

--- a/src/cogent3/core/new_sequence.py
+++ b/src/cogent3/core/new_sequence.py
@@ -1363,12 +1363,17 @@ class Sequence:
             annotation_db=None if exclude_annotations else self.annotation_db,
         )
 
+    @c3warn.deprecated_args(
+        "2025.6",
+        old_new=[("annot_types", "biotypes")],
+        reason="consistency with Alignment method",
+    )
+    @c3warn.deprecated_args("2025.6", reason="not used", discontinued="extend_query")
     def with_masked_annotations(
         self,
-        annot_types: StrORIterableStr,
+        biotypes: StrORIterableStr,
         mask_char: str | None = None,
         shadow: bool = False,
-        extend_query: bool = False,
     ) -> typing_extensions.Self:
         """returns a sequence with annot_types regions replaced by mask_char
         if shadow is False, otherwise all other regions are masked.
@@ -1394,12 +1399,11 @@ class Sequence:
         )
 
         annotations = []
-        annot_types = [annot_types] if isinstance(annot_types, str) else annot_types
-        for annot_type in annot_types:
+        biotypes = [biotypes] if isinstance(biotypes, str) else biotypes
+        for annot_type in biotypes:
             annotations += list(
                 self.get_features(biotype=annot_type, allow_partial=True),
             )
-
         if not annotations:
             region = Feature(
                 parent=self,

--- a/tests/test_core/test_new_seq_annotation.py
+++ b/tests/test_core/test_new_seq_annotation.py
@@ -180,3 +180,25 @@ def test_feature_names_seq():
     s = seq[f]
     assert s.name == "s1-cds"
     assert s.name == f.name
+
+
+def test_seq_with_masked_annotations():
+    seq = makeSampleSequence("seq1", with_gaps=False)
+    raw_seq = str(seq)
+    cds = next(iter(seq.annotation_db.get_records_matching(biotype="CDS")))
+    start, stop = cds["start"], cds["stop"]
+    expect = raw_seq[:start] + "?" * (stop - start) + raw_seq[stop:]
+    masked = seq.with_masked_annotations(biotypes="CDS")
+    assert str(masked) == expect
+    shadow = seq.with_masked_annotations(biotypes="CDS", shadow=True)
+    expect = "?" * start + raw_seq[start:stop] + "?" * (len(raw_seq) - stop)
+    assert str(shadow) == expect
+    print(shadow)
+
+
+@pytest.mark.parametrize("shadow", [True, False])
+def test_seq_with_masked_annotations_missing_feature(shadow):
+    seq = makeSampleSequence("seq1", with_gaps=False)
+    raw_seq = str(seq)
+    masked = seq.with_masked_annotations(biotypes="not-present", shadow=shadow)
+    assert str(masked) == raw_seq


### PR DESCRIPTION
## Summary by Sourcery

Fix and improve the behavior of masking annotations in sequences and alignments

Bug Fixes:
- Corrected the masking of annotations to handle cases with no matching features
- Improved handling of masking for specific sequences in an alignment

Enhancements:
- Added support for masking annotations with more flexible options
- Implemented seqid-specific masking in alignments

Tests:
- Added new test cases for masking annotations with different scenarios
- Introduced tests for masking with missing features
- Added parametrized tests for shadow and non-shadow masking