### PR TITLE
API: simplify the API for AnnotationDbABC

### DIFF
--- a/changelog.d/20250406_125550_Gavin.Huttley.md
+++ b/changelog.d/20250406_125550_Gavin.Huttley.md
@@ -37,9 +37,19 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecations category.
 
 -->
-<!--
+
 ### Discontinued
 
-- A bullet item for the Discontinued category.
-
--->
+- We have changed the API for the SupportsFeatures protocol. It no longer
+  inherits from SerialisableType. Thus, subclasses of AnnotationDbABC no
+  longer have to implement `to_rich_dict()`, `from_dict()` and
+  `to_json()` methods.
+- We have changed the API for AnnotationDbABC. The following methods
+  have been converted from abstractmethods to concrete methods. The
+  concrete methods raise a NotImplementedError. This means
+  developers need not implement them in their subclasses. The methods are:
+  - `add_feature()`
+  - `add_records()`
+  - `subset()`
+  - `update()`
+  - `union()`

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -211,7 +211,6 @@ class SupportsWriteFeatures(typing.Protocol):  # pragma: no cover
 class SupportsFeatures(
     SupportsQueryFeatures,
     SupportsWriteFeatures,
-    SerialisableType,
     typing.Sized,
     typing.Protocol,
 ):  # pragma: no cover
@@ -280,7 +279,6 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         **kwargs: dict[str, typing.Any],
     ) -> int: ...
 
-    @abc.abstractmethod
     def subset(
         self,
         *,
@@ -292,33 +290,44 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         strand: str | None = None,
         attributes: str | None = None,
         **kwargs: dict[str, typing.Any],
-    ) -> typing_extensions.Self: ...
+    ) -> typing_extensions.Self:
+        # override in subclass
+        msg = f"{self.__class__.__name__!r} does not support subset()"
+        raise NotImplementedError(msg)
 
-    @abc.abstractmethod
-    def add_feature(self, **kwargs: dict[str, typing.Any]) -> None: ...
+    def add_feature(self, **kwargs: dict[str, typing.Any]) -> None:
+        # override in subclass
+        msg = f"{self.__class__.__name__!r} does not support add_feature()"
+        raise NotImplementedError(msg)
 
-    @abc.abstractmethod
     def add_records(
         self,
         *,
         records: typing.Sequence[dict],
         **kwargs: dict[str, typing.Any],
-    ) -> None: ...
+    ) -> None:
+        # override in subclass
+        msg = f"{self.__class__.__name__!r} does not support add_records()"
+        raise NotImplementedError(msg)
 
-    @abc.abstractmethod
     def update(
         self,
         annot_db: AnnotationDbABC,
         seqids: OptionalStrList = None,
         **kwargs: dict[str, typing.Any],
-    ) -> None: ...
+    ) -> None:
+        # override in subclass
+        msg = f"{self.__class__.__name__!r} does not support update()"
+        raise NotImplementedError(msg)
 
-    @abc.abstractmethod
     def union(
         self,
         annot_db: AnnotationDbABC,
         **kwargs: dict[str, typing.Any],
-    ) -> SupportsFeatures: ...
+    ) -> SupportsFeatures:
+        # override in subclass
+        msg = f"{self.__class__.__name__!r} does not support union"
+        raise NotImplementedError(msg)
 
 
 def _make_table_sql(


### PR DESCRIPTION
[CHANGED] convert some of the anstractmethods to concrete methods.
    We need to revist these to assess whether they should be removed
    entirely. We want to make it as easy as possible for third party
    developers to provide their own implementations.

## Summary by Sourcery

Simplify the API for AnnotationDbABC by converting abstract methods to concrete methods with default NotImplementedError implementations

Enhancements:
- Simplified the SupportsFeatures protocol by removing SerialisableType inheritance
- Converted abstract methods to concrete methods with default error handling to make subclassing easier