### PR TITLE
API: move table to cogent3.core

### DIFF
--- a/changelog.d/20250406_125550_Gavin.Huttley.md
+++ b/changelog.d/20250406_125550_Gavin.Huttley.md
@@ -62,4 +62,6 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   - `update()`
   - `union()`
 - `cogent3.format.alignment` has been renamed `cogent3.format.sequence`.
-   This is a backwards incompatible change!
+  This is a backwards incompatible change!
+- `cogent3.util.table` has been moved to `cogent3.core.table`. Usage of the
+  top level functions for making, loading tables is unaffected.

--- a/doc/api/table/classes/cogent3.util.table.Columns.rst
+++ b/doc/api/table/classes/cogent3.util.table.Columns.rst
@@ -1,7 +1,7 @@
 Columns
 ======= 
 
-.. currentmodule:: cogent3.util.table
+.. currentmodule:: cogent3.core.table
 
 .. autoclass:: Columns
     :members:

--- a/doc/api/table/classes/cogent3.util.table.Table.rst
+++ b/doc/api/table/classes/cogent3.util.table.Table.rst
@@ -1,7 +1,7 @@
 Table
 ===== 
 
-.. currentmodule:: cogent3.util.table
+.. currentmodule:: cogent3.core.table
 
 .. autoclass:: Table
     :members:

--- a/doc/api/table/table.rst
+++ b/doc/api/table/table.rst
@@ -1,7 +1,7 @@
 :mod:`table`
 ============
 
-.. currentmodule:: cogent3.util.table
+.. currentmodule:: cogent3.core.table
 
 .. autosummary::
     :toctree: classes

--- a/doc/cookbook/annotation_db.rst
+++ b/doc/cookbook/annotation_db.rst
@@ -64,7 +64,7 @@ To load features from a Genbank file, we can once again use the ``load_annotatio
 How to generate a summary of an ``AnnotationDb``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To generate a summary of an ``AnnotationDb``, we can access the ``describe`` attribute of the database. This attribute returns a ``cogent3.util.table.Table`` instance that shows the number of records for each seqid, the count for each biotype, and the number of rows in each table (in this example there is a "gff" table with 1,169 rows and an empty "user" table).
+To generate a summary of an ``AnnotationDb``, we can access the ``describe`` attribute of the database. This attribute returns a ``cogent3.core.table.Table`` instance that shows the number of records for each seqid, the count for each biotype, and the number of rows in each table (in this example there is a "gff" table with 1,169 rows and an empty "user" table).
 
 .. jupyter-execute::
     :raises:

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -8,7 +8,12 @@ import warnings
 from collections.abc import Callable
 
 from cogent3._version import __version__
-from cogent3.app import app_help, available_apps, get_app, open_data_store  # noqa
+from cogent3.app import (  # noqa: F401
+    app_help,
+    available_apps,
+    get_app,
+    open_data_store,
+)
 from cogent3.core import annotation_db as _anno_db
 from cogent3.core.alignment import (
     Alignment,
@@ -16,25 +21,25 @@ from cogent3.core.alignment import (
     Sequence,
     SequenceCollection,
 )
-from cogent3.core.genetic_code import available_codes, get_code  # noqa
+from cogent3.core.genetic_code import available_codes, get_code  # noqa: F401
 
 # note that moltype has to be imported last, because it sets the moltype in
 # the objects created by the other modules.
-from cogent3.core.moltype import (
-    ASCII,  # noqa
-    DNA,  # noqa
-    PROTEIN,  # noqa
-    RNA,  # noqa
-    available_moltypes,  # noqa
+from cogent3.core.moltype import (  # noqa: F401
+    ASCII,
+    DNA,
+    PROTEIN,
+    RNA,
+    available_moltypes,
     get_moltype,
 )
-from cogent3.core.table import load_table, make_table  # noqua
-from cogent3.core.tree import PhyloNode, TreeBuilder, TreeError, TreeNode
-from cogent3.evolve.fast_distance import (
-    available_distances,  # noqa
-    get_distance_calculator,  # noqa
+from cogent3.core.table import load_table, make_table  # noqa: F401
+from cogent3.core.tree import PhyloNode, TreeBuilder, TreeError, TreeNode  # noqa: F401
+from cogent3.evolve.fast_distance import (  # noqa: F401
+    available_distances,
+    get_distance_calculator,
 )
-from cogent3.evolve.models import available_models, get_model  # noqa
+from cogent3.evolve.models import available_models, get_model  # noqa: F401
 from cogent3.parse.cogent3_json import load_from_json
 from cogent3.parse.newick import parse_string as newick_parse_string
 from cogent3.parse.sequence import is_genbank

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -4,7 +4,6 @@ execution on compute systems with 1000s of CPUs."""
 
 import os
 import pathlib
-import pickle
 import warnings
 from collections.abc import Callable
 
@@ -29,6 +28,7 @@ from cogent3.core.moltype import (
     available_moltypes,  # noqa
     get_moltype,
 )
+from cogent3.core.table import load_table, make_table  # noqua
 from cogent3.core.tree import PhyloNode, TreeBuilder, TreeError, TreeNode
 from cogent3.evolve.fast_distance import (
     available_distances,  # noqa
@@ -37,14 +37,10 @@ from cogent3.evolve.fast_distance import (
 from cogent3.evolve.models import available_models, get_model  # noqa
 from cogent3.parse.cogent3_json import load_from_json
 from cogent3.parse.newick import parse_string as newick_parse_string
-from cogent3.parse.sequence import get_parser, is_genbank
-from cogent3.parse.table import load_delimited
+from cogent3.parse.sequence import is_genbank
 from cogent3.parse.tree_xml import parse_string as tree_xml_parse_string
-from cogent3.util import warning as c3warn
 from cogent3.util.io import get_format_suffixes, is_url, open_
 from cogent3.util.progress_display import display_wrap
-from cogent3.util.table import Table as _Table
-from cogent3.util.table import cast_str_to_array
 
 __copyright__ = "Copyright 2007-2023, The Cogent Project"
 __credits__ = "https://github.com/cogent3/cogent3/graphs/contributors"
@@ -567,218 +563,6 @@ def load_aligned_seqs(
         info=info,
         new_type=new_type,
         **kw,
-    )
-
-
-def make_table(
-    header=None,
-    data=None,
-    row_order=None,
-    digits=4,
-    space=4,
-    title="",
-    max_width=1e100,
-    index_name=None,
-    legend="",
-    missing_data="",
-    column_templates=None,
-    data_frame=None,
-    format="simple",
-    **kwargs,
-):
-    """
-
-    Parameters
-    ----------
-    header
-        column headings
-    data
-        a 2D dict, list or tuple. If a dict, it must have column
-        headings as top level keys, and common row labels as keys in each
-        column.
-    row_order
-        the order in which rows will be pulled from the twoDdict
-    digits
-        floating point resolution
-    space
-        number of spaces between columns or a string
-    title
-        as implied
-    max_width
-        maximum column width for printing
-    index_name
-        column name with values to be used as row identifiers and keys
-        for slicing. All column values must be unique.
-    legend
-        table legend
-    missing_data
-        replace missing data with this
-    column_templates
-        dict of column headings
-        or a function that will handle the formatting.
-    limit
-        exits after this many lines. Only applied for non pickled data
-        file types.
-    data_frame
-        a pandas DataFrame, supersedes header/rows
-    format
-        output format when using str(Table)
-
-    """
-    if any(isinstance(a, str) for a in (header, data)):
-        msg = "str type invalid, if it's a path use load_table()"
-        raise TypeError(msg)
-
-    data = kwargs.get("rows", data)
-    if data_frame is not None:
-        from pandas import DataFrame
-
-        if not isinstance(data_frame, DataFrame):
-            msg = f"expecting a DataFrame, got{type(data_frame)}"
-            raise TypeError(msg)
-
-        data = {c: data_frame[c].to_numpy() for c in data_frame}
-
-    return _Table(
-        header=header,
-        data=data,
-        digits=digits,
-        row_order=row_order,
-        title=title,
-        column_templates=column_templates,
-        space=space,
-        missing_data=missing_data,
-        max_width=max_width,
-        index_name=index_name,
-        legend=legend,
-        data_frame=data_frame,
-        format=format,
-    )
-
-
-def load_table(
-    filename: str | pathlib.Path,
-    sep=None,
-    reader=None,
-    digits=4,
-    space=4,
-    title="",
-    missing_data="",
-    max_width=1e100,
-    index_name=None,
-    legend="",
-    column_templates=None,
-    static_column_types=False,
-    limit=None,
-    format="simple",
-    skip_inconsistent=False,
-    **kwargs,
-):
-    """
-
-    Parameters
-    ----------
-    filename
-        path to file containing a tabular data
-    sep
-        the delimiting character between columns
-    reader
-        a parser for reading filename. This approach assumes the first
-        row returned by the reader will be the header row.
-    static_column_types
-        if True, and reader is None, identifies columns
-        with a numeric/bool data types from the first non-header row.
-        This assumes all subsequent entries in that column are of the same type.
-        Default is False.
-    digits
-        floating point resolution
-    space
-        number of spaces between columns or a string
-    title
-        as implied
-    missing_data
-        character assigned if a row has no entry for a column
-    max_width
-        maximum column width for printing
-    index_name
-        column name with values to be used as row identifiers and keys
-        for slicing. All column values must be unique.
-    legend
-        table legend
-    column_templates
-        dict of column headings
-        or a function that will handle the formatting.
-    limit
-        exits after this many lines. Only applied for non pickled data
-        file types.
-    format
-        output format when using str(Table)
-    skip_inconsistent
-        skips rows that have different length to header row
-    """
-    if not any(isinstance(filename, t) for t in (str, pathlib.PurePath)):
-        msg = "filename must be string or Path, perhaps you want make_table()"
-        raise TypeError(
-            msg,
-        )
-
-    sep = sep or kwargs.pop("delimiter", None)
-    file_format, compress_format = get_format_suffixes(filename)
-
-    if file_format == "json":
-        return load_from_json(filename, (_Table,))
-    if file_format in ("pickle", "pkl"):
-        with open_(filename, mode="rb") as f:
-            loaded_table = pickle.load(f)
-
-        r = _Table()
-        r.__setstate__(loaded_table)
-        return r
-
-    if reader:
-        with open_(filename, newline=None) as f:
-            data = list(reader(f))
-            header = data[0]
-            data = {column[0]: column[1:] for column in zip(*data, strict=False)}
-    else:
-        if file_format == "csv":
-            sep = sep or ","
-        elif file_format == "tsv":
-            sep = sep or "\t"
-
-        header, rows, loaded_title, legend = load_delimited(
-            filename,
-            sep=sep,
-            limit=limit,
-            **kwargs,
-        )
-        if skip_inconsistent:
-            num_fields = len(header)
-            rows = [r for r in rows if len(r) == num_fields]
-        else:
-            lengths = set(map(len, [header, *rows]))
-            if len(lengths) != 1:
-                msg = f"inconsistent number of fields {lengths}"
-                raise ValueError(msg)
-
-        title = title or loaded_title
-        data = {column[0]: column[1:] for column in zip(header, *rows, strict=False)}
-
-    for key, value in data.items():
-        data[key] = cast_str_to_array(value, static_type=static_column_types)
-
-    return make_table(
-        header=header,
-        data=data,
-        digits=digits,
-        title=title,
-        column_templates=column_templates,
-        space=space,
-        missing_data=missing_data,
-        max_width=max_width,
-        index_name=index_name,
-        legend=legend,
-        format=format,
     )
 
 

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -7,6 +7,7 @@ import textwrap
 import warnings
 from typing import TYPE_CHECKING
 
+import cogent3
 from cogent3._plugin import get_app_manager
 
 from .composable import is_app, is_app_composable
@@ -15,7 +16,7 @@ from .io import open_data_store  # noqa
 if TYPE_CHECKING:
     from stevedore.extension import Extension
 
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
 
 def _get_extension_attr(extension: Extension) -> list[str]:
@@ -60,7 +61,6 @@ def available_apps(name_filter: str | None = None) -> Table:
     """
     returns Table listing the available apps
     """
-    from cogent3.util.table import Table
 
     rows = []
 
@@ -75,7 +75,7 @@ def available_apps(name_filter: str | None = None) -> Table:
             rows.append(_get_extension_attr(extension))
 
     header = ["package", "name", "composable", "doc", "input type", "output type"]
-    return Table(header=header, data=rows)
+    return cogent3.make_table(header=header, data=rows)
 
 
 _get_param = re.compile('(?<=").+(?=")')

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -19,10 +19,10 @@ from scitrack import get_text_hexdigest
 
 from cogent3.core import alignment as old_alignment
 from cogent3.core import new_alignment
+from cogent3.core.table import Table
 from cogent3.util.deserialise import deserialise_object
 from cogent3.util.io import get_format_suffixes, open_
 from cogent3.util.parallel import is_master_process
-from cogent3.util.table import Table
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -20,9 +20,9 @@ from cogent3.core.profile import (
     make_motif_freqs_from_tabular,
     make_pssm_from_tabular,
 )
+from cogent3.core.table import Table
 from cogent3.evolve.fast_distance import DistanceMatrix
 from cogent3.util.deserialise import deserialise_object
-from cogent3.util.table import Table
 
 from .composable import LOADER, WRITER, NotCompleted, define_app
 from .data_store import (

--- a/src/cogent3/app/result.py
+++ b/src/cogent3/app/result.py
@@ -11,8 +11,8 @@ from scipy.stats.distributions import chi2
 import cogent3
 from cogent3._version import __version__
 from cogent3.app.data_store import get_data_source
+from cogent3.core.table import Table
 from cogent3.util.misc import extend_docstring_from, get_object_provenance
-from cogent3.util.table import Table
 
 
 class generic_result(MutableMapping):

--- a/src/cogent3/app/typing.py
+++ b/src/cogent3/app/typing.py
@@ -149,7 +149,7 @@ def defined_types():
     These (or standard Python) types are required to annotate argument and
     return values from cogent3 apps. They define the compatability of apps.
     """
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     rows = [[n, ", ".join(get_constraint_names(t))] for n, t in _all_types.items()]
     title = "To use a type hint, from cogent3.app import typing"

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -16,12 +16,12 @@ import numpy
 import typing_extensions
 
 from cogent3._version import __version__
+from cogent3.core.table import Table
 from cogent3.parse.gff import merged_gff_records
 from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.io import PathType, iter_line_blocks
 from cogent3.util.misc import extend_docstring_from, get_object_provenance
 from cogent3.util.progress_display import display_wrap
-from cogent3.util.table import Table
 
 OptionalInt = int | None
 OptionalStr = str | None

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -10,7 +10,7 @@ import os
 import re
 from itertools import product
 
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 maketrans = str.maketrans
 
@@ -567,7 +567,7 @@ def get_code(code_id: int = 1, new_type: bool = False):
 
 def available_codes():
     """returns Table listing the available genetic codes"""
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     all_keys = sorted({int(k) for k in GeneticCodes if str(k).isdigit()})
     rows = [(k, GeneticCodes[k].name) for k in all_keys]

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1551,7 +1551,7 @@ def get_moltype(name, new_type: bool = False):
 
 def available_moltypes():
     """returns Table listing the available moltypes"""
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     rows = []
     for n, m in moltypes.items():

--- a/src/cogent3/core/new_genetic_code.py
+++ b/src/cogent3/core/new_genetic_code.py
@@ -19,7 +19,7 @@ import typing
 import numpy
 
 from cogent3.core import new_alphabet, new_moltype
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 if typing.TYPE_CHECKING:
     from cogent3.core.sequence import Sequence

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -1426,7 +1426,7 @@ def get_moltype(name: str | MolType) -> MolType:
 
 def available_moltypes():
     """returns Table listing the available moltypes"""
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     rows = []
     for n, m in _moltypes.items():

--- a/src/cogent3/core/table.py
+++ b/src/cogent3/core/table.py
@@ -2412,7 +2412,7 @@ def load_table(
         )
 
     sep = sep or kwargs.pop("delimiter", None)
-    file_format, compress_format = get_format_suffixes(filename)
+    file_format, _ = get_format_suffixes(filename)
 
     if file_format == "json":
         return c3_json.load_from_json(filename, (Table,))

--- a/src/cogent3/evolve/distance.py
+++ b/src/cogent3/evolve/distance.py
@@ -5,10 +5,10 @@ from itertools import combinations
 from warnings import warn
 
 from cogent3 import make_tree
+from cogent3.core import table
 from cogent3.evolve.fast_distance import DistanceMatrix
 from cogent3.maths.stats.number import NumberCounter
 from cogent3.util import progress_display as UI
-from cogent3.util import table
 
 _NEW_TYPE = "COGENT3_NEW_TYPE" in os.environ
 

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -298,7 +298,7 @@ Stats = namedtuple("Stats", ["length", "fraction_variable", "dist", "variance"])
 
 
 def _make_stat_table(stats, names, **kwargs):
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     header = ["Seq1 \\ Seq2", *names]
     rows = zeros((len(names), len(names)), dtype="O")
@@ -709,7 +709,7 @@ def available_distances():
     -----
     For more complicated genetic distance methods, see the evolve.models module.
     """
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     rows = []
     for n, c in _calculators.items():
@@ -759,7 +759,7 @@ class DistanceMatrix(DictArray):
 
     def to_table(self):
         """converted to a Table"""
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         data = {"names": self.names}
         for i, name in enumerate(self.names):

--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -8,7 +8,7 @@ import numpy
 import cogent3
 from cogent3._version import __version__
 from cogent3.core import alignment as old_alignment
-from cogent3.core import new_alignment
+from cogent3.core import new_alignment, table
 from cogent3.core.tree import PhyloNode
 from cogent3.evolve import substitution_model
 from cogent3.evolve.simulate import AlignmentEvolver, random_sequence
@@ -20,7 +20,6 @@ from cogent3.maths.measure import (
 )
 from cogent3.recalculation.definition import ParameterController
 from cogent3.recalculation.scope import InvalidScopeError
-from cogent3.util import table
 from cogent3.util.dict_array import DictArrayTemplate
 from cogent3.util.misc import adjusted_gt_minprob, get_object_provenance
 

--- a/src/cogent3/evolve/likelihood_tree.py
+++ b/src/cogent3/evolve/likelihood_tree.py
@@ -96,7 +96,7 @@ class _LikelihoodTreeEdge:
 
     def calc_G_statistic(self, likelihoods, return_table=False):
         # A Goodness-of-fit statistic
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         unambig = (self.ambig == 1.0).nonzero()[0]
         observed = self.counts[unambig].astype(int)

--- a/src/cogent3/evolve/models.py
+++ b/src/cogent3/evolve/models.py
@@ -13,13 +13,13 @@ from itertools import permutations
 import numpy
 
 import cogent3
+from cogent3.core.table import Table
 from cogent3.evolve import ns_substitution_model, substitution_model
 from cogent3.evolve.predicate import MotifChange, omega
 from cogent3.evolve.solved_models import _solved_nucleotide
 from cogent3.evolve.substitution_model import _SubstitutionModel
 from cogent3.evolve.substitution_model import kappa_r as _kappa_r
 from cogent3.evolve.substitution_model import kappa_y as _kappa_y
-from cogent3.util.table import Table
 
 nucleotide_models = []
 codon_models = []

--- a/src/cogent3/evolve/substitution_model.py
+++ b/src/cogent3/evolve/substitution_model.py
@@ -825,7 +825,7 @@ class Parametric(_ContinuousSubstitutionModel):
     def ascii_art(self, delim="", delim2="|", max_width=70, return_table=False):
         """An ASCII-art table representing the model.  'delim' delimits
         parameter names, 'delim2' delimits motifs"""
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         labels = list(self.alphabet)
         pars = self.get_matrix_params()

--- a/src/cogent3/maths/markov.py
+++ b/src/cogent3/maths/markov.py
@@ -51,7 +51,7 @@ class TransitionMatrix:
             state = bisect.bisect_left(partitions[state], x)
 
     def __repr__(self) -> str:
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         labels = []
         for i, label in enumerate(self.Tags):

--- a/src/cogent3/maths/stats/contingency.py
+++ b/src/cogent3/maths/stats/contingency.py
@@ -416,7 +416,7 @@ class TestResult:
         setattr(self, stat_name, stat)
 
     def _get_repr_(self):
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         header = [str(self.stat_name), "df", "pvalue"]
         col_templates = {

--- a/src/cogent3/maths/stats/jackknife.py
+++ b/src/cogent3/maths/stats/jackknife.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 
 def index_gen(length):

--- a/src/cogent3/maths/stats/number.py
+++ b/src/cogent3/maths/stats/number.py
@@ -186,7 +186,7 @@ class CategoryCounter(MutableMapping, SummaryStatBase):
         -------
         cogent3 Table instance
         """
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         if (
             not column_names

--- a/src/cogent3/parse/cogent3_json.py
+++ b/src/cogent3/parse/cogent3_json.py
@@ -2,7 +2,7 @@
 
 import json
 
-from cogent3.app.data_store import load_record_from_json
+from cogent3.app import data_store
 from cogent3.util.deserialise import deserialise_object
 from cogent3.util.io import open_
 from cogent3.util.misc import get_object_provenance
@@ -25,7 +25,7 @@ def load_from_json(filename, classes):
     with open_(filename) as f:
         content = json.loads(f.read())
     try:
-        _, data, completed = load_record_from_json(content)
+        _, data, completed = data_store.load_record_from_json(content)
         if not completed:
             msg = "json file is a record for type NotCompleted."
             raise TypeError(msg)

--- a/src/cogent3/parse/psl.py
+++ b/src/cogent3/parse/psl.py
@@ -5,7 +5,7 @@ Compatible with blat v.34
 
 import contextlib
 
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 
 def make_header(lines):

--- a/src/cogent3/util/deserialise.py
+++ b/src/cogent3/util/deserialise.py
@@ -15,7 +15,7 @@ class register_deserialiser:
 
     Functions are added to a dict which is used by the deserialise_object()
     function. The type string(s) must uniquely identify the appropriate
-    value for the dict 'type' entry, e.g. 'cogent3.util.table.Table'.
+    value for the dict 'type' entry, e.g. 'cogent3.core.table.Table'.
 
     Parameters
     ----------
@@ -58,7 +58,7 @@ def str_to_version(v):
 
 
 @register_deserialiser(
-    "cogent3.util.table.Table",
+    "cogent3.core.table.Table",
     "cogent3.util.dict_array.DictArray",
     "cogent3.evolve.fast_distance.DistanceMatrix",
 )

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -633,7 +633,7 @@ class DictArray:
             msg = f"cannot make 2D table from {ndim}D array"
             raise ValueError(msg)
 
-        from .table import Table
+        from cogent3.core.table import Table
 
         header = self.template.names[0] if ndim == 1 else self.template.names[1]
         index = "" if ndim == 2 else None

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -26,7 +26,7 @@ from cogent3.app.data_store import (
     load_record_from_json,
     summary_not_completeds,
 )
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 from cogent3.util.union_dict import UnionDict
 
 

--- a/tests/test_app/test_evo.py
+++ b/tests/test_app/test_evo.py
@@ -817,7 +817,7 @@ class TestNatSel(TestCase):
 class TestTabulateStats(TestCase):
     def test_tabulate(self):
         """call returns tabular_result with Tables"""
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         _data = {
             "Human": "ATGCGGCTCGCGGAGGCCGCGCTCGCGGAG",

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -9,7 +9,7 @@ import pytest
 
 from cogent3 import app_help, available_apps, get_app, open_data_store
 from cogent3.app.composable import LOADER, WRITER, is_app
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 
 def _get_all_composables(tmp_dir_name):
@@ -57,7 +57,7 @@ def _get_all_composables(tmp_dir_name):
 class TestAvailableApps(TestCase):
     def test_available_apps(self):
         """available_apps returns a table"""
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         apps = available_apps()
         assert isinstance(apps, Table)

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -23,11 +23,11 @@ from cogent3.app.data_store import (
 )
 from cogent3.app.io import DEFAULT_DESERIALISER, DEFAULT_SERIALISER
 from cogent3.core.profile import PSSM, MotifCountsArray, MotifFreqsArray
+from cogent3.core.table import Table
 from cogent3.evolve.fast_distance import DistanceMatrix
 from cogent3.maths.util import safe_log
 from cogent3.parse.sequence import PARSERS
 from cogent3.util.deserialise import deserialise_object
-from cogent3.util.table import Table
 
 DNA = get_moltype("dna")
 

--- a/tests/test_app/test_plugins.py
+++ b/tests/test_app/test_plugins.py
@@ -16,7 +16,7 @@ from cogent3.app import (
     get_app,
 )
 from cogent3.app.composable import define_app
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 
 @pytest.fixture

--- a/tests/test_app/test_sqlite_data_store.py
+++ b/tests/test_app/test_sqlite_data_store.py
@@ -21,7 +21,7 @@ from cogent3.app.sqlite_data_store import (
     has_valid_schema,
     open_sqlite_db_rw,
 )
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 
 @pytest.fixture

--- a/tests/test_app/test_typing.py
+++ b/tests/test_app/test_typing.py
@@ -23,9 +23,9 @@ def test_get_constraint_names():
         ArrayAlignment,
         SequenceCollection,
     )
+    from cogent3.core.table import Table
     from cogent3.evolve.fast_distance import DistanceMatrix
     from cogent3.util.dict_array import DictArray
-    from cogent3.util.table import Table
 
     got = get_constraint_names(AlignedSeqsType)
     assert got == {obj.__name__ for obj in (Alignment, ArrayAlignment)}

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -133,7 +133,7 @@ def test_constructor_db_connection_works(db_name, cls, request):
 
 
 def test_gff_describe(gff_db):
-    from cogent3.util.table import Table
+    from cogent3.core.table import Table
 
     result = gff_db.describe
     assert isinstance(result, Table)

--- a/tests/test_format/test_bedgraph.py
+++ b/tests/test_format/test_bedgraph.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 
 
 class FormatBedgraph(TestCase):

--- a/tests/test_util/test_dictarray.py
+++ b/tests/test_util/test_dictarray.py
@@ -405,7 +405,7 @@ class DictArrayTest(TestCase):
 
     def test_to_table(self):
         """creates Table when ndim <= 2"""
-        from cogent3.util.table import Table
+        from cogent3.core.table import Table
 
         a1D = DictArrayTemplate(["a", "b"]).wrap([0, 1])
         t = a1D.to_table()

--- a/tests/test_util/test_warning.py
+++ b/tests/test_util/test_warning.py
@@ -216,7 +216,7 @@ def test_method_deprecated_method_pickling(recwarn):
 )
 def test_deprecated_callable_resolves_type(recwarn, func, _type):
     func(2)
-    assert _type in recwarn.list[0].message.args[0]
+    assert any(_type in str(e) for e in recwarn.list), recwarn.list
 
 
 def test_function_deprecated_args_deprecated_callable_chained_decorators(recwarn):


### PR DESCRIPTION
## Summary by Sourcery

Move the table module from cogent3.util to cogent3.core, updating all import references accordingly

Enhancements:
- Reorganized the table module to be part of the core package
- Updated import statements across multiple files to reference the new module location

Documentation:
- Updated changelog to reflect the module move

Chores:
- Cleaned up import statements
- Removed unused imports