### PR TITLE
API: refactor format parser plugin base class

### DIFF
--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -8,7 +8,7 @@ if typing.TYPE_CHECKING:
     from cogent3.core.new_alignment import Alignment, SequenceCollection
     from cogent3.core.tree import PhyloNode
     from cogent3.evolve.fast_distance import DistanceMatrix
-    from cogent3.parse.sequence import ParserOutputType, SeqParserInputTypes
+    from cogent3.parse.sequence import SeqParserInputTypes, SequenceParserBase
 
 SeqsTypes = typing.Union["SequenceCollection", "Alignment"]
 
@@ -56,8 +56,8 @@ def get_seq_format_parser_plugin(
     *,
     format_name: str | None = None,
     file_suffix: str | None = None,
-) -> typing.Callable[["SeqParserInputTypes"], "ParserOutputType"] | None:
-    """returns sequence format parser
+) -> typing.Callable[["SeqParserInputTypes"], "SequenceParserBase"] | None:
+    """returns sequence format parser plugin
 
     Parameters
     ----------
@@ -81,9 +81,9 @@ def get_seq_format_parser_plugin(
         plugin = ext.plugin()
         if file_suffix in plugin.supported_suffixes or plugin.name == format_name:
             if ext.module_name.startswith("cogent3."):
-                built_in = plugin.parser
+                built_in = plugin
                 continue
-            return plugin.parser
+            return plugin
 
     if built_in:
         # if we have a built-in plugin, return it

--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -1,5 +1,4 @@
 import functools
-import pathlib
 import typing
 
 import stevedore
@@ -8,7 +7,8 @@ if typing.TYPE_CHECKING:
     from cogent3.core.new_alignment import Alignment, SequenceCollection
     from cogent3.core.tree import PhyloNode
     from cogent3.evolve.fast_distance import DistanceMatrix
-    from cogent3.parse.sequence import SeqParserInputTypes, SequenceParserBase
+    from cogent3.format.sequence import SequenceWriterBase
+    from cogent3.parse.sequence import SequenceParserBase
 
 SeqsTypes = typing.Union["SequenceCollection", "Alignment"]
 
@@ -56,7 +56,7 @@ def get_seq_format_parser_plugin(
     *,
     format_name: str | None = None,
     file_suffix: str | None = None,
-) -> typing.Callable[["SeqParserInputTypes"], "SequenceParserBase"] | None:
+) -> "SequenceParserBase":
     """returns sequence format parser plugin
 
     Parameters
@@ -102,7 +102,7 @@ def get_seq_format_writer_plugin(
     *,
     format_name: str | None = None,
     file_suffix: str | None = None,
-) -> typing.Callable[[SeqsTypes], pathlib.Path] | None:
+) -> "SequenceWriterBase":
     """returns sequence format writer
 
     Parameters

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -45,6 +45,9 @@ from .typing import (
     UnalignedSeqsType,
 )
 
+if typing.TYPE_CHECKING:
+    from cogent3.parse.sequence import SequenceParserBase
+
 _datastore_reader_map = {}
 
 MolTypes = old_moltype.MolType | new_moltype.MolType
@@ -280,10 +283,18 @@ def _(path: str) -> os.PathLike:
     return _read_it(Path(path))
 
 
-def _load_seqs(path, coll_maker, parser, moltype):
-    data = _read_it(path)
-    data = data.splitlines()
-    data = dict(iter(parser(data)))
+def _load_seqs(
+    path: str | Path,
+    coll_maker: type,
+    parser: "SequenceParserBase",
+    moltype: str,
+) -> SeqsCollectionType:
+    if not parser.result_is_storage:
+        data = _read_it(path)
+        data = data.splitlines()
+        data = dict(iter(parser.loader(data)))
+    else:
+        data = parser.loader(path)
     unique_id = getattr(path, "unique_id", getattr(path, "name", str(path)))
     return coll_maker(data=data, moltype=moltype, source=unique_id)
 

--- a/src/cogent3/parse/sequence.py
+++ b/src/cogent3/parse/sequence.py
@@ -39,9 +39,14 @@ class SequenceParserBase(abc.ABC):
         ...
 
     @property
+    def result_is_storage(self) -> bool:
+        """True if the loader directly returns SeqsDataABC or AlignedSeqdDataABC"""
+        return False
+
+    @property
     @abc.abstractmethod
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
-        """returns a parser"""
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+        """a callable for loading from a file"""
         ...
 
 
@@ -114,7 +119,7 @@ class FastaParser(SequenceParserBase):
         return {"fasta", "fa", "fna", "faa", "mfa"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return fasta.iter_fasta_records
 
 
@@ -130,7 +135,7 @@ class GdeParser(SequenceParserBase):
         return {"gde"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(fasta.MinimalGdeParser)
 
 
@@ -146,7 +151,7 @@ class PhylipParser(SequenceParserBase):
         return {"phylip", "phy"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(phylip.MinimalPhylipParser)
 
 
@@ -162,7 +167,7 @@ class ClustalParser(SequenceParserBase):
         return {"clustal", "aln"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(clustal.ClustalParser)
 
 
@@ -178,7 +183,7 @@ class PamlParser(SequenceParserBase):
         return {"paml"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(paml.PamlParser)
 
 
@@ -194,7 +199,7 @@ class NexusParser(SequenceParserBase):
         return {"nexus", "nex", "nxs"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(nexus.MinimalNexusAlignParser)
 
 
@@ -210,7 +215,7 @@ class GenbankParser(SequenceParserBase):
         return {"gb", "gbk", "gbff", "genbank"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return genbank.rich_parser
 
 
@@ -226,7 +231,7 @@ class MsfParser(SequenceParserBase):
         return {"msf"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(gcg.MsfParser)
 
 
@@ -242,7 +247,7 @@ class XmfaParser(SequenceParserBase):
         return {"xmfa"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(fasta.MinimalXmfaParser)
 
 
@@ -258,7 +263,7 @@ class TinyseqParser(SequenceParserBase):
         return {"tinyseq"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(tinyseq.TinyseqParser)
 
 
@@ -274,7 +279,7 @@ class GbSeqParser(SequenceParserBase):
         return {"gbseq"}
 
     @property
-    def parser(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
+    def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return gbseq.GbSeqXmlParser
 
 


### PR DESCRIPTION
[CHANGED] we added a result_is_storage property to the base class,
     paving the way for different types of input files.

## Summary by Sourcery

Refactor the sequence format parser plugin system to support loaders that return different data types.

Enhancements:
- Rename the `parser` property to `loader` in the sequence parser plugin base class and its implementations.
- Add a `result_is_storage` property to parser plugins to indicate whether the loader returns raw records or a data storage object.
- Update sequence loading functions (`load_seq`, `load_unaligned_seqs`, `load_aligned_seqs`) to use the parser plugin instance and handle the `result_is_storage` property.
- Remove the internal `_load_seqs` helper function, integrating its logic into the main loading functions.