### PR TITLE
MAINT: make repr of SequenceCollection and Alignment consistent

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -2184,7 +2184,7 @@ class SequenceCollection:
 
         seqs = ", ".join(seqs)
 
-        return f"{len(self.names)}x ({seqs}) {self.moltype.label} seqcollection"
+        return f"{len(self.names)}x {self.moltype.label} seqcollection: ({seqs})"
 
     def _repr_html_(self) -> str:
         settings = self._repr_policy.copy()

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -790,7 +790,7 @@ def test_sequence_collection_repr():
     seqs = new_alignment.make_unaligned_seqs(data, moltype="dna")
     assert (
         repr(seqs)
-        == "2x (ENSMUSG00000039616[GCCCTTCAAA...], ENSMUSG00000056468[GCCAGGGGGA...]) dna seqcollection"
+        == "2x dna seqcollection: (ENSMUSG00000039616[GCCCTTCAAA...], ENSMUSG00000056468[GCCAGGGGGA...])"
     )
 
     data = {
@@ -800,20 +800,20 @@ def test_sequence_collection_repr():
     seqs = new_alignment.make_unaligned_seqs(data, moltype="dna")
     assert (
         repr(seqs)
-        == "2x (ENSMUSG00000039616[GCCCTTCAAA...], ENSMUSG00000056468[GCCAGGGGGA...]) dna seqcollection"
+        == "2x dna seqcollection: (ENSMUSG00000039616[GCCCTTCAAA...], ENSMUSG00000056468[GCCAGGGGGA...])"
     )
 
     data = {
         "a": "TCGAT",
     }
     seqs = new_alignment.make_unaligned_seqs(data, moltype="dna")
-    assert repr(seqs) == "1x (a[TCGAT]) dna seqcollection"
+    assert repr(seqs) == "1x dna seqcollection: (a[TCGAT])"
 
     data = {
         "a": "TCGAT" * 2,
     }
     seqs = new_alignment.make_unaligned_seqs(data, moltype="dna")
-    assert repr(seqs) == "1x (a[TCGATTCGAT]) dna seqcollection"
+    assert repr(seqs) == "1x dna seqcollection: (a[TCGATTCGAT])"
 
 
 def test_sequence_collection_set_wrap_affects_repr_html():

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -815,6 +815,10 @@ def test_sequence_collection_repr():
     seqs = new_alignment.make_unaligned_seqs(data, moltype="dna")
     assert repr(seqs) == "1x dna seqcollection: (a[TCGATTCGAT])"
 
+    data = {"a": "", "b": ""}
+    seqs = new_alignment.make_unaligned_seqs(data, moltype="dna")
+    assert repr(seqs) == "2x dna seqcollection: (a[], b[])"
+
 
 def test_sequence_collection_set_wrap_affects_repr_html():
     """the wrap argument affects the number of columns"""


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update the `SequenceCollection` `repr` format to place the moltype and class name before the sequence list, separated by a colon.