### PR TITLE
ENH: add support for seq storage drivers

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -8,6 +8,7 @@ import warnings
 from collections.abc import Callable
 
 from cogent3._dataset import available_datasets, get_dataset  # noqa: F401
+from cogent3._plugin import set_storage_defaults  # noqa: F401
 from cogent3._version import __version__
 from cogent3.app import (  # noqa: F401
     app_help,


### PR DESCRIPTION
[NEW] we provide entry points for two different types of sequence
     storage backends: unaligned and aligned. Each must inherit from
     the appropriate SeqsDataABC or AlignedSeqsDataABC base classes.
     Their class methods are used to create the instance assigned as
     the storage backend. This choice also made available in the degap()
     method which creates a new type. Developers of custom storage plugins
     can provide format parser and format writer plugins using the
     base classes defined in parse.sequence and format.sequence.

[NEW] top level cogent3.set_storage_defaults() function for defining
     default storage drivers for unaligned and aligned sequences.

[CHANGED] changed the API of the prep_for_seqs_data() function. It now
     takes only a dict[name, seq] mapping. It also no longer returns
     the name_map. This is now handled by the new `make_name_map()`
     function. Renaming of seqs is now handled in that function too.

## Summary by Sourcery

Introduce a pluggable storage backend system for sequence data, enabling custom storage solutions for both unaligned and aligned sequences.

New Features:
- Define entry points for registering unaligned (`cogent3.storage.unaligned_seqs`) and aligned (`cogent3.storage.aligned_seqs`) sequence storage driver plugins.
- Add the `set_storage_defaults` function to configure default storage drivers globally.

Enhancements:
- Refactor sequence data preparation, input coercion, and name mapping logic into distinct internal functions.
- Update sequence collection and alignment factory functions (`make_unaligned_seqs`, `make_aligned_seqs`) to utilize the storage backend system.
- Allow specifying a storage backend via the `storage_backend` parameter in `degap` methods.