### PR TITLE
ENH: added new duplicated_seqs() method

### DIFF
--- a/changelog.d/20250406_125550_Gavin.Huttley.md
+++ b/changelog.d/20250406_125550_Gavin.Huttley.md
@@ -30,6 +30,9 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   with cogent3! The main brca1 alignment and associated Murphy tree are now
   included with the package. Use `cogent3.available_datasets()` and
   `cogent3.get_dataset()` to create the instances that use these.
+- Added `duplicated_seqs()` method to new type SequenceCollection and Alignments.
+  As the name implies, it identifies the names of sequences that are equal. On
+  Alignments, the gapped sequence is used.
 
 <!--
 ### BUG

--- a/changelog.d/20250406_125550_Gavin.Huttley.md
+++ b/changelog.d/20250406_125550_Gavin.Huttley.md
@@ -32,7 +32,9 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   `cogent3.get_dataset()` to create the instances that use these.
 - Added `duplicated_seqs()` method to new type SequenceCollection and Alignments.
   As the name implies, it identifies the names of sequences that are equal. On
-  Alignments, the gapped sequence is used.
+  Alignments, the gapped sequence is used. Added companion method
+  `drop_duplicated_seqs()` which does as the name implies. The first name in each
+  group of duplicates is retained.
 
 <!--
 ### BUG

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -2426,6 +2426,22 @@ class SequenceCollection:
             seq_hashes[array_hash64(numpy.array(s))].append(s.name)
         return [v for v in seq_hashes.values() if len(v) > 1]
 
+    def drop_duplicated_seqs(self) -> typing_extensions.Self:
+        """returns self without duplicated sequences
+
+        Notes
+        -----
+        Retains the first sequence of each duplicte group.
+        """
+        dupes = self.duplicated_seqs()
+        if not dupes:
+            return self
+
+        omit = []
+        for group in dupes:
+            omit.extend(group[1:])
+        return self.take_seqs(omit, negate=True)
+
 
 @register_deserialiser(get_object_provenance(SequenceCollection))
 def deserialise_sequence_collection(data: dict) -> SequenceCollection:

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -5950,3 +5950,44 @@ def test_duplicated_seqs_no_duplicates(mk_cls):
     seqcoll = mk_cls(data, moltype="dna")
     got = [set(v) for v in seqcoll.duplicated_seqs()]
     assert got == []
+
+
+@pytest.mark.parametrize(
+    "mk_cls", [new_alignment.make_aligned_seqs, new_alignment.make_unaligned_seqs]
+)
+def test_drop_duplicated_seqs(mk_cls):
+    data = {
+        "seq1": "ATC-G",
+        "seq2": "TAGCC",
+        "seq1-1": "ATC-G",
+        "seq2-1": "TAGCC",
+        "seq2-2": "TAGCC",
+        "seq2-3": "TAGCC",
+    }
+    seqcoll = mk_cls(data, moltype="dna")
+    got = seqcoll.drop_duplicated_seqs()
+    names = set(got.names)
+    assert len(names & {"seq1", "seq1-1"}) == 1
+    assert len(names & {"seq2", "seq2-1", "seq2-2", "seq2-3"}) == 1
+
+    # on a collection with zero length seqs
+    data = {
+        "seq1": "",
+        "seq2": "",
+    }
+    seqcoll = mk_cls(data, moltype="dna")
+    got = seqcoll.drop_duplicated_seqs()
+
+
+@pytest.mark.parametrize(
+    "mk_cls", [new_alignment.make_aligned_seqs, new_alignment.make_unaligned_seqs]
+)
+def test_drop_duplicated_seqs_no_dupes(mk_cls):
+    data = {
+        "seq1": "ATC-G",
+        "seq2": "TAGCC",
+        "seq3": "T-GCC",
+    }
+    seqcoll = mk_cls(data, moltype="dna")
+    got = seqcoll.drop_duplicated_seqs()
+    assert got is seqcoll


### PR DESCRIPTION
[NEW] on new type sequence collections. Returns list of list of sequence
    names whose hashes are equal.

## Summary by Sourcery

Add a new method `duplicated_seqs()` to SequenceCollection and Alignment classes to identify sequences with identical content

New Features:
- Added `duplicated_seqs()` method to identify sequences with identical content in SequenceCollection and Alignment classes

Enhancements:
- Implemented a hash-based approach to detect duplicate sequences
- Supports both aligned and unaligned sequence collections

Tests:
- Added comprehensive test cases for `duplicated_seqs()` method with various sequence scenarios