### PR TITLE
DEV: add cogenr3-h5seqs as a testing dependency now its on PyPI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,11 +22,6 @@ def test_slow(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    # the following line is temporary until we have both
-    # cogent3-h5seqs and cogent3 with driver support on pypi
-    session.install(
-        "cogent3-h5seqs @ git+https://github.com/GavinHuttley/cogent3-h5seqs.git@develop",
-    )
     session.install("-e.[test]")
     session.run("pip", "list")
     # doctest modules within cogent3/app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Changelog = "https://github.com/cogent3/cogent3/blob/develop/changelog.md"
 
 [project.optional-dependencies]
 test = [
+    "cogent3-h5seqs",
     "ruff==0.11.8",
     "kaleido",
     "pandas",


### PR DESCRIPTION
## Summary by Sourcery

Add cogent3-h5seqs as a testing dependency from PyPI

Chores:
- Removed manual git installation of cogent3-h5seqs
- Added cogent3-h5seqs to test dependencies in pyproject.toml