### PR TITLE
MAINT: make the seq storage to_alphabet() exception types consistent

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -589,9 +589,7 @@ class SeqsData(SeqsDataABC):
                     f"Changing from old alphabet={self.alphabet} to new "
                     f"{alphabet=} is not valid for this data"
                 )
-                raise new_alphabet.AlphabetError(
-                    msg,
-                )
+                raise new_alphabet.AlphabetError(msg)
             new_data[seqid] = as_new_alpha
 
         return self.copy(
@@ -4103,9 +4101,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
                     f"Changing from old alphabet={self.alphabet} to new "
                     f"{alphabet=} is not valid for this data"
                 )
-                raise new_moltype.MolTypeError(
-                    msg,
-                )
+                raise new_alphabet.AlphabetError(msg)
             gapped[i] = as_new_alpha
 
         return self.__class__(

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -2208,7 +2208,7 @@ def test_to_dna():
     assert dna.moltype.label == "dna"
     # should fail if invalid character set
     paln = dna.get_translation()
-    with pytest.raises(new_moltype.MolTypeError):
+    with pytest.raises(new_alphabet.AlphabetError):
         _ = paln.to_dna()
 
 


### PR DESCRIPTION
[CHANGED] SeqsData.to_alphabet() and AlignedSeqsData.to_alphabet() now
    both raise an AlphabetError if data inconsistent

## Summary by Sourcery

Unify exception handling in sequence storage to_alphabet() methods by consistently raising AlphabetError for data inconsistencies and update related tests accordingly.

Bug Fixes:
- Standardize exception type to AlphabetError for inconsistent data in to_alphabet() methods.

Tests:
- Update tests to expect AlphabetError instead of MolTypeError for to_alphabet() failures.