### PR TITLE
MAINT: more type hints and style mods

### DIFF
--- a/src/cogent3/align/align.py
+++ b/src/cogent3/align/align.py
@@ -4,8 +4,10 @@ from cogent3.align import indel_model, pairwise
 from cogent3.evolve.likelihood_tree import make_likelihood_tree_leaf
 
 
-def make_dna_scoring_dict(match, transition, transversion):
-    DNA = {}
+def make_dna_scoring_dict(
+    match: float, transition: float, transversion: float
+) -> dict[tuple[str, str], float]:
+    score_mat = {}
     for a in "ATCG":
         ar = a in "AG"
         for b in "ATCG":
@@ -16,8 +18,8 @@ def make_dna_scoring_dict(match, transition, transversion):
                 score = transition
             else:
                 score = transversion
-            DNA[a, b] = score
-    return DNA
+            score_mat[a, b] = score
+    return score_mat
 
 
 def make_generic_scoring_dict(match, mtype):

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -1,8 +1,8 @@
 import os
+import typing
 import warnings
 from bisect import bisect_left
 from itertools import combinations
-from typing import Union
 
 from numpy import array, isnan
 
@@ -32,6 +32,9 @@ if _NEW_TYPE:
     from cogent3.core.new_alignment import Aligned
 else:
     from cogent3.core.alignment import Aligned
+
+if typing.TYPE_CHECKING:
+    from cogent3.core.tree import PhyloNode
 
 
 class _GapOffset:
@@ -346,10 +349,10 @@ class align_to_ref:
     def __init__(
         self,
         ref_seq="longest",
-        score_matrix=None,
-        insertion_penalty=20,
-        extension_penalty=2,
-        moltype="dna",
+        score_matrix: dict[str, float] | None = None,
+        insertion_penalty: float = 20.0,
+        extension_penalty: float = 2.0,
+        moltype: str = "dna",
     ) -> None:
         """
         Parameters
@@ -416,7 +419,7 @@ class align_to_ref:
 
         return pairwise_to_multiple(pwise, ref_seq, self._moltype, info=seqs.info)
 
-    T = Union[SerialisableType, AlignedSeqsType]
+    T = SerialisableType | AlignedSeqsType
 
     def main(self, seqs: UnalignedSeqsType) -> T:
         """return aligned sequences"""
@@ -541,7 +544,7 @@ class progressive_align:
         self._distance = distance
         self._iters = iters
         if callable(guide_tree):
-            self._make_tree = guide_tree
+            self._make_tree: typing.Callable = guide_tree
             guide_tree = None  # callback takes precedence
         elif approx_dists and len(moltype.alphabet) == 4:
             dist_app = dist.get_approx_dist_calc(dist="jc69", num_states=4)
@@ -578,14 +581,14 @@ class progressive_align:
             "iters": self._iters,
         }
 
-    def _build_guide(self, seqs):
+    def _build_guide(self, seqs) -> "PhyloNode":
         tree = self._make_tree(seqs)
         if self._scalar != 1:
             scaler = scale_branches(scalar=self._scalar)
             tree = scaler(tree)
         return tree
 
-    T = Union[SerialisableType, AlignedSeqsType]
+    T = SerialisableType | AlignedSeqsType
 
     def main(self, seqs: UnalignedSeqsType) -> T:
         """returned progressively aligned sequences"""
@@ -597,8 +600,7 @@ class progressive_align:
             if not self._guide_tree:
                 return self._guide_tree
             self._kwargs["tree"] = self._guide_tree
-            diff = set(self._guide_tree.get_tip_names()) ^ set(seqs.names)
-            if diff:
+            if set(self._guide_tree.get_tip_names()) ^ set(seqs.names):
                 len(set(self._guide_tree.get_tip_names()))
                 seqs = seqs.take_seqs(self._guide_tree.get_tip_names())
 
@@ -695,11 +697,11 @@ class smith_waterman:
         self._extension_penalty = extension_penalty
 
     def main(self, seqs: UnalignedSeqsType) -> AlignedSeqsType:
-        if seqs.num_seqs > 2:
+        if seqs.num_seqs != 2:
             return NotCompleted(
                 "ERROR",
                 self,
-                message="maximum number of two seqs per collection",
+                message="requires two seqs per collection",
                 source=seqs,
             )
         seqs = seqs.to_moltype(self.moltype)
@@ -740,7 +742,7 @@ class ic_score:
     Bioinformatics vol. 15 563–577 (Oxford University Press, 1999)
     """
 
-    def __init__(self, equifreq_mprobs=True) -> None:
+    def __init__(self, equifreq_mprobs: bool = True) -> None:
         """
         Parameters
         ----------
@@ -791,8 +793,8 @@ class ic_score:
         counts = counts.array[:, cols]
         frequency = counts / aln.num_seqs
         log_f = safe_log(frequency / p)
-        I_seq = log_f * frequency
-        return I_seq.sum()
+        i_seq = log_f * frequency
+        return i_seq.sum()
 
 
 @define_app

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -544,7 +544,9 @@ class progressive_align:
         self._distance = distance
         self._iters = iters
         if callable(guide_tree):
-            self._make_tree: typing.Callable = guide_tree
+            self._make_tree: typing.Callable[[UnalignedSeqsType], PhyloNode] = (
+                guide_tree
+            )
             guide_tree = None  # callback takes precedence
         elif approx_dists and len(moltype.alphabet) == 4:
             dist_app = dist.get_approx_dist_calc(dist="jc69", num_states=4)

--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -5658,9 +5658,7 @@ class Alignment(SequenceCollection):
         """
         from cogent3.evolve.pairwise_distance_numba import get_distance_calculator
 
-        calc = get_distance_calculator(
-            calc,
-        )
+        calc = get_distance_calculator(calc)
         try:
             result = calc(self, invalid_raises=not drop_invalid, parallel=parallel)
         except ArithmeticError as e:


### PR DESCRIPTION
## Summary by Sourcery

Refine alignment modules by expanding type hint coverage, embracing PEP 604 unions, and tidying style and naming inconsistencies

Enhancements:
- Add explicit type hints to alignment classes, functions, and scoring utilities, adopting PEP 604 union syntax
- Introduce TYPE_CHECKING imports and return type annotations (e.g., PhyloNode) for internal alignment methods
- Rename and type-annotate the DNA scoring dictionary function for improved clarity
- Simplify conditional logic and update error messaging in two-sequence alignment workflows
- Streamline code formatting by removing extraneous commas and renaming inconsistent variables