### PR TITLE
Tweaks to plugin support code

### DIFF
--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -44,10 +44,11 @@ def get_quick_tree_hook(
         name="quick_tree",
         invoke_on_load=False,
     )
-    if name != "cogent3":
+    if name and name != "cogent3":
         for extension in mgr.extensions:
             if name is None or extension.module_name.startswith(name):
                 return extension.plugin()
+
         msg = f"Could not find quick_tree plugin for {name!r}"
         raise ValueError(msg)
 

--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -48,6 +48,8 @@ def get_quick_tree_hook(
         for extension in mgr.extensions:
             if name is None or extension.module_name.startswith(name):
                 return extension.plugin()
+        msg = f"Could not find quick_tree plugin for {name!r}"
+        raise ValueError(msg)
 
     return cogent3.get_app("quick_tree")
 
@@ -185,7 +187,7 @@ def _get_driver(namespace: str, storage_backend: str) -> stevedore.driver.Driver
 
 
 def get_unaligned_storage_driver(
-    storage_backend: str,
+    storage_backend: str | None,
 ) -> typing.Optional["SeqsDataABC"]:
     """returns unaligned sequence storage driver
 
@@ -205,7 +207,7 @@ ALIGNED_SEQ_STORAGE_ENTRY_POINT = "cogent3.storage.aligned_seqs"
 
 
 def get_aligned_storage_driver(
-    storage_backend: str,
+    storage_backend: str | None,
 ) -> typing.Optional["AlignedSeqsDataABC"]:
     """returns aligned sequence storage driver
 

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -4914,7 +4914,7 @@ def brca1_data():
 
 
 @pytest.mark.parametrize("calc", ["hamming", None])
-@pytest.mark.parametrize("use_hook", ["cogent3", None, "not present"])
+@pytest.mark.parametrize("use_hook", ["cogent3", None])
 def test_alignment_quick_tree(calc, brca1_data, use_hook):
     """quick tree method returns tree"""
     aln = new_alignment.make_aligned_seqs(brca1_data, moltype="dna")[:100]
@@ -4923,6 +4923,13 @@ def test_alignment_quick_tree(calc, brca1_data, use_hook):
     kwargs = {**kwargs, "calc": calc} if calc else kwargs
     tree = aln.quick_tree(**kwargs)
     assert set(tree.get_tip_names()) == set(aln.names)
+
+
+def test_alignment_quick_tree_missing_hook(brca1_data):
+    aln = new_alignment.make_aligned_seqs(brca1_data, moltype="dna")[:100]
+    aln = aln.take_seqs(["Human", "Rhesus", "HowlerMon", "Galago", "Mouse"])
+    with pytest.raises(ValueError):
+        aln.quick_tree(use_hook="missing_hook")
 
 
 @pytest.mark.skipif(not has_piqtree, reason="piqtree not installed")

--- a/tests/test_evolve/test_distance.py
+++ b/tests/test_evolve/test_distance.py
@@ -854,7 +854,7 @@ def test_take_dists():
     assert_allclose(got1.array.astype(float), got2.array.astype(float))
 
 
-@pytest.mark.parametrize("use_hook", ["cogent3", None, "not present"])
+@pytest.mark.parametrize("use_hook", ["cogent3", None])
 def test_build_phylogeny(use_hook):
     """build a NJ tree"""
     from cogent3 import make_tree


### PR DESCRIPTION
## Summary by Sourcery

Add explicit error for missing quick_tree plugin and allow optional storage_backend in storage driver getters

Bug Fixes:
- Raise ValueError in get_quick_tree_hook when no matching plugin extension is found

Enhancements:
- Accept None for storage_backend parameter in get_unaligned_storage_driver and get_aligned_storage_driver

Tests:
- Remove invalid "not present" hook parameter and add test to verify error is raised for missing quick_tree hook