### PR TITLE
MAINT: improved type hints

### DIFF
--- a/src/cogent3/core/new_alphabet.py
+++ b/src/cogent3/core/new_alphabet.py
@@ -17,13 +17,13 @@ if typing.TYPE_CHECKING:
 
 NumpyIntType = numpy.dtype[numpy.integer]
 NumpyIntArrayType = numpy.typing.NDArray[numpy.integer]
-StrORBytes = str | bytes
-StrORArray = str | NumpyIntArrayType
-StrORBytesORArray = str | bytes | NumpyIntArrayType
+StrORBytes = typing.TypeVar("StrORBytes", str, bytes)
+StrORArray = typing.TypeVar("StrORArray", str, NumpyIntArrayType)
+StrORBytesORArray = typing.TypeVar("StrORBytesORArray", str, bytes, NumpyIntArrayType)
 OptInt = int | None
 OptStr = str | None
 OptBytes = bytes | None
-PySeqStrOrBytes = typing.Sequence[str | bytes]
+PySeqStrOrBytes = typing.Sequence[str] | typing.Sequence[bytes]
 
 
 @functools.singledispatch

--- a/src/cogent3/core/new_alphabet.py
+++ b/src/cogent3/core/new_alphabet.py
@@ -293,7 +293,7 @@ class CharAlphabet(tuple, AlphabetABC, MonomerAlphabetABC):
 
     def __new__(
         cls,
-        chars: typing.Sequence[StrORBytes],
+        chars: typing.Sequence[StrORBytes] | str | bytes,
         gap: OptStr = None,
         missing: OptStr = None,
     ) -> "CharAlphabet":
@@ -329,7 +329,7 @@ class CharAlphabet(tuple, AlphabetABC, MonomerAlphabetABC):
 
     def __init__(
         self,
-        chars: typing.Sequence[StrORBytes],
+        chars: typing.Sequence[StrORBytes] | str | bytes,  # noqa: ARG002
         gap: OptStr = None,
         missing: OptStr = None,
     ) -> None:
@@ -1419,9 +1419,9 @@ _alphabet_moltype_map = {}
 
 def make_alphabet(
     *,
-    chars: typing.Sequence[str],
-    gap: str | None,
-    missing: str | None,
+    chars: typing.Sequence[str | bytes] | str | bytes,
+    gap: str | bytes | None,
+    missing: str | bytes | None,
     moltype: "MolType",
 ) -> CharAlphabet:
     """constructs a character alphabet and registers the associated moltype

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -16,17 +16,17 @@ from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.misc import get_object_provenance
 
 if typing.TYPE_CHECKING:
-    from cogent3.core.sequence import SeqViewABC
+    from cogent3.core.new_sequence import SeqViewABC
 
-OptStr = typing.Optional[str]
-OptFloat = typing.Optional[float]
-OptCallable = typing.Optional[typing.Callable]
-SeqStrType = typing.Union[list[str], tuple[str, ...]]
-StrORBytes = typing.Union[str, bytes]
-StrORArray = typing.Union[str, numpy.ndarray]
-StrORBytesORArray = typing.Union[str, bytes, numpy.ndarray]
-SeqStrBytesType = typing.Union[list[StrORBytes], tuple[StrORBytes, ...]]
-OptTranslater = typing.Optional[typing.Callable[[bytes], bytes]]
+NumpyIntType = numpy.dtype[numpy.integer]
+NumpyIntArrayType = numpy.typing.NDArray[numpy.integer]
+OptStr = str | None
+OptFloat = float | None
+OptCallable = typing.Callable | None
+StrORBytes = typing.TypeVar("StrORBytes", str, bytes)
+StrORArray = typing.TypeVar("StrORArray", str, NumpyIntArrayType)
+StrORBytesORArray = typing.TypeVar("StrORBytesORArray", str, bytes, NumpyIntArrayType)
+OptTranslater = typing.Callable[[bytes], bytes] | None
 
 
 IUPAC_gap = "-"
@@ -385,13 +385,7 @@ AA_COLORS = _expand_colors(
 )
 
 
-def _strictly_upper(monomers: tuple[StrORBytes]):
-    """whether all elements correspond to upper case characters"""
-    cast = str if isinstance(monomers[0], str) else chr
-    return all(cast(c).isupper() for c in monomers)
-
-
-def _combined_chars(*parts) -> str | bytes:
+def _combined_chars(*parts: StrORBytes) -> StrORBytes:
     concat = parts[0]
     for part in parts[1:]:
         if not part or part in concat:

--- a/src/cogent3/core/new_moltype.py
+++ b/src/cogent3/core/new_moltype.py
@@ -391,7 +391,7 @@ def _strictly_upper(monomers: tuple[StrORBytes]):
     return all(cast(c).isupper() for c in monomers)
 
 
-def _combined_chars(*parts):
+def _combined_chars(*parts) -> str | bytes:
     concat = parts[0]
     for part in parts[1:]:
         if not part or part in concat:


### PR DESCRIPTION
## Summary by Sourcery

Enhance type annotations to accept both str and bytes for character alphabets and related parameters, and annotate helper return types

Enhancements:
- Broaden CharAlphabet constructors and make_alphabet function to accept str|bytes alongside sequence types for chars
- Extend gap and missing parameters to accept bytes in addition to str or None
- Add explicit return type annotation (str|bytes) to the _combined_chars helper function