### PR TITLE
ENH: Check all immediate children for presence of support

### DIFF
--- a/src/cogent3/draw/dendrogram.py
+++ b/src/cogent3/draw/dendrogram.py
@@ -555,7 +555,7 @@ class Dendrogram(Drawable):
         self._length_attr = self.tree._length
         self._tip_names = tuple(e.name for e in self.tree.tips())
         self._max_label_length = max(map(len, self._tip_names))
-        if "support" not in self.tree.children[0].params:
+        if all("support" not in child.params for child in self.tree.children):
             show_support = False
         self._show_support = show_support
         self._threshold = threshold


### PR DESCRIPTION
When drawing a dendrogram, if the first child is a tip, then this won't contain IQ-TREE's ultrafast bootstrap support. This leads to support not being drawn on many trees.

Separately, the default threshold for drawing support is 1.0 - support values above this will not be drawn unless it's set to be higher. IQ-TREE uses 100 as the maximum support - should the default threshold be increased? 

Alternative as just discussed, have a `support_as_percentage` or proportion boolean value

## Summary by Sourcery

Enhancements:
- Check all immediate children for support parameters before disabling support display instead of only inspecting the first child