### PR TITLE
Bug fix for parallel

### DIFF
--- a/changelog.d/20250604_092738_Gavin.Huttley.md
+++ b/changelog.d/20250604_092738_Gavin.Huttley.md
@@ -4,12 +4,12 @@ A new scriv changelog fragment.
 Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 
-<!--
+
 ### Contributors
 
-- A bullet item for the Contributors category.
+- rmcar17, fixed display of support in dendrograms
+- GavinHuttley, MPI rank check fix
 
--->
 <!--
 ### Enhancements
 
@@ -22,7 +22,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - cogent3.util.parallel.is_master_process() now works correctly
   when running using MPI. This was affecting the ability to create
   data stores when running with MPI.
-
+- fix for displaying support statistics on dendrograms
 
 <!--
 ### Documentation

--- a/changelog.d/20250604_092738_Gavin.Huttley.md
+++ b/changelog.d/20250604_092738_Gavin.Huttley.md
@@ -1,0 +1,44 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Contributors
+
+- A bullet item for the Contributors category.
+
+-->
+<!--
+### Enhancements
+
+- A bullet item for the Enhancements category.
+
+-->
+
+### Bug fixes
+
+- cogent3.util.parallel.is_master_process() now works correctly
+  when running using MPI. This was affecting the ability to create
+  data stores when running with MPI.
+
+
+<!--
+### Documentation
+
+- A bullet item for the Documentation category.
+
+-->
+<!--
+### Deprecations
+
+- A bullet item for the Deprecations category.
+
+-->
+<!--
+### Discontinued
+
+- A bullet item for the Discontinued category.
+
+-->

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,18 +76,18 @@ def testmpi(session):
     session.install("-e.[test]")
     session.install("mpi4py")
     py = pathlib.Path(session.bin_paths[0]) / "python"
-    session.chdir("tests")
+    session.chdir("tests/test_app")
     session.run(
         "mpiexec",
         "-n",
-        "2",
+        "4",
         str(py),
         "-m",
         "mpi4py.futures",
         "-m",
         "pytest",
         "-x",
-        "test_app/test_app_mpi.py",
+        "test_app_mpi.py",
         external=True,
     )
 

--- a/src/cogent3/format/bedgraph.py
+++ b/src/cogent3/format/bedgraph.py
@@ -53,7 +53,7 @@ def raise_invalid_vals(key, val) -> bool | None:
     if str(val) not in valid_values[key]:
         raise AssertionError(
             "Invalid bedgraph key/val pair: "
-            + f"got {key}={val}; valid values are {valid_values[key]}",
+            f"got {key}={val}; valid values are {valid_values[key]}",
         )
     return None
 
@@ -67,7 +67,7 @@ def get_header(name=None, description=None, color=None, **kwargs):
     """returns header line for bedgraph"""
     min_header = (
         'track type=bedGraph name="%(name)s" '
-        + 'description="%(description)s" color=%(color)s'
+        'description="%(description)s" color=%(color)s'
     )
 
     assert None not in (name, description, color)

--- a/src/cogent3/format/nexus.py
+++ b/src/cogent3/format/nexus.py
@@ -16,7 +16,7 @@ def nexus_from_alignment(aln, seq_type, wrap=50):
     if aln.is_ragged():
         raise ValueError(
             "Sequences in alignment are not all the same "
-            + "length. Cannot generate NEXUS format.",
+            "length. Cannot generate NEXUS format.",
         )
     num_seq = len(aln.seqs)
     if not aln or not num_seq:

--- a/src/cogent3/util/parallel.py
+++ b/src/cogent3/util/parallel.py
@@ -47,7 +47,7 @@ def get_size():
 SIZE = get_size()
 
 
-def is_master_process():
+def is_master_process() -> bool:
     """
     Evaluates if current process is master
 
@@ -66,7 +66,9 @@ def is_master_process():
     process_file = process_cmd.split(os.sep)[-1]
     if process_file == "server.py":
         return False
-    return None
+
+    comm = MPI.COMM_WORLD
+    return comm.Get_rank() == 0
 
 
 class PicklableAndCallable:

--- a/tests/test_app/test_app_mpi.py
+++ b/tests/test_app/test_app_mpi.py
@@ -36,3 +36,21 @@ def test_write_db(tmp_dir):
     got = [str(m) for m in result]
 
     assert got == expect
+
+
+def is_master(n):
+    return parallel.is_master_process()
+
+
+def test_is_master_process():
+    """
+    is_master_process() should return False
+    for all child processes
+    """
+    assert parallel.is_master_process()  # this should be master!
+    index = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    # but workers should not
+    master_processes = sum(
+        bool(result) for result in parallel.imap(is_master, index, use_mpi=True)
+    )
+    assert master_processes == 0

--- a/tests/test_format/test_bedgraph.py
+++ b/tests/test_format/test_bedgraph.py
@@ -21,7 +21,7 @@ class FormatBedgraph(TestCase):
         assert bgraph, "\n".join(
             [
                 'track type=bedGraph name="test track" '
-                + 'description="test of bedgraph" color=255,0,0',
+                'description="test of bedgraph" color=255,0,0',
                 "1\t100\t110\t0",
                 "1\t150\t160\t10",
             ],
@@ -43,7 +43,7 @@ class FormatBedgraph(TestCase):
         assert bgraph, "\n".join(
             [
                 'track type=bedGraph name="test track" '
-                + 'description="test of bedgraph" color=255,0,0',
+                'description="test of bedgraph" color=255,0,0',
                 "1\t100\t120\t0",
                 "1\t150\t160\t10",
             ],
@@ -66,7 +66,7 @@ class FormatBedgraph(TestCase):
         assert bgraph, "\n".join(
             [
                 'track type=bedGraph name="test track" '
-                + 'description="test of bedgraph" color=255,0,0',
+                'description="test of bedgraph" color=255,0,0',
                 "1\t100\t120\t1",
                 "1\t150\t160\t10",
                 "2\t105\t120\t1",
@@ -125,7 +125,7 @@ class FormatBedgraph(TestCase):
         assert bgraph, "\n".join(
             [
                 'track type=bedGraph name="test track" '
-                + 'description="test of bedgraph" color=255,0,0 autoScale=on',
+                'description="test of bedgraph" color=255,0,0 autoScale=on',
                 "1\t100\t110\t1",
                 "1\t150\t160\t10",
             ],
@@ -149,7 +149,7 @@ class FormatBedgraph(TestCase):
         assert bgraph, "\n".join(
             [
                 'track type=bedGraph name="test track" '
-                + 'description="test of bedgraph" color=255,0,0 smoothingWindow=10',
+                'description="test of bedgraph" color=255,0,0 smoothingWindow=10',
                 "1\t100\t110\t1",
                 "1\t150\t160\t10",
             ],

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -336,9 +336,8 @@ ORIGIN
         assert result["reference"] == "2  (bases 1 to 2587)"
         assert result["authors"] == "Janzen,D.M. and Geballe,A.P."
         assert (
-            result["title"]
-            == "The effect of eukaryotic release factor depletion "
-            + "on translation termination in human cell lines"
+            result["title"] == "The effect of eukaryotic release factor depletion "
+            "on translation termination in human cell lines"
         )
         assert result["journal"] == "(er) Nucleic Acids Res. 32 (15), 4491-4502 (2004)"
         assert result["pubmed"] == "15326224"


### PR DESCRIPTION
## Summary by Sourcery

Fix MPI master process detection, add corresponding tests, update MPI test configuration, clean up string concatenations, and add changelog entries.

Bug Fixes:
- Parallel.is_master_process() now correctly returns True only for the MPI rank 0 process and False for workers
- Fixed display of support statistics on dendrograms

Enhancements:
- Remove redundant string concatenation in bedgraph, nexus format code, and related tests for cleaner string literal usage

CI:
- Update noxfile MPI test session to run in the correct directory, use four processes, and adjust pytest invocation

Documentation:
- Add changelog fragment for MPI rank check fix and dendrogram support display fix

Tests:
- Add tests to verify master and worker behavior of is_master_process in MPI context