### PR TITLE
MAINT: app writers return not completed if no ID inferrable

### DIFF
--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -540,7 +540,7 @@ class write_json:
     def __init__(
         self,
         data_store: DataStoreABC,
-        id_from_source: callable = get_unique_id,
+        id_from_source: typing.Callable[[object], str | None] = get_unique_id,
     ) -> None:
         """
         Parameters
@@ -571,6 +571,12 @@ class write_json:
         identifier: str | None = None,
     ) -> IdentifierType:
         identifier = identifier or self._id_from_source(data)
+        if identifier is None:
+            msg = "identifier cannot be None"
+            return NotCompleted(
+                type="ERROR", origin=self, message=msg, source="unknown"
+            )
+
         if isinstance(data, NotCompleted):
             return self.data_store.write_not_completed(
                 unique_id=f"{identifier}.json",
@@ -589,7 +595,7 @@ class write_seqs:
     def __init__(
         self,
         data_store: DataStoreABC,
-        id_from_source: callable = get_unique_id,
+        id_from_source: typing.Callable[[object], str | None] = get_unique_id,
         format: str = "fasta",
     ) -> None:
         """
@@ -625,6 +631,12 @@ class write_seqs:
         identifier: str | None = None,
     ) -> IdentifierType:
         identifier = identifier or self._id_from_source(data)
+        if identifier is None:
+            msg = "identifier cannot be None"
+            return NotCompleted(
+                type="ERROR", origin=self, message=msg, source="unknown"
+            )
+
         if isinstance(data, NotCompleted):
             return self.data_store.write_not_completed(
                 unique_id=f"{identifier}.json",
@@ -642,7 +654,7 @@ class write_tabular:
     def __init__(
         self,
         data_store: DataStoreABC,
-        id_from_source: callable = get_unique_id,
+        id_from_source: typing.Callable[[object], str | None] = get_unique_id,
         format: str = "tsv",
     ) -> None:
         """
@@ -674,6 +686,12 @@ class write_tabular:
         identifier: str | None = None,
     ) -> IdentifierType:
         identifier = identifier or self._id_from_source(data)
+        if identifier is None:
+            msg = "identifier cannot be None"
+            return NotCompleted(
+                type="ERROR", origin=self, message=msg, source="unknown"
+            )
+
         if isinstance(data, NotCompleted):
             return self.data_store.write_not_completed(
                 unique_id=f"{identifier}.json",
@@ -694,7 +712,7 @@ class write_db:
     def __init__(
         self,
         data_store: DataStoreABC,
-        id_from_source: callable = get_unique_id,
+        id_from_source: typing.Callable[[object], str | None] = get_unique_id,
         serialiser: callable = DEFAULT_SERIALISER,
     ) -> None:
         """
@@ -727,8 +745,13 @@ class write_db:
         identifier: str | None = None,
     ) -> IdentifierType:
         identifier = identifier or self._id_from_source(data)
-        blob = self._serialiser(data)
+        if identifier is None:
+            msg = "identifier cannot be None"
+            return NotCompleted(
+                type="ERROR", origin=self, message=msg, source="unknown"
+            )
 
+        blob = self._serialiser(data)
         if isinstance(data, NotCompleted):
             return self.data_store.write_not_completed(unique_id=identifier, data=blob)
 

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -527,6 +527,11 @@ def test_get_unique_id(name):
     assert got == "name"
 
 
+def test_get_unique_id_none():
+    got = get_unique_id(None)
+    assert got is None
+
+
 @pytest.mark.parametrize("data", [{}, set(), {"info": {}}])
 def test_get_data_source_none(data):
     assert get_data_source(data) is None

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -589,6 +589,25 @@ def test_writer_unique_id_arg(tmp_dir, writer, data, dstore):
 
 
 @pytest.mark.parametrize(
+    ("writer", "data", "attr", "dstore"),
+    [
+        ("write_seqs", seqs(), "info", dir_dstore),
+        ("write_db", seqs(), "info", db_dstore),
+        ("write_json", seqs(), "info", dir_dstore),
+        ("write_tabular", table(), "source", dir_dstore),
+    ],
+)
+def test_writer_no_unique_id(tmp_dir, writer, data, attr, dstore):
+    writer = get_app(writer, data_store=dstore(tmp_dir))
+    # no unique id possible, so m will be NotCompleted error
+    value = {} if attr == "info" else None
+    setattr(data, attr, value)
+    m = writer(data)
+    assert isinstance(m, NotCompleted)
+    assert m.type == "ERROR"
+
+
+@pytest.mark.parametrize(
     "writer",
     [
         "write_seqs",


### PR DESCRIPTION
## Summary by Sourcery

Handle cases where no identifier can be inferred in app writers by returning a NotCompleted error, update id_from_source type hints to allow None, and add corresponding tests.

Enhancements:
- Allow id_from_source to return None and early-return a NotCompleted error in writers when no identifier is available
- Update writer constructor signatures to accept Callable returning Optional[str]

Tests:
- Add parameterized tests to ensure writers return NotCompleted with ERROR when no unique ID can be inferred
- Add a test to verify get_unique_id returns None for None input