### PR TITLE
DEV: use uv for github action and pin python 3.13.3

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.3"]
 
     steps:
       - uses: "actions/checkout@v4"
@@ -32,11 +32,16 @@ jobs:
         with:
             python-version: "${{ matrix.python-version }}"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
       - name: "Installs for ${{ matrix.python-version }}"
         run: |
-          python --version
-          pip install --upgrade pip wheel setuptools flit
-          pip install --upgrade nox
+          uv venv venv -p python${{ matrix.python-version }}
+          uv tool install -p venv nox
 
       - name: "Run nox for ${{ matrix.python-version }}"
         shell: bash
@@ -45,7 +50,7 @@ jobs:
           echo "$dn"
           cov="--cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov cogent3 --cov-config=${dn}/.coveragerc"
           echo "$cov"
-          nox -s test-${{ matrix.python-version }} -- $cov
+          nox  -db uv --force-python python -s test -- $cov
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
[CHANGED] addressing incompatibility betwen numba and python 3.13.4
    by pinning to the previous minor release.