### PR TITLE
Fixed newick formatting bug

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -878,10 +878,10 @@ class TreeNode:
         semicolon
             end tree string with a semicolon
         escape_name
-            if any of these characters []'"(),
+            if any of these characters []'"() are within the
             nodes name, wrap the name in single quotes
         with_node_names
-            includes internal node names (except 'root')
+            includes internal node names
         """
         if not self.is_tip() and not with_node_names:
             # if not a tip and not with node names, don't include name

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -1375,18 +1375,12 @@ class TreeNode:
             ]
         )
 
-    def _get_node_matching_name(self, name):
-        """
-        find the edge with the name, or return None
-        """
+    def get_node_matching_name(self, name: str) -> typing_extensions.Self | None:
+        """find the edge with the name, or return None"""
         for node in self.traverse(self_before=True, self_after=False):
             if node.name == name:
-                return node
-        return None
-
-    def get_node_matching_name(self, name):
-        node = self._get_node_matching_name(name)
-        if node is None:
+                break
+        else:
             msg = f"No node named '{name}' in {self.get_tip_names()}"
             raise TreeError(msg)
         return node

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -1357,8 +1357,13 @@ class TreeNode:
             ]
         )
 
-    def get_node_matching_name(self, name: str) -> typing_extensions.Self | None:
-        """find the edge with the name, or return None"""
+    def get_node_matching_name(self, name: str) -> typing_extensions.Self:
+        """find the edge with the name
+
+        Raises
+        -------
+        TreeError if no edge with the name is found
+        """
         for node in self.traverse(self_before=True, self_after=False):
             if node.name == name:
                 break

--- a/src/cogent3/evolve/parameter_controller.py
+++ b/src/cogent3/evolve/parameter_controller.py
@@ -318,7 +318,7 @@ class _LikelihoodParameterController(_LF):
 
             edge_sets = [
                 {"edges": [n]}
-                for n in self.tree.get_node_names(includeself=False)
+                for n in self.tree.get_node_names(include_self=False)
                 if n not in exclude_edges
             ]
         elif type(edge_sets) == dict:

--- a/src/cogent3/parse/ncbi_taxonomy.py
+++ b/src/cogent3/parse/ncbi_taxonomy.py
@@ -229,7 +229,7 @@ class NcbiTaxonomy:
                         )
                     deadbeats[t.ParentId] = t
         self.Deadbeats = deadbeats
-        self.Root = t.root()
+        self.Root = t.get_root()
 
     def __getitem__(self, item):
         """If item is int, returns taxon by id: otherwise, searches by name.

--- a/src/cogent3/phylo/consensus.py
+++ b/src/cogent3/phylo/consensus.py
@@ -87,7 +87,7 @@ def weighted_rooted_majority_rule(weighted_trees, strict=False, attr="support"):
         total += weight
         edges = tree.get_edge_vector()
         for edge in edges:
-            tips = edge.get_tip_names(includeself=True)
+            tips = edge.get_tip_names(include_self=True)
             tips = frozenset(tips)
             if tips not in cladecounts:
                 cladecounts[tips] = 0

--- a/tests/test_cluster/test_UPGMA.py
+++ b/tests/test_cluster/test_UPGMA.py
@@ -108,10 +108,10 @@ class UPGMATests(TestCase):
         node_order = self.node_order
         node_order = condense_node_order(matrix, index, node_order)
         assert node_order[1] is None
-        assert node_order[0].__str__() == "(a:0.5,b:0.5);"
-        assert node_order[2].__str__() == "c;"
-        assert node_order[3].__str__() == "d;"
-        assert node_order[4].__str__() == "e;"
+        assert str(node_order[0]) == "(a:0.5,b:0.5);"
+        assert str(node_order[2]) == "c;"
+        assert str(node_order[3]) == "d;"
+        assert str(node_order[4]) == "e;"
 
     def test_upgma_cluster(self):
         """UPGMA_cluster clusters nodes based on info in a matrix with UPGMA"""

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -2674,7 +2674,6 @@ def test_rooted_with_tip():
 def tested_rooted_newick():
     tree = make_tree(treestring="(A:0.006,B:0.0025,C:0.003)")
     nt = tree.rooted("A")
-    x = str(nt.children[0])
     got = str(nt.get_newick(with_distances=False))
     assert got in {"(A,(B,C));", "((B,C),A);", "((C,B),A);"}
 

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1240,9 +1240,9 @@ def test_make_tree_array(tree_root):
 def test_get_node_names():
     """get_node_names works correctly"""
     tree = make_tree(treestring="((a:3,(b:2,(c:1,d:1):1):1):2,(e:3,f:3):2);")
-    names = tree.get_node_names(includeself=False, tipsonly=False)
+    names = tree.get_node_names(include_self=False, tips_only=False)
     assert tree.name not in names
-    names = tree.get_node_names(includeself=True, tipsonly=False)
+    names = tree.get_node_names(include_self=True, tips_only=False)
     assert tree.name in names
     tree.get_node_matching_name("a")
 
@@ -2367,14 +2367,14 @@ def test_getsubtree_5():
         if "Mus" in edge.name:
             edge.name = "Mus musculus"
 
-    sub1 = tree.get_sub_tree(names, tipsonly=False)
+    sub1 = tree.get_sub_tree(names, tips_only=False)
     assert tree.same_topology(sub1)
     expect = make_tree(
         treestring="(Homo_sapiens,Mus_musculus,"
         "(Canis_familiaris,Ornithorhynchus_anatinus))",
         underscore_unmunge=True,
     )
-    sub2 = tree.get_sub_tree(names, tipsonly=True)
+    sub2 = tree.get_sub_tree(names, tips_only=True)
     assert expect.same_topology(sub2)
 
 
@@ -2388,7 +2388,7 @@ def test_getsubtree_6():
     for edge in tree.postorder(include_self=False):
         edge.params["non-scalar"] = {edge.name: vals.get(edge.name, 99)}
 
-    sub1 = tree.get_sub_tree(names, tipsonly=False)
+    sub1 = tree.get_sub_tree(names, tips_only=False)
     assert set(tree.get_tip_names()), set("ABC")
     # the edge value for "non-scalar" should be same as original tree
     assert all(sub1.get_node_matching_name(name).params["non-scalar"] for name in names)

--- a/tests/test_evolve/test_likelihood_function.py
+++ b/tests/test_evolve/test_likelihood_function.py
@@ -933,7 +933,7 @@ class LikelihoodFunctionTests(TestCase):
         lf.optimise(max_evaluations=10, limit_action="ignore", show_progress=False)
         stats = lf.get_statistics()
         timehet_edge_names = {
-            n for n in self.tree.get_node_names(includeself=False) if n not in edges
+            n for n in self.tree.get_node_names(include_self=False) if n not in edges
         }
         for t in stats:
             if t.title == "edge locus params":
@@ -1019,7 +1019,7 @@ class LikelihoodFunctionTests(TestCase):
         lf = self.submodel.make_likelihood_function(self.tree)
         lf.set_time_heterogeneity(is_independent=True)
         got = lf.get_num_free_params()
-        assert got == nfp + len(lf.tree.get_node_names(includeself=False)) - 1
+        assert got == nfp + len(lf.tree.get_node_names(include_self=False)) - 1
 
         # we should be able to specify a set of edges that get treated as a block
         # if not specified, the edges are considered to be not-independent

--- a/tests/test_parse/test_tree.py
+++ b/tests/test_parse/test_tree.py
@@ -185,7 +185,7 @@ class DndParserTests(TestCase):
         assert len(t) == 2
         assert len(t[0]) == 0  # first child is terminal
         assert len(t[1]) == 2  # second child has two children
-        assert str(t) == "(abc:3.0,(def:4.0,ghi:5.0)jkl:6.0);"
+        assert str(t) == "(abc:3.0,(def:4.0,ghi:5.0):6.0);"
         info_dict = {}
         for node in t.traverse():
             info_dict[node.name] = node.length
@@ -203,7 +203,7 @@ class DndParserTests(TestCase):
         )
         tdata = DndParser(node_data_sample, unescape_name=True)
         assert (
-            str(tdata)
+            tdata.get_newick(with_distances=True, with_node_names=True)
             == "((xyz:0.28124,(def:0.24498,mno:0.03627)A:0.1771)B:0.0487,abc:0.05925,(ghi:0.06914,jkl:0.13776)C:0.09853);"
         )
 
@@ -254,21 +254,27 @@ class PhyloNodeTests(TestCase):
     def test_gops(self):
         """Basic PhyloNode operations should work as expected"""
         p = PhyloNode()
-        assert str(p) == ";"
+        assert p.get_newick(with_node_names=True) == ";"
         p.name = "abc"
-        assert str(p) == "abc;"
+        assert p.get_newick(with_node_names=True) == "abc;"
         p.length = 3
-        assert str(p) == "abc:3;"  # don't suppress branch from root
+        assert (
+            p.get_newick(with_node_names=True, with_distances=True) == "abc:3;"
+        )  # don't suppress branch from root
         q = PhyloNode()
         p.append(q)
-        assert str(p) == "()abc:3;"
+        assert p.get_newick(with_node_names=True, with_distances=True) == "()abc:3;"
         r = PhyloNode()
         q.append(r)
-        assert str(p) == "(())abc:3;"
+        assert p.get_newick(with_node_names=True, with_distances=True) == "(())abc:3;"
         r.name = "xyz"
-        assert str(p) == "((xyz))abc:3;"
+        assert (
+            p.get_newick(with_node_names=True, with_distances=True) == "((xyz))abc:3;"
+        )
         q.length = 2
-        assert str(p) == "((xyz):2)abc:3;"
+        assert (
+            p.get_newick(with_node_names=True, with_distances=True) == "((xyz):2)abc:3;"
+        )
 
 
 def test_make_tree_simple():


### PR DESCRIPTION
## Summary by Sourcery

Overhaul the Newick string generation to fix formatting bugs and simplify logic, standardize parameter naming across TreeNode methods with deprecation warnings, and update tests and other modules to align with the revised API.

Bug Fixes:
- Fix semicolon placement and root node handling in Newick output
- Correct inclusion of internal node names, branch lengths, and escape quoting in Newick formatting

Enhancements:
- Refactor get_newick to a recursive implementation with type annotations
- Standardize method parameters (e.g., include_self, tips_only) and add deprecation warnings for legacy argument names

Tests:
- Update test suite to call get_newick with explicit flags and adjust expected Newick outputs

Chores:
- Update various modules to use new parameter names (get_node_names, get_tip_names, taxonomy root lookup, consensus clade extraction)