### PR TITLE
MAINT: make sure annotion db's are closed after use

### DIFF
--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -1562,6 +1562,7 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         col_order = [
             r["name"] for r in self.db.execute("PRAGMA table_info(gb)").fetchall()
         ]
+
         val_placeholder = ", ".join("?" * len(col_order))
         sql = f"INSERT INTO gb ({', '.join(col_order)}) VALUES ({val_placeholder})"
 
@@ -1990,3 +1991,4 @@ def update_file_format(
                 f"UPDATE {table_name} SET {column}=update_array_format({column});",
             )
         conn.commit()
+    anno_db.close()

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -516,7 +516,7 @@ class TreeNode:
             halved. The new tree will have two children.
         """
         tree = self.deepcopy()
-        if self.name != "root":
+        if not self.is_root():
             msg = (
                 f"cannot apply from non-root node {self.name!r}, "
                 "use self.get_root() first"

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -738,7 +738,9 @@ class DistanceMatrix(DictArray):
         self.source = source
 
     @classmethod
-    def from_array_names(cls, matrix: numpy.ndarray, names: PySeqStr, invalid=None):
+    def from_array_names(
+        cls, matrix: numpy.ndarray, names: PySeqStr, invalid=None
+    ) -> "DistanceMatrix":
         """construct a distance matrix from numpy array and names"""
         darr = DictArray.from_array_names(matrix, names, names)
         return cls(darr, invalid=invalid)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -26,13 +26,17 @@ DNA = cogent3.get_moltype("dna")
 @pytest.fixture
 def gff_db(DATA_DIR):
     path = DATA_DIR / "c_elegans_WS199_shortened_gff.gff3"
-    return load_annotations(path=path)
+    db = load_annotations(path=path)
+    yield db
+    db.close()
 
 
 @pytest.fixture
 def gff_small_db(DATA_DIR):
     path = DATA_DIR / "simple.gff"
-    return load_annotations(path=path)
+    db = load_annotations(path=path)
+    yield db
+    db.close()
 
 
 @pytest.fixture
@@ -1126,6 +1130,7 @@ def test_update_file_format(db_name, cls, backup, tmp_path, request):
 
     # The tables should remain the same
     assert old_tables == new_tables
+    db.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Ensure annotation database connections are properly closed after use by adding explicit close() calls in tests and core routines.

Enhancements:
- Convert pytest fixtures to yield loaded annotation DBs and close them after tests run
- Add db.close() in test_update_file_format to clean up connection
- Invoke anno_db.close() at the end of update_file_format to close the database