### PR TITLE
DEP: tree compare_by_tip_distances()

### DIFF
--- a/doc/cookbook/simple_trees.rst
+++ b/doc/cookbook/simple_trees.rst
@@ -205,25 +205,6 @@ Get sum of all branch lengths
     tr = make_tree("(B:3,(C:2,D:4)F:5)G;")
     tr.total_length()
 
-Compare two trees using tip-to-tip distance matrices
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Score ranges from 0 (minimum distance) to 1 (maximum
-distance). The default is to use Pearson's correlation,
-in which case a score of 0 means that the Pearson's
-correlation was perfectly good (1), and a score of 1
-means that the Pearson's correlation was perfectly bad (-1).
-
-Note: automatically strips out the names that don't match.
-
-.. jupyter-execute::
-
-    from cogent3 import make_tree
-
-    tr1 = make_tree("(B:2,(C:3,D:4)F:5)G;")
-    tr2 = make_tree("(C:2,(B:3,D:4)F:5)G;")
-    tr1.compare_by_tip_distances(tr2)
-
 Getting the last common ancestor (LCA) for two nodes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2098,13 +2098,16 @@ class PhyloNode(TreeNode):
         """returns pairwise distance matrix"""
         return self.tip_to_tip_distances(names=names)
 
+    @c3warn.deprecated_callable(
+        "2025.9", "use the distance matrices directly", is_discontinued=True
+    )
     def compare_by_tip_distances(
         self,
         other,
         sample=None,
         dist_f=distance_from_r,
         shuffle_f=shuffle,
-    ):
+    ):  # pragma: no cover
         """Compares self to other using tip-to-tip distance matrices.
 
         Value returned is dist_f(m1, m2) for the two matrices. Default is

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_allclose, assert_equal
 from cogent3 import get_dataset, load_tree, make_tree, open_
 from cogent3._version import __version__
 from cogent3.core.tree import PhyloNode, TreeError, TreeNode, split_name_and_support
-from cogent3.maths.stats.test import correlation
 from cogent3.parse.tree import DndParser
 from cogent3.util.misc import get_object_provenance
 
@@ -1502,7 +1501,7 @@ def test_tips_within_distance_nodistances():
 
 
 def test_distance(phylo_nodes):
-    """PhyloNode Distance should report correct distance between nodes"""
+    """PhyloNode distance should report correct distance between nodes"""
     nodes = phylo_nodes
     a = nodes["a"]
     b = nodes["b"]
@@ -1584,31 +1583,6 @@ def test_distance(phylo_nodes):
     assert h.distance(f) == 7
     assert h.distance(g) == 10
     assert h.distance(h) == 0
-
-
-def test_compare_by_tip_distances(phylo_1, phylo_2):
-    obs = phylo_1.compare_by_tip_distances(phylo_2)
-    # note: common taxa are H, G, R (only)
-    m1 = array([[0, 2, 6.5], [2, 0, 6.5], [6.5, 6.5, 0]])
-    m2 = array([[0, 2, 6], [2, 0, 6], [6, 6, 0]])
-    r = correlation(m1.flat, m2.flat)[0]
-    assert obs == (1 - r) / 2
-
-
-def test_compare_by_tip_distances_sample(
-    phylo_1, phylo_2, phylostring_1, phylostring_2
-):
-    obs = phylo_1.compare_by_tip_distances(phylo_2, sample=3, shuffle_f=sorted)
-    # note: common taxa are H, G, R (only)
-    m1 = array([[0, 2, 6.5], [2, 0, 6.5], [6.5, 6.5, 0]])
-    m2 = array([[0, 2, 6], [2, 0, 6], [6, 6, 0]])
-    r = correlation(m1.flat, m2.flat)[0]
-    assert obs == (1 - r) / 2
-
-    # 4 common taxa, still picking H, G, R
-    t = DndParser(phylostring_1, PhyloNode)
-    t3 = DndParser(phylostring_2, PhyloNode)
-    obs = t.compare_by_tip_distances(t3, sample=3, shuffle_f=sorted)
 
 
 def test_tip_to_tip_distances_endpoints(phylo_1):


### PR DESCRIPTION
[CHANGED] marked for deprecation in version 2025.9. This capability
    does not belong on a tree. The function can be more explicitly
    addressed by using the distance matrices of two trees.

## Summary by Sourcery

Deprecate the compare_by_tip_distances() functionality on Tree, remove its associated tests, and direct users to work with distance matrices explicitly.

Enhancements:
- Mark the Tree.compare_by_tip_distances() method as deprecated and discontinued in version 2025.9 with a warning to use distance matrices directly
- Exclude the deprecated compare_by_tip_distances() method from test coverage

Tests:
- Remove tests for compare_by_tip_distances() and its sampling variant from test_tree.py