### PR TITLE
DEV: reduce matrix size in CI github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.13.3"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.5"]
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13.3"]
+        python-version: ["3.10", "3.13.5"]
 
     steps:
       - uses: "actions/checkout@v4"


### PR DESCRIPTION
[CHANGED] we now only test the oldest and newest versions of python,
    rather than all versions, in our CI. This reduces the energy
    consumption of our testing. We do test all versions in our release
    workflow.

[CHANGED] also pinned 3.13.5 as the latest tested version

## Summary by Sourcery

Reduce CI energy usage by limiting the development test matrix to only the oldest and newest Python versions and updating the release workflow to include all supported versions with a pinned latest version.

Enhancements:
- Decrease CI matrix size to cut energy consumption by testing only Python 3.10 and 3.13.5 on develop branches.

CI:
- Shrink testing_develop.yml workflow to Python versions 3.10 and 3.13.5.
- Expand release.yml workflow to run on Python 3.10, 3.11, 3.12, and pin the latest to 3.13.5.