### PR TITLE
MAINT: another effort to close sqlitedb's

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ Changelog = "https://github.com/cogent3/cogent3/blob/develop/changelog.md"
 test = [
     "cogent3-h5seqs",
     "piqtree; sys_platform != 'win32'",  # not supported their yet
-    "ruff==0.11.13",
+    "ruff==0.12.0",
     "kaleido",
     "pandas",
     "plotly",

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -1991,4 +1991,5 @@ def update_file_format(
                 f"UPDATE {table_name} SET {column}=update_array_format({column});",
             )
         conn.commit()
+    cursor.close()
     anno_db.close()

--- a/src/cogent3/parse/gcg.py
+++ b/src/cogent3/parse/gcg.py
@@ -42,7 +42,7 @@ def MsfParser(f):
     for name, value_ in sequences.items():
         if len(value_) != seqinfo[name]:
             warnings.warn(
-                f"Length of loaded seqs [{name}] is [{len(sequences[name])}] not "
+                f"Length of loaded seqs [{name}] is [{len(value_)}] not "
                 f"[{seqinfo[name]}] as expected.",
                 stacklevel=2,
             )


### PR DESCRIPTION
## Summary by Sourcery

Ensure proper closure of sqlite database cursors, refine parser warning output, and update the linting tool dependency

Bug Fixes:
- Close sqlite cursor after committing in annotation_db.update_file_format to prevent resource leaks
- Correct variable reference in warning message of MsfParser for accurate sequence length reporting

Enhancements:
- Bump ruff linting dependency to version 0.12.0