### PR TITLE
Refactor work on tree class methods

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -292,10 +292,8 @@ class TreeNode:
         return len(self.children)
 
     # support for copy module
-    def copy(self, memo=None, _nil=None, constructor="ignored"):
+    def copy(self, memo=None, _nil=None, constructor: None = None):
         """Returns a copy of self using an iterative approach"""
-
-        _nil = _nil or []
 
         root = _copy_node(self)
         nodes_stack = [[root, self, len(self.children)]]
@@ -2285,7 +2283,7 @@ def make_tree(
     tip_names: list[str] | None = None,
     format: str | None = None,
     underscore_unmunge: bool = False,
-    source: str | None = None,
+    source: str | pathlib.Path | None = None,
 ) -> PhyloNode | TreeNode:
     """Initialises a tree.
 
@@ -2368,8 +2366,8 @@ def load_tree(
     -------
     PhyloNode
     """
-    file_format, _ = get_format_suffixes(filename)
-    format = format or file_format
+    fmt, _ = get_format_suffixes(filename)
+    format = format or fmt
     if format == "json":
         tree = load_from_json(filename, (TreeNode, PhyloNode))
         tree.source = str(filename)

--- a/src/cogent3/parse/tree.py
+++ b/src/cogent3/parse/tree.py
@@ -86,6 +86,10 @@ def DndParser(lines, constructor=PhyloNode, unescape_name=False):
     explicitly).
     """
     data = lines if isinstance(lines, str) else "".join(lines)
+    data = data.strip()
+    if not data.endswith(";"):
+        data = f"{data};"
+
     # skip arb comment stuff if present: start at first paren
     paren_index = data.find("(")
     data = data[paren_index:]

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1920,13 +1920,16 @@ def test_balanced():
 
 
 def test_params_merge():
-    t = make_tree(treestring="((((a,b)ab,c)abc),d)")
-    for label, length, beta in [("a", 1, 20), ("b", 3, 2.0), ("ab", 4, 5.0)]:
-        t.get_node_matching_name(label).params = {"length": length, "beta": beta}
+    t = make_tree(treestring="((((a:1,b:3)ab:4,c)abc),d)")
+    for label, beta in [("a", 20), ("b", 2.0), ("ab", 5.0)]:
+        t.get_node_matching_name(label).params |= {"beta": beta}
     t = t.get_sub_tree(["b", "c", "d"])
+    # previous implementation on merge was
+    # dividing the sum of parameters across nodes by the lengths
+    # we no longer try and support this
     assert t.get_node_matching_name("b").params == {
         "length": 7,
-        "beta": float(2 * 3 + 4 * 5) / (3 + 4),
+        "beta": 2 + 5,
     }
     assert str(t.get_sub_tree(["b", "c", "xxx"], ignore_missing=True)) == "(b:7,c);"
     with pytest.raises(ValueError):

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -23,7 +23,7 @@ def test_make_tree():
     # NOTE: This method now sits in cogent3.__init__
 
     t_str = "(a_a:10,(b_b:2,c_c:4):5);"
-    # NOTE: Tree quotes these labels because they have underscores in them.
+    # Tree quotes these labels because they have underscores in them.
     result_str = "('a_a':10.0,('b_b':2.0,'c_c':4.0):5.0);"
     t = make_tree(treestring=t_str)
     names = [i.name for i in t.tips()]
@@ -43,15 +43,6 @@ def test_make_tree():
     # when creating a tree from a list of integer tip names.
     t = make_tree(tip_names=[1, 2, 3])
     assert t.get_tip_names() == ["1", "2", "3"]
-
-
-def _new_child(old_node, constructor):
-    """Returns new_node which has old_node as its parent."""
-    new_node = constructor()
-    new_node.parent = old_node
-    if old_node is not None and new_node not in old_node.children:
-        old_node.children.append(new_node)
-    return new_node
 
 
 tree_std = """\

--- a/tests/test_parse/test_tree.py
+++ b/tests/test_parse/test_tree.py
@@ -2,6 +2,8 @@
 
 from unittest import TestCase
 
+import pytest
+
 from cogent3.core.tree import PhyloNode
 from cogent3.parse.tree import DndParser, DndTokenizer, RecordError
 
@@ -347,3 +349,12 @@ def test_make_tree_with_nhx(DATA_DIR):
     assert set(vert.params["other"]) == {'&sCF="50.68"', 'sDF1="24.42"'}
     vert = got.get_connecting_node("t5", "t6")
     assert set(vert.params["other"]) == {'&sCF="77.1"', 'sDF1="11.53"'}
+
+
+@pytest.mark.parametrize(
+    "treestring", ["(a,b)ab;", "(a,b)ab", "(a,b,(c,(d,e)))ab", "(a:3,b)ab"]
+)
+def test_parse_named_root_nodes(treestring):
+    tree = DndParser(treestring, PhyloNode)
+    assert tree.name == "ab"
+    assert tree.parent is None


### PR DESCRIPTION
## Summary by Sourcery

Refactor Tree and TreeBuilder methods to streamline signatures, add static type hints, and improve subtree extraction and parameter merging logic; update Newick parser to accept missing semicolons and adjust tests to validate new behavior.

Bug Fixes:
- Handle Newick strings lacking trailing semicolons in DndParser

Enhancements:
- Introduce is_number helper and generalize prune to sum numeric parameters across nodes
- Replace legacy _get_sub_tree with a clearer get_sub_tree implementation that preserves unrooted status and supports tip-only extraction
- Simplify method signatures (copy, unrooted_deepcopy, _default_tree_constructor) and add type annotations throughout Tree and TreeBuilder classes

Tests:
- Revise and add tests for get_sub_tree behavior, param merging, unrooted cases, and parsing named root nodes without semicolons