### PR TITLE
ENH: unwrap source_proxy if result has identifiable source

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -703,10 +703,22 @@ def _source_wrapped(
     self,
     value: source_proxy | c3_typing.HasSource,
 ) -> c3_typing.HasSource:
+    """retains result association with source
+
+    Notes
+    -----
+    Returns the unwrapped result if it has a .source instance,
+    otherwise returns the original source_proxy with the .obj
+    updated with result.
+    """
     if not isinstance(value, source_proxy):
         return self(value)
 
-    value.set_obj(self(value.obj))
+    result = self(value.obj)
+    if get_data_source(result):
+        return result
+
+    value.set_obj(result)
     return value
 
 
@@ -860,7 +872,7 @@ def _apply_to(
     ):
         member = self.main(
             data=getattr(result, "obj", result),
-            identifier=id_from_source(result.source),
+            identifier=id_from_source(result),
         )
         if self.logger:
             md5 = getattr(member, "md5", None)


### PR DESCRIPTION
## Summary by Sourcery

Unwrap source_proxy when the result has a recognized data source and update identifier extraction, with new tests to verify behavior.

Enhancements:
- Return the actual result object instead of a source_proxy when it has an identifiable data source in _source_wrapped
- Use id_from_source on the full result rather than its .source attribute in _apply_to

Tests:
- Update existing test assertion to drop the .obj layer
- Add a source_type fixture to parametrize input sources as Path, string, or proxy
- Introduce tests to verify that as_completed and direct calls unwrap source_proxy when possible