### PR TITLE
Deprecate binomial exact

### DIFF
--- a/changelog.d/20250624_035311_richard_deprecate_binomial_exact.md
+++ b/changelog.d/20250624_035311_richard_deprecate_binomial_exact.md
@@ -1,0 +1,6 @@
+Contributors
+* khiron
+
+Deprecations
+
+- `cogent3.math.stats.distribution.binomial_exact` has been deprecated in favour of scipy function `scipy.stats.binom.pmf`.  `binomial_exact` will be discontinued in cogent3 release 2025.9

--- a/changelog.d/20250624_035311_richard_deprecate_binomial_exact.md
+++ b/changelog.d/20250624_035311_richard_deprecate_binomial_exact.md
@@ -3,4 +3,4 @@ Contributors
 
 Deprecations
 
-- `cogent3.math.stats.distribution.binomial_exact` has been deprecated in favour of scipy function `scipy.stats.binom.pmf`.  `binomial_exact` will be discontinued in cogent3 release 2025.9
+- `cogent3.math.stats.distribution.binomial_exact` has been deprecated in favour of scipy function `scipy.stats.binom.pmf`.  `binomial_exact` will be discontinued in cogent3 release 2025.9.  Until then `binomial_exact` will use `scipy.stats.binom.pmf` internally and floating point values for `successes` and `trials` will be truncated to integers using `math.floor` introducing a potential breaking change in behaviour. 

--- a/src/cogent3/maths/stats/distribution.py
+++ b/src/cogent3/maths/stats/distribution.py
@@ -5,7 +5,7 @@ which is (c) Stephen L. Moshier 1984, 1995.
 
 from numpy import arctan as atan
 from numpy import array, exp, sqrt
-from scipy.stats import f, norm, t
+from scipy.stats import f, norm, t, binom
 from scipy.stats.distributions import chi2
 
 from cogent3.maths.stats.special import (
@@ -23,6 +23,7 @@ from cogent3.maths.stats.special import (
     log1p,
     ndtri,
 )
+from cogent3.util.warning import deprecated_callable
 
 # ndtri import b/c it should be available via this module
 
@@ -42,23 +43,73 @@ def tprob(x, df):
     return 2 * t.sf(abs(x), df)
 
 
+def approximate_binomial_pmf(successes, trials, prob):
+    """Smooth approximation of the binomial probability mass function.
+
+    Extends the binomial PMF to support non-integer values of `successes` and `trials`
+    using the Gamma function via a log-domain formulation.
+
+    This is not a true probability mass function when `successes` or `trials` are non-integer;
+    summing over fractional values will not yield 1.
+
+
+    Parameters
+    ----------
+    successes : float
+        Number of observed successes (can be non-integer)
+    trials : float
+        Total number of trials (can be non-integer)
+    prob : float in [0, 1]
+        Probability of success on each trial
+
+    Returns
+    -------
+    float
+        Approximate binomial probability for the given parameters
+    """
+    if not (0 <= prob <= 1):
+        raise ValueError("Binomial prob must be between 0 and 1.")
+    if not (0 <= successes <= trials):
+        raise ValueError("Successes must be between 0 and trials.")
+
+    return exp(ln_binomial(successes, trials, prob))
+
+@deprecated_callable(
+    "2025.9", # this function will be removed from release 2025.9
+    "Use scipy.stats.binom.pmf if both `sucesses` and `trials` are integers, or approximate_binomial_pmf if either is a float.",
+    new="scipy.stats.binom.pmf",
+    is_discontinued=True 
+)
 def binomial_exact(successes, trials, prob):
     """Returns binomial probability of exactly X successes.
 
-    Works for integer and floating point values.
+    Redirects to scipy.stats.binom.pmf if successes and trials are integers,
+    otherwise uses a generalized loggamma approximation.
 
     Note: this function is only a probability mass function for integer
     values of 'trials' and 'successes', i.e. if you sum up non-integer
     values you probably won't get a sum of 1.
-    """
-    if (prob < 0) or (prob > 1):
-        msg = "Binomial prob must be between 0 and 1."
-        raise ValueError(msg)
-    if (successes < 0) or (trials < successes):
-        msg = "Binomial successes must be between 0 and trials."
-        raise ValueError(msg)
-    return exp(ln_binomial(successes, trials, prob))
 
+    Parameters
+    ----------
+    successes : int or float
+    trials : int or float
+    prob : float in [0, 1]
+
+    Returns
+    -------
+    float
+        Binomial probability or its approximation
+    """
+    if not (0 <= prob <= 1):
+        raise ValueError("Binomial prob must be between 0 and 1.")
+    if not (0 <= successes <= trials):
+        raise ValueError("Successes must be between 0 and trials.")
+
+    if float(successes).is_integer() and float(trials).is_integer():
+        return binom.pmf(k=int(successes), n=int(trials), p=prob)
+    else:
+        approximate_binomial_pmf(successes, trials, prob)
 
 def fprob(dfn, dfd, F, side="right"):
     """Returns both tails of F distribution (-inf to F and F to inf)

--- a/tests/test_maths/test_stats/test_distribution.py
+++ b/tests/test_maths/test_stats/test_distribution.py
@@ -167,19 +167,20 @@ class DistributionsTests(TestCase):
     def test_binomial_exact_floats(self):
         """binomial_exact should be within limits for floating point numbers"""
         expected = {
-            (18.3, 100, 0.2): (0.09089812, 0.09807429),
-            (2.7, 1050, 0.006): (0.03615498, 0.07623827),
-            (2.7, 1050, 0.06): (1.365299e-25, 3.044327e-24),
-            (2, 100.5, 0.6): (7.303533e-37, 1.789727e-36),
-            (10, 100.5, 0.5): (7.578011e-18, 1.365543e-17),
-            (0.2, 60, 0.5): (8.673617e-19, 5.20417e-17),
-            (0.5, 5, 0.3): (0.16807, 0.36015),
+            (0.0, 1.0, 0.5): 0.5,
+            (1.0, 1.0, 0.5): 0.5,
+            (1.0, 1.0, 0.0000001): 1e-07,
+            (1.0, 1.0, 0.9999999): 0.9999999,
+            (3.0, 5.0, 0.75): 0.2636719,
+            (0.0, 60.0, 0.5): 8.673617e-19,
+            (129.0, 130.0, 0.5): 9.550892e-38,
+            (299.0, 300.0, 0.099): 1.338965e-298,
+            (9.0, 27.0, 0.0003): 9.175389e-26,
+            (1032.0, 2050.0, 0.5): 0.01679804,
         }
 
         for key, value in list(expected.items()):
-            min_val, max_val = value
-            assert min_val < binomial_exact(*key) < max_val
-            # assert_almost_equal(binomial_exact(*key), value, 1e-4)
+            assert_almost_equal(binomial_exact(*key), value, 1e-4)
 
     def test_binomial_exact_errors(self):
         """binomial_exact should raise errors on invalid input"""

--- a/tests/test_maths/test_stats/test_special.py
+++ b/tests/test_maths/test_stats/test_special.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 from numpy.testing import assert_allclose
 
+from cogent3.maths.stats.distribution import binomial_exact
 from cogent3.maths.stats.special import (
     igami,
     incbi,
@@ -51,7 +52,6 @@ class SpecialTests(TestCase):
         for key, value in list(expected.items()):
             min_val, max_val = value
             assert min_val < ln_binomial(*key) < max_val
-            # self.assert_allclose(binomial_exact(*key), value, 1e-4)
 
     def test_ln_binomial_range(self):
         """ln_binomial should increase in a monotonically increasing region."""


### PR DESCRIPTION
addresses issue #2227 

Contributors
* khiron

Deprecations

- `cogent3.math.stats.distribution.binomial_exact` has been deprecated in favour of scipy function `scipy.stats.binom.pmf`.  `binomial_exact` will be discontinued in cogent3 release 2025.9.  Until then `binomial_exact` will use `scipy.stats.binom.pmf` internally and floating point values for `successes` and `trials` will be truncated to integers using `math.floor` introducing a potential breaking change in behaviour. 