### PR TITLE
MAINT: refactor source proxy wrapping in composable apps

### DIFF
--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -14,12 +14,13 @@ from numpy.testing import assert_allclose
 import cogent3
 from cogent3 import get_app, get_moltype, open_data_store
 from cogent3.app import io as io_app
-from cogent3.app.composable import NotCompleted, source_proxy
+from cogent3.app.composable import NotCompleted, propagate_source, source_proxy
 from cogent3.app.data_store import (
     DataMember,
     DataStoreDirectory,
     Mode,
     ReadOnlyDataStoreZipped,
+    get_data_source,
 )
 from cogent3.app.io import DEFAULT_DESERIALISER, DEFAULT_SERIALISER
 from cogent3.core.profile import PSSM, MotifCountsArray, MotifFreqsArray
@@ -120,11 +121,14 @@ def test_source_proxy_simple(fasta_dir):
     data = reader(path)
     # direct call gives you back the annotated type
     assert isinstance(data, bytes | bytearray)
+    # create a source wrapper
+    wrapper = propagate_source(reader, get_data_source)
     # directly calling the intermediate wrap method should work
-    got = reader._source_wrapped(source_proxy(path))
+    got = wrapper(source_proxy(path))
     assert isinstance(got, source_proxy)
     # calling with list of data that doesn't have a source should
-    # also return source_proxy
+    # also return source_proxy. In this case, the wrapper is automatically
+    # created and assigned to the reader._source_wrapped attribute
     got = list(reader.as_completed([path], show_progress=False))
     assert isinstance(got[0], source_proxy)
 


### PR DESCRIPTION
[NEW] added id_from_source optional argument to as_completed
     method. Defaults to get_unique_id (from app.data_store).

[NEW] propagate_source class which replaces the _source_wrapped
     method and is callable. This new class takes as an argument
     the reference to the id_from_source function. When called,
     it uses the bound function to see if the result has a source
     attribute with a valid value.

[CHANGED] The method _source_wrapped added to apps by the define_app
     decorator is now an attribute. A propagate_source instance is
     assigned to that attribute within the aforementioned methods.
     This means a user controlled function is the only one used to check
     the result objects.

## Summary by Sourcery

Refactor the source proxy wrapping mechanism in composable apps by introducing a propagate_source class, enabling custom id_from_source hooks, and updating internal method signatures and tests accordingly

New Features:
- Add optional id_from_source parameter to as_completed and apply_to for custom source identification
- Introduce propagate_source class to wrap and propagate source metadata for composable app results

Enhancements:
- Replace standalone _source_wrapped function with a propagate_source instance attribute initialized by define_app
- Initialize _source_wrapped attributes in as_completed and apply_to so user‐supplied functions control result wrapping
- Improve type annotations across source_proxy and composable app methods

Tests:
- Update tests to use propagate_source wrapper and verify source wrapping in as_completed