### PR TITLE
BUG: support pickling of new type seq collections

### DIFF
--- a/src/cogent3/core/new_alignment.py
+++ b/src/cogent3/core/new_alignment.py
@@ -702,6 +702,15 @@ class SequenceCollection(AnnotatableMixin):
         # override in subclasses
         self._seqs = _IndexableSeqs(self, make_seq=self._make_seq)
 
+    def __getstate__(self) -> dict:
+        return self._get_init_kwargs()
+
+    def __setstate__(self, state: dict) -> None:
+        state["name_map"] = types.MappingProxyType(state.pop("name_map"))
+        obj = self.__class__(**state)
+
+        self.__dict__.update(obj.__dict__)
+
     def _make_seq(self, name: str) -> new_sequence.Sequence:
         # seqview is given the name of the parent (if different from the current name)
         # the sequence is given the current name

--- a/tests/test_core/test_new_alignment.py
+++ b/tests/test_core/test_new_alignment.py
@@ -6123,6 +6123,20 @@ def test_renamed_deepcopy(renamed_aln):
     assert set(got.names) == {k.upper() for k in data}
 
 
+@pytest.mark.parametrize(
+    "mk_cls", [new_alignment.make_unaligned_seqs, new_alignment.make_aligned_seqs]
+)
+def test_pickling_seqcoll(mk_cls):
+    import pickle
+
+    raw = {"s1": "ACG-T", "s2": "ACGGT"}
+    coll = mk_cls(raw, moltype="dna")
+    pickled = pickle.dumps(coll)
+    unpickled = pickle.loads(pickled)
+    assert set(unpickled.names) == {k.lower() for k in raw}
+    assert unpickled.to_dict() == raw
+
+
 def test_alignment_copy_handling_annot_db():
     """Test that copying an alignment works correctly."""
     data = {


### PR DESCRIPTION
[FIXED] the MappingProxyType class cannot be pickled,
     so this required custom methods to support pickling.

## Summary by Sourcery

Enable pickling support for the new aligned and unaligned sequence collection types and add tests to verify correct serialization and deserialization.

Bug Fixes:
- Fix pickling of sequence collection classes by implementing custom __getstate__ and __setstate__ methods to restore MappingProxyType for the name_map.

Tests:
- Add parametrized tests to ensure aligned and unaligned sequence collections round-trip through pickle preserving names and sequence data.