### PR TITLE
MAINT: load_db defaults to using obj.source

### DIFF
--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -516,16 +516,15 @@ class load_db:
         """returns deserialised object"""
         try:
             data = identifier.read()
-        except AttributeError:
+        except AttributeError as e:
             msg = f"{identifier} failed because its of type {type(identifier)}"
-            raise AttributeError(
-                msg,
-            )
+            raise AttributeError(msg) from e
 
         # do we need to inject identifier attribute?
         result = self.deserialiser(data)
-        if hasattr(result, "info"):
-            result.info["source"] = result.info.get("source", identifier)
+        if not hasattr(result, "source") and hasattr(result, "info"):
+            src = Path(identifier.data_store.source) / identifier.unique_id
+            result.info["source"] = result.info.get("source", str(src))
         else:
             with contextlib.suppress(AttributeError):
                 identifier = getattr(result, "source", identifier)

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -473,6 +473,29 @@ def test_write_db_load_db(fasta_dir, tmp_dir):
     assert data_store.record_type == get_object_provenance(orig)
 
 
+def test_load_db_prefer_source_attr(tmp_dir):
+    from cogent3.app.sqlite_data_store import DataStoreSqlite
+
+    path = tmp_dir / "test.sqlitedb"
+    data_store = DataStoreSqlite(path, mode="w")
+
+    seqs = cogent3.make_unaligned_seqs(
+        data={"a": "ACGG", "b": "GGC"},
+        moltype="dna",
+        info={"demo": "dummy"},
+        new_type=True,
+        source="blah.1.2.fa",
+    )
+    writer = io_app.write_db(data_store=data_store)
+    writer(seqs)
+    data_store.close()
+    data_store = open_data_store(path)
+    # this old style rich dict will
+    loader = io_app.load_db()
+    got = loader(data_store[0])
+    assert "source" not in got.info
+
+
 def test_write_read_db_not_completed(tmp_dir):
     from cogent3.app.sqlite_data_store import DataStoreSqlite
 

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -487,12 +487,12 @@ def test_load_db_prefer_source_attr(tmp_dir):
         source="blah.1.2.fa",
     )
     writer = io_app.write_db(data_store=data_store)
-    writer(seqs)
+    writer(seqs)  # pylint: disable=not-callable
     data_store.close()
     data_store = open_data_store(path)
     # this old style rich dict will
     loader = io_app.load_db()
-    got = loader(data_store[0])
+    got = loader(data_store[0])  # pylint: disable=not-callable
     assert "source" not in got.info
 
 


### PR DESCRIPTION
[CHANGED] don't inject identifier into info dict as that is not
    json compatible

## Summary by Sourcery

Improve load_db behavior to respect existing source attributes, avoid injecting identifiers into the info dictionary for JSON compatibility, and maintain exception context while adding a test to validate the new loading logic.

Bug Fixes:
- Prevent injection of the record identifier into the info dict to avoid JSON compatibility issues

Enhancements:
- Change load_db to prefer an object's own source attribute and derive a default source path when missing
- Chain the original AttributeError when deserialisation fails to preserve context

Tests:
- Add test to verify load_db does not add a source entry when the object already provides a source attribute