### PR TITLE
Fix feature querying when sequences have annotation offsets

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1448,7 +1448,6 @@ class SequenceCollection(AnnotatableMixin):
         of strand of the current instance.
         - start is non-inclusive, so if allow_partial is False, only features
         strictly starting after start will be returned.
-
         """
 
         if not self._annotation_db:
@@ -1458,21 +1457,17 @@ class SequenceCollection(AnnotatableMixin):
             msg = f"unknown {seqid=}"
             raise ValueError(msg)
 
-        for feature in self.annotation_db.get_features_matching(
-            seqid=seqid,
-            biotype=biotype,
-            name=name,
-            on_alignment=False,
-            start=start,
-            stop=stop,
-            allow_partial=allow_partial,
-            **kwargs,
-        ):
-            seqname = feature["seqid"]
-            seq = self.seqs[seqname]
-            if offset := seq.annotation_offset:
-                feature["spans"] = (numpy.array(feature["spans"]) - offset).tolist()
-            yield seq.make_feature(feature, self)
+        seqids = [seqid] if isinstance(seqid, str) else self.names
+        for seqid in seqids:
+            seq = self.seqs[seqid]
+            yield from seq.get_features(
+                biotype=biotype,
+                name=name,
+                start=start,
+                stop=stop,
+                allow_partial=allow_partial,
+                **kwargs,
+            )
 
     def to_fasta(self, block_size: int = 60) -> str:
         """Return collection in Fasta format.

--- a/tests/test_core/test_aln_annotation.py
+++ b/tests/test_core/test_aln_annotation.py
@@ -1002,3 +1002,35 @@ def test_get_feature_seqs_offset(mk_cls):
     got = feature[0].get_slice()
     got = got if mk_cls == c3_alignment.make_unaligned_seqs else got.get_seq("s1")
     assert str(got) == "AAGTA"
+
+
+@pytest.mark.parametrize(
+    "mk_cls",
+    [c3_alignment.make_aligned_seqs, c3_alignment.make_unaligned_seqs],
+)
+def test_get_feature_seqs_offset_minus_strand(mk_cls):
+    raw_seq = "GTTGAAGTAGTA"
+    data = {
+        "s1": c3_moltype.DNA.rc(raw_seq),
+        "s2": "TAC---CTTA--",
+        "s3": "CACTACTTCAGC",
+    }
+    rel_start = 4
+    rel_stop = 9
+    ann_offset = 20
+    offset = {"s1": ann_offset}
+    coll = mk_cls(data, moltype="dna", offset=offset, reversed_seqs={"s1"})
+    coll.annotation_db.add_feature(
+        seqid="s1",
+        biotype="exon",
+        name="exon",
+        spans=[(ann_offset + rel_start, ann_offset + rel_stop)],
+        strand=1,
+    )
+
+    expect = raw_seq[rel_start:rel_stop]
+    feature = list(coll.get_features(biotype="exon", name="exon"))
+    assert feature
+    got = feature[0].get_slice()
+    got = got if mk_cls == c3_alignment.make_unaligned_seqs else got.get_seq("s1")
+    assert str(got) == expect

--- a/tests/test_core/test_aln_annotation.py
+++ b/tests/test_core/test_aln_annotation.py
@@ -7,7 +7,6 @@ from cogent3.core import alignment as c3_alignment
 from cogent3.core import genetic_code as c3_genetic_code
 from cogent3.core import moltype as c3_moltype
 from cogent3.core.annotation_db import (
-    BasicAnnotationDb,
     GffAnnotationDb,
     load_annotations,
 )
@@ -993,9 +992,10 @@ def test_get_feature_seqs_offset(mk_cls):
         "s3": "GCTGAAGTAGTG",
     }
     offset = {"s1": 20}
-    db = BasicAnnotationDb()
-    db.add_feature(seqid="s1", biotype="exon", name="exon", spans=[(24, 29)])
-    coll = mk_cls(data, annotation_db=db, moltype="dna", offset=offset)
+    coll = mk_cls(data, moltype="dna", offset=offset)
+    coll.annotation_db.add_feature(
+        seqid="s1", biotype="exon", name="exon", spans=[(24, 29)]
+    )
     assert coll.storage.offset["s1"] == offset["s1"]
     feature = list(coll.get_features(biotype="exon", name="exon"))
     assert feature

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -10,7 +10,6 @@ import pytest
 import cogent3
 from cogent3._version import __version__
 from cogent3.core import alphabet as c3_alphabet
-from cogent3.core import annotation_db as anndb_module
 from cogent3.core import genetic_code as c3_genetic_code
 from cogent3.core import moltype as c3_moltype
 from cogent3.core import sequence as c3_sequence
@@ -892,74 +891,6 @@ def test_strand_symmetry():
     assert len(ssym.observed.keys()) <= 8
     assert numpy.allclose(ssym.observed["AA"].to_array(), [2, 1])
     assert numpy.allclose(ssym.observed["CC"].to_array(), [1, 2])
-
-
-def test_is_annotated():
-    """is_annotated operates correctly"""
-    s = c3_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG", name="s1")
-    _ = s.add_feature(biotype="gene", name="blah", spans=[(0, 10)])
-    assert s.is_annotated()
-
-
-@pytest.mark.parametrize("biotype", ["gene", "exon", ("gene", "exon")])
-def test_is_annotated_biotype(biotype):
-    """is_annotated operates correctly"""
-    s = c3_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG", name="s1")
-    _ = s.add_feature(biotype="gene", name="blah", spans=[(0, 10)])
-    _ = s.add_feature(biotype="exon", name="blah", spans=[(0, 10)])
-    assert s.is_annotated(biotype=biotype)
-
-
-def test_annotation_db_lazy_evaluation():
-    s = c3_moltype.DNA.make_seq(seq="AC", name="s1")
-    assert isinstance(s._annotation_db, list)
-    # now if we invoke the property we get an actual db instance created
-    assert isinstance(s.annotation_db, anndb_module.SupportsFeatures)
-
-
-def test_init_with_annotationdb():
-    anndb = anndb_module.GffAnnotationDb()
-    s = c3_moltype.DNA.make_seq(seq="AC", name="s1", annotation_db=anndb)
-    assert isinstance(s.annotation_db, anndb_module.GffAnnotationDb)
-    assert s.annotation_db is anndb
-
-
-def test_init_with_annotation_offset():
-    s = c3_moltype.DNA.make_seq(seq="AC", name="s1", annotation_offset=2)
-    assert s.annotation_offset == 2
-
-
-def test_init_with_annotation_offset_sliced():
-    s = c3_moltype.DNA.make_seq(seq="ACTTTGG", name="s1", annotation_offset=2)
-    sl = s[2:5]
-    assert sl.annotation_offset == 4
-    _, start, stop, _ = sl.parent_coordinates()
-    assert start == 4
-    assert stop == 7
-
-
-def test_not_is_annotated():
-    """is_annotated operates correctly"""
-    s = c3_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG", name="s1")
-    assert not s.is_annotated()
-    # annotation on different seq
-    s.annotation_db.add_feature(
-        seqid="s2",
-        biotype="gene",
-        name="blah",
-        spans=[(0, 10)],
-    )
-    assert not s.is_annotated()
-    # annotation wrong biotype
-    s.annotation_db.add_feature(
-        seqid="s1",
-        biotype="exon",
-        name="blah",
-        spans=[(0, 10)],
-    )
-    assert not s.is_annotated(biotype="gene")
-    s.annotation_db = None
-    assert not s.is_annotated()
 
 
 def test_to_html():


### PR DESCRIPTION
## Summary by Sourcery

Fix querying and slicing of annotated features by correctly applying annotation offsets at the sequence and alignment levels and add comprehensive tests for annotation_offset support.

New Features:
- Allow sequences to be created with an annotation_offset and propagate it through slicing and reverse complement operations

Bug Fixes:
- Correct translation between relative sequence coordinates and annotation spans by accounting for parent_offset in both absolute_position and relative_position calculations

Enhancements:
- Delegate alignment-level get_features calls to the sequence-level implementation to unify offset handling
- Add boundary checks in sequence.get_features to prevent index errors on view boundaries
- Implement lazy instantiation of the annotation_db property

Tests:
- Add tests for is_annotated under various biotype and missing-annotation scenarios
- Add tests for lazy annotation_db evaluation and explicit annotation_db initialization
- Add tests to verify annotation_offset behavior in sequence slicing and reverse complement contexts
- Add tests to verify feature extraction with offsets in both aligned and unaligned sequence collections