### PR TITLE
Bug fixes

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1774,7 +1774,8 @@ class SequenceCollection(AnnotatableMixin):
             )
             motifs.update(c.keys())
             counts.append(c)
-        motifs = sorted(motifs)
+        # use motifs from moltype if empty sequences
+        motifs = sorted(motifs) or sorted(self.moltype)
         for i, c in enumerate(counts):
             counts[i] = c.tolist(motifs)
         return MotifCountsArray(counts, motifs, row_indices=self.names)
@@ -5081,6 +5082,11 @@ class Alignment(SequenceCollection):
             motif columns
         """
         length = (len(self) // motif_length) * motif_length
+        if not length:
+            motifs = list(self.moltype)
+            counts = numpy.zeros((len(self.names), len(motifs)), dtype=int)
+            return MotifCountsArray(counts, motifs, row_indices=self.names)
+
         if warn and len(self) != length:
             warnings.warn(f"trimmed {len(self) - length}", UserWarning, stacklevel=2)
 

--- a/src/cogent3/core/profile.py
+++ b/src/cogent3/core/profile.py
@@ -28,7 +28,7 @@ class _MotifNumberArray(DictArray):
         # TODO validate that motifs are strings and row_indices are ints or
         # strings
         # TODO change row_indices argument name to row_keys
-        some_data = data.any() if isinstance(data, numpy.ndarray) else any(data)
+        some_data = any(data.shape) if isinstance(data, numpy.ndarray) else any(data)
         if not some_data or len(data) == 0:
             msg = "Must provide data"
             raise ValueError(msg)

--- a/src/cogent3/core/profile.py
+++ b/src/cogent3/core/profile.py
@@ -28,7 +28,7 @@ class _MotifNumberArray(DictArray):
         # TODO validate that motifs are strings and row_indices are ints or
         # strings
         # TODO change row_indices argument name to row_keys
-        some_data = any(data.shape) if isinstance(data, numpy.ndarray) else any(data)
+        some_data = data.size if isinstance(data, numpy.ndarray) else any(data)
         if not some_data or len(data) == 0:
             msg = "Must provide data"
             raise ValueError(msg)

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -334,6 +334,8 @@ class Sequence(AnnotatableMixin):
             motif columns
         """
         data = numpy.array(self)
+        if not len(data):
+            return CategoryCounter()
 
         if motif_length != 1:
             if warn and len(data) % motif_length != 0:

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -3978,6 +3978,26 @@ def test_alignment_repr():
     )
 
 
+@pytest.mark.parametrize(
+    "mk_cls", [c3_alignment.make_aligned_seqs, c3_alignment.make_unaligned_seqs]
+)
+def test_seqcoll_counts_per_seq(mk_cls):
+    data = {"a": "", "b": ""}
+    coll = mk_cls(data, moltype="dna")
+    got = coll.counts_per_seq()
+    assert numpy.allclose(got, 0)
+
+
+@pytest.mark.parametrize(
+    "mk_cls", [c3_alignment.make_aligned_seqs, c3_alignment.make_unaligned_seqs]
+)
+def test_seqcoll_repr_html(mk_cls):
+    data = {"a": "", "b": ""}
+    coll = mk_cls(data, moltype="dna")
+    got = coll.to_html()
+    assert isinstance(got, str)
+
+
 @pytest.mark.parametrize("seqid", ["seq1", "seq2", "seq3", "seq4"])
 def test_alignment_getitem_slice(aligned_dict, seqid):
     """slicing an alignment should propogate the slice to aligned instances"""
@@ -5366,10 +5386,8 @@ def test_make_gap_filter():
 
 @pytest.fixture(scope="session")
 def codon_and_aa_alns():
-    import cogent3
-
     data = {"s1": "ATG --- --- GAT --- AAA", "s2": "ATG CAA TCG AAT GAA ATA"}
-    dna = cogent3.make_aligned_seqs(
+    dna = c3_alignment.make_aligned_seqs(
         {n: s.replace(" ", "") for n, s in data.items()},
         moltype="dna",
     )
@@ -6199,3 +6217,10 @@ def test_alignment_copy_handling_annot_db():
 
     copied_aln = aln.copy(copy_annotations=False)
     assert copied_aln.annotation_db is orig_db
+
+
+def test_empty_aln_to_pretty():
+    data = {"a": "", "b": ""}
+    coll = c3_alignment.make_aligned_seqs(data, moltype="dna")
+    got = coll.to_pretty()
+    assert isinstance(got, str)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -3057,3 +3057,9 @@ def test_to_html_custom_moltype():
     )
     seq = mt.make_seq(seq="ACG.")
     assert isinstance(seq.to_html(), str)
+
+
+def test_counts_empty_seq():
+    s = cogent3.make_seq("", "a", moltype="dna")
+    c = s.counts()
+    assert not c.sum


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of empty sequences and alignments in counts methods and profile initialization, and add tests to cover these scenarios.

Bug Fixes:
- Ensure alignment.counts_per_seq() returns zero counts for empty alignments and falls back to moltype motifs
- Make codon-based counts method return zero arrays for empty alignments
- Have sequence.counts() return an empty CategoryCounter for empty sequences
- Correct profile initialization to detect empty numpy arrays via shape rather than data.any()

Tests:
- Add tests for empty alignment counts_per_seq, to_html, and to_pretty methods
- Add test for empty sequence counts() returning no counts
- Update alignment tests to use c3_alignment aliases consistently