### PR TITLE
BUG: fix alphabet.get_kmer_alphabet() for bytes moltype

### DIFF
--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -620,7 +620,8 @@ def _get_kmer_alpha(
 
     gap = gap_char * k if include_gap and gap_char is not None else None
     missing = missing_char * k if missing_char is not None and include_gap else None
-    words = tuple("".join(e) for e in itertools.product(chars, repeat=k))
+    joiner = b"".join if isinstance(monomers[0], bytes) else "".join
+    words = tuple(joiner(e) for e in itertools.product(chars, repeat=k))
     words += (gap,) if include_gap and gap else ()
     words += (missing,) if include_gap and missing else ()
 

--- a/tests/test_core/test_alphabet.py
+++ b/tests/test_core/test_alphabet.py
@@ -200,10 +200,19 @@ def test_char_alphabet_with_gap(gap):
 
 @pytest.mark.parametrize("k", [2, 3])
 def test_kmer_alphabet_construction(k):
-    dna = c3_moltype.get_moltype("dna")
-    monomers = dna.alphabet
+    mt = c3_moltype.get_moltype("dna")
+    monomers = mt.alphabet
     kmers = monomers.get_kmer_alphabet(k)
-    assert len(kmers) == 4**k
+    assert len(kmers) == len(monomers) ** k
+    assert kmers.motif_len == k
+
+
+def test_kmer_alphabet_construction_bytes():
+    k = 2
+    mt = c3_moltype.get_moltype("bytes")
+    monomers = mt.alphabet
+    kmers = monomers.get_kmer_alphabet(k)
+    assert len(kmers) == len(monomers) ** k
     assert kmers.motif_len == k
 
 


### PR DESCRIPTION
## Summary by Sourcery

Fix get_kmer_alphabet to support bytes alphabets by selecting the correct join function and add tests for bytes k-mer alphabets

Bug Fixes:
- Correct k-mer alphabet construction for bytes moltype

Enhancements:
- Use a bytes-specific joiner when monomer elements are bytes

Tests:
- Add test for bytes moltype k-mer alphabet construction
- Replace hardcoded size assertion with len(monomers)**k in k-mer alphabet tests