### PR TITLE
MAINT: added type hints to two stats.test functions

### DIFF
--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -1,7 +1,9 @@
 """Provides standard statistical tests. Tests produce statistic and P-value."""
 
+import typing
 import warnings
 
+import numpy.typing as npt
 from numpy import (
     absolute,
     allclose,
@@ -2289,7 +2291,10 @@ def get_ltm_cells(cells):  # pragma: no cover
     return sorted(set(new_cells))
 
 
-def probability_points(n):
+NumpyFloatArrayType = npt.NDArray[float64]
+
+
+def probability_points(n: int) -> NumpyFloatArrayType:
     """return series of n probabilities
 
     Returns
@@ -2300,13 +2305,21 @@ def probability_points(n):
     -----
     Useful for plotting probability distributions
     """
-    assert n > 0, f"{n} must be > 0"
+    if n <= 0:
+        msg = f"{n} must be > 0"
+        raise ValueError(msg)
+
     adj = 0.5 if n > 10 else 3 / 8
     denom = n if n > 10 else n + 1 - 2 * adj
     return array([(i - adj) / denom for i in range(1, n + 1)])
 
 
-def theoretical_quantiles(n, dist, **kwargs):
+DistLiteral = typing.Literal["normal", "chisq", "t", "uniform"]
+
+
+def theoretical_quantiles(
+    n: int, dist: DistLiteral, **kwargs: dict[str, typing.Any]
+) -> NumpyFloatArrayType:
     """returns theoretical quantiles from dist
 
     Parameters
@@ -2327,22 +2340,20 @@ def theoretical_quantiles(n, dist, **kwargs):
     -------
     Numpy array of quantiles
     """
-
-    dist = dist.lower()
+    dist_name = dist.lower()
     funcs = {
         "normal": ndtri,
         "chisq": chi2.isf,
         "t": t.ppf,
     }
 
-    if dist != "uniform" and dist not in funcs:
-        msg = f"'{dist} not in {list(funcs)}"
+    if dist_name != "uniform" and dist_name not in funcs:
+        msg = f"'{dist_name} not in {list(funcs)}"
         raise ValueError(msg)
 
     probs = probability_points(n)
-    if dist == "uniform":
+    if dist_name == "uniform":
         return probs
 
-    func = funcs[dist]
-
+    func = funcs[dist_name]
     return array([func(p, **kwargs) for p in probs])

--- a/tests/test_maths/test_stats/test_test.py
+++ b/tests/test_maths/test_stats/test_test.py
@@ -484,4 +484,6 @@ class TestDistMatrixPermutationTest(TestCase):
         assert_almost_equal(got, expect)
 
 
-# execute tests if called from command line
+def test_probability_point_invalid():
+    with pytest.raises(ValueError):
+        probability_points(-11)


### PR DESCRIPTION
## Summary by Sourcery

Annotate statistical test functions with precise type hints and aliases, refine error handling in probability_points, clarify variable naming in theoretical_quantiles, and add a corresponding unit test for invalid inputs.

Enhancements:
- Add type annotations and aliases for probability_points and theoretical_quantiles functions
- Replace assert with explicit ValueError in probability_points for invalid inputs
- Normalize distribution name variable in theoretical_quantiles and enforce supported distributions

Tests:
- Add test to verify ValueError is raised for invalid probability_points input