### PR TITLE
Revert "MAINT: added type hints to two stats.test functions"

### DIFF
--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -1,9 +1,7 @@
 """Provides standard statistical tests. Tests produce statistic and P-value."""
 
-import typing
 import warnings
 
-import numpy.typing as npt
 from numpy import (
     absolute,
     allclose,
@@ -2291,10 +2289,7 @@ def get_ltm_cells(cells):  # pragma: no cover
     return sorted(set(new_cells))
 
 
-NumpyFloatArrayType = npt.NDArray[float64]
-
-
-def probability_points(n: int) -> NumpyFloatArrayType:
+def probability_points(n):
     """return series of n probabilities
 
     Returns
@@ -2305,21 +2300,13 @@ def probability_points(n: int) -> NumpyFloatArrayType:
     -----
     Useful for plotting probability distributions
     """
-    if n <= 0:
-        msg = f"{n} must be > 0"
-        raise ValueError(msg)
-
+    assert n > 0, f"{n} must be > 0"
     adj = 0.5 if n > 10 else 3 / 8
     denom = n if n > 10 else n + 1 - 2 * adj
     return array([(i - adj) / denom for i in range(1, n + 1)])
 
 
-DistLiteral = typing.Literal["normal", "chisq", "t", "uniform"]
-
-
-def theoretical_quantiles(
-    n: int, dist: DistLiteral, **kwargs: dict[str, typing.Any]
-) -> NumpyFloatArrayType:
+def theoretical_quantiles(n, dist, **kwargs):
     """returns theoretical quantiles from dist
 
     Parameters
@@ -2340,20 +2327,22 @@ def theoretical_quantiles(
     -------
     Numpy array of quantiles
     """
-    dist_name = dist.lower()
+
+    dist = dist.lower()
     funcs = {
         "normal": ndtri,
         "chisq": chi2.isf,
         "t": t.ppf,
     }
 
-    if dist_name != "uniform" and dist_name not in funcs:
-        msg = f"'{dist_name} not in {list(funcs)}"
+    if dist != "uniform" and dist not in funcs:
+        msg = f"'{dist} not in {list(funcs)}"
         raise ValueError(msg)
 
     probs = probability_points(n)
-    if dist_name == "uniform":
+    if dist == "uniform":
         return probs
 
-    func = funcs[dist_name]
+    func = funcs[dist]
+
     return array([func(p, **kwargs) for p in probs])

--- a/tests/test_maths/test_stats/test_test.py
+++ b/tests/test_maths/test_stats/test_test.py
@@ -484,6 +484,4 @@ class TestDistMatrixPermutationTest(TestCase):
         assert_almost_equal(got, expect)
 
 
-def test_probability_point_invalid():
-    with pytest.raises(ValueError):
-        probability_points(-11)
+# execute tests if called from command line


### PR DESCRIPTION
Reverts cogent3/cogent3#2430

## Summary by Sourcery

Revert recently added type hints in stats test functions, restoring original untyped signatures, simplifying input validation and variable naming, and removing the corresponding invalid-input test.

Enhancements:
- Remove NumpyFloatArrayType and DistLiteral aliases and their type annotations
- Restore original untyped signatures for probability_points and theoretical_quantiles
- Replace ValueError check in probability_points with an assert-based input validation
- Simplify variable naming and error messaging in theoretical_quantiles

Tests:
- Remove test for invalid probability_points input