### PR TITLE
MAINT: fix error message

### DIFF
--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -2348,7 +2348,7 @@ def theoretical_quantiles(
     }
 
     if dist_name != "uniform" and dist_name not in funcs:
-        msg = f"'{dist_name} not in {list(funcs)}"
+        msg = f"{dist_name!r} not in {list(funcs)}"
         raise ValueError(msg)
 
     probs = probability_points(n)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use repr to properly quote the distribution name in the error message when it is not found in the supported functions list