### PR TITLE
clean up deprecated maths/stats/test.py code and tests

### DIFF
--- a/src/cogent3/maths/stats/test.py
+++ b/src/cogent3/maths/stats/test.py
@@ -209,7 +209,7 @@ def G_2_by_2(a, b, c, d, williams=1, directional=1):
     # find which tail we were in if the test was directional
     if directional:
         is_high = (b == 0) or (d != 0 and (a / b > c / d))
-        p = tail(p, is_high)
+        p = p / 2 if is_high else 1 - p / 2
         if not is_high:
             G = -G
     return G, p
@@ -2328,7 +2328,7 @@ def theoretical_quantiles(n, dist, **kwargs):
     Numpy array of quantiles
     """
 
-    dist = dist.lower()
+    dist_name = dist.lower()
     funcs = {
         "normal": ndtri,
         "chisq": chi2.isf,
@@ -2340,9 +2340,9 @@ def theoretical_quantiles(n, dist, **kwargs):
         raise ValueError(msg)
 
     probs = probability_points(n)
-    if dist == "uniform":
+    if dist_name == "uniform":
         return probs
 
-    func = funcs[dist]
+    func = funcs[dist_name]
 
     return array([func(p, **kwargs) for p in probs])

--- a/tests/test_maths/test_stats/test_test.py
+++ b/tests/test_maths/test_stats/test_test.py
@@ -118,16 +118,6 @@ class TestsHelper(TestCase):
 class TestsTests(TestCase):
     """Tests miscellaneous functions."""
 
-    def test_multiple_n(self):
-        """multiple_n should swap parameters in multiple_comparisons"""
-        assert_allclose(multiple_n(1e-7, 1 - 0.9990005), 10000, rtol=1e-6, atol=1e-6)
-        assert_allclose(multiple_n(0.05, 0.4012631), 10, rtol=1e-6, atol=1e-6)
-        assert_allclose(multiple_n(1e-20, 1e-20), 1)
-        assert_allclose(multiple_n(1e-300, 1e-300), 1)
-        assert_allclose(multiple_n(0.95, 0.99987499999999996), 3)
-        assert_allclose(multiple_n(0.5, 0.96875), 5)
-        assert_allclose(multiple_n(1e-20, 1e-19), 10)
-
     def test_get_alternate(self):
         """correctly identifies the specified alternate hypothesis"""
         alt = _get_alternate("lo")
@@ -310,17 +300,6 @@ class StatTests(TestsHelper):
             7.25,
             7.79,
         ]
-
-    def test_permute_observations(self):
-        """Test works correctly on small input dataset."""
-        I = [10, 20.0, 1]
-        II = [2, 4, 5, 7]
-        obs = _permute_observations(I, II, 1)
-        assert len(obs[0]) == 1
-        assert len(obs[1]) == 1
-        assert len(obs[0][0]) == len(I)
-        assert len(obs[1][0]) == len(II)
-        assert_allclose(sorted(concatenate((obs[0][0], obs[1][0]))), sorted(I + II))
 
 
 class CorrelationTests(TestsHelper):


### PR DESCRIPTION
2 tests of functions (`multiple_n`,` _permute_observations`) that have been deprecated - removing the tests

`G_2_by_2` was calling deprecated function `tail` when the arg direction is set (1-tailed test) - now inlined 

fix dist_names in test:theoretical_quantiles
