### PR TITLE
BUG: Sequence.is_valid() now works

### DIFF
--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -452,7 +452,7 @@ class Sequence(AnnotatableMixin):
 
     def is_valid(self) -> bool:
         """Returns True if sequence contains no items absent from alphabet."""
-        return self.moltype.is_valid(self)
+        return self.moltype.is_valid(numpy.array(self))
 
     def is_strict(self) -> bool:
         """Returns True if sequence contains only monomers."""

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -3063,3 +3063,19 @@ def test_counts_empty_seq():
     s = cogent3.make_seq("", "a", moltype="dna")
     c = s.counts()
     assert not c.sum
+
+
+@pytest.mark.parametrize("name", ["dna", "rna", "protein", "protein_with_stop", "text"])
+def test_is_valid(name):
+    raw = "ACGGA"
+    moltype = c3_moltype.get_moltype(name)
+    seq = moltype.make_seq(name="s1", seq=raw)
+    assert seq.is_valid()
+
+
+@pytest.mark.parametrize("name", ["dna", "rna"])
+def test_is_valid_false(name):
+    raw = "ACGXA"
+    moltype = c3_moltype.get_moltype(name)
+    seq = moltype.make_seq(name="s1", seq=raw, check_seq=False)
+    assert not seq.is_valid()


### PR DESCRIPTION
[FIXED] thanks for reporting this @rmcar17!

## Summary by Sourcery

Fix sequence validity check and add tests for Sequence.is_valid

Bug Fixes:
- Sequence.is_valid now passes a numpy array to moltype.is_valid to correctly validate sequences

Tests:
- Add parametrized tests for Sequence.is_valid returning True for various moltypes with valid sequences
- Add parametrized tests for Sequence.is_valid returning False for DNA and RNA sequences containing invalid characters