### PR TITLE
Another bug fix

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1308,10 +1308,10 @@ class MolType(Generic[StrOrBytes]):
             the sequence whose molecular weight is to be calculated.
         method
             the method provided to .disambiguate() to disambiguate the sequence.
-            either "random" or "first".
+            either "random" (a random choice of states encoded by the ambiguity)
+            or "strip" (delete positions with ambiguous characters).
         delta
             if delta is present, uses it instead of the standard weight adjustment.
-
         """
         if not seq:
             return 0

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -546,7 +546,7 @@ class Sequence(AnnotatableMixin):
         the MW by 2: the results may not be accurate due to strand bias, e.g.
         in mitochondrial genomes.
         """
-        return self.moltype.mw(self, method, delta)
+        return self.moltype.mw(str(self), method, delta)
 
     def can_match(self, other: Self) -> bool:
         """Returns True if every pos in self could match same pos in other.

--- a/src/cogent3/data/molecular_weight.py
+++ b/src/cogent3/data/molecular_weight.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env Python
 """Data for molecular weight calculations on proteins and nucleotides."""
+
+from cogent3.util import warning as c3warn
 
 ProteinWeights = {
     "A": 71.09,
@@ -38,20 +39,25 @@ class WeightCalculator:
     """Calculates molecular weight of a non-degenerate sequence."""
 
     # refactor: array
+    c3warn.deprecated_args(
+        "2025.9",
+        reason="pep8",
+        old_new=[("Weights", "weights"), ("Correction", "correction")],
+    )
 
-    def __init__(self, Weights: dict[str, float], Correction: float) -> None:
+    def __init__(self, weights: dict[str, float], correction: float) -> None:
         """Returns a new WeightCalculator object (class, so serializable)."""
-        self.Weights = Weights
-        self.Correction = Correction
+        self.weights = weights
+        self.correction = correction
 
     def __call__(self, seq: str, correction: float | None = None) -> float:
         """Returns the molecular weight of a specified sequence."""
         if not seq:
             return 0
         if correction is None:
-            correction = self.Correction
-        get_mw = self.Weights.get
-        return sum([get_mw(i, 0) for i in seq]) + correction
+            correction = self.correction
+        mws = self.weights
+        return sum(mws[i] for i in seq) + correction
 
 
 DnaMW = WeightCalculator(DnaWeights, DnaWeightCorrection)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -492,6 +492,18 @@ def test_mw():
     assert numpy.allclose(c3_moltype.RNA.make_seq(seq="AAACCCA").mw(), 2182.37)
 
 
+def test_mw_method():
+    """MW handles ambiguity using nominated method"""
+    seq = c3_moltype.RNA.make_seq(seq="AARCCCA")
+    strip_seq = c3_moltype.RNA.make_seq(seq="AACCCA")
+    # strip method removes ambiguity characters
+    with_strip = seq.mw(method="strip")
+    expect = strip_seq.mw()
+    assert numpy.allclose(with_strip, expect)
+    with_random = seq.mw(method="random")
+    assert not numpy.allclose(with_random, expect)
+
+
 def test_can_match():
     """Sequence can_match should return True if all positions can match"""
     assert c3_moltype.RNA.make_seq(seq="").can_match("")

--- a/tests/test_data/test_molecular_weight.py
+++ b/tests/test_data/test_molecular_weight.py
@@ -1,38 +1,29 @@
-#!/usr/bin/env python
 """Tests for molecular weight."""
-
-from unittest import TestCase
 
 from numpy.testing import assert_allclose
 
 from cogent3.data.molecular_weight import ProteinMW, RnaMW
 
 
-class WeightCalculatorTests(TestCase):
-    """Tests for WeightCalculator, which should calculate molecular weights."""
-
-    def test_call(self):
-        """WeightCalculator should return correct molecular weight"""
-        r = RnaMW
-        p = ProteinMW
-        assert p("") == 0
-        assert r("") == 0
-        assert_allclose(p("A"), 89.09)
-        assert_allclose(r("A"), 375.17)
-        assert_allclose(p("AAA"), 231.27)
-        assert_allclose(r("AAA"), 1001.59)
-        assert_allclose(r("AAACCCA"), 2182.37)
-        assert_allclose(
-            p(
-                "MVQQAESLEAESNLPREALDTEEGEFMACSPVALDESDPDWCKTASGHIKRPMNAFMVWSKIERRKIMEQSPDMHNAEISKRLGKR\
-                                 WKMLKDSEKIPFIREAERLRLKHMADYPDYKYRPRKKPKMDPSAKPSASQSPEKSAAGGGGGSAGGGAGGAKTSKGSSKKCGKLKA\
-                                 PAAAGAKAGAGKAAQSGDYGGAGDDYVLGSLRVSGSGGGGAGKTVKCVFLDEDDDDDDDDDELQLQIKQEPDEEDEEPPHQQLLQP\
-                                 PGQQPSQLLRRYNVAKVPASPTLSSSAESPEGASLYDEVRAGATSGAGGGSRLYYSFKNITKQHPPPLAQPALSPASSRSVSTSSS\
-                                 SSSGSSSGSSGEDADDLMFDLSLNFSQSAHSASEQQLGGGAAAGNLSLSLVDKDLDSFSEGSLGSHFEFPDYCTPELSEMIAGDWL\
-                                 EANFSDLVFTY",
-            ),
-            46685.97,
-        )
-
-
-# run if called from command-line
+def test_call():
+    """WeightCalculator should return correct molecular weight"""
+    r = RnaMW
+    p = ProteinMW
+    assert p("") == 0
+    assert r("") == 0
+    assert_allclose(p("A"), 89.09)
+    assert_allclose(r("A"), 375.17)
+    assert_allclose(p("AAA"), 231.27)
+    assert_allclose(r("AAA"), 1001.59)
+    assert_allclose(r("AAACCCA"), 2182.37)
+    big_seq = (
+        "MVQQAESLEAESNLPREALDTEEGEFMACSPVALDESDPDWCKTASGHIKRPMNAFMVWS"
+        "KIERRKIMEQSPDMHNAEISKRLGKRWKMLKDSEKIPFIREAERLRLKHMADYPDYKYRP"
+        "RKKPKMDPSAKPSASQSPEKSAAGGGGGSAGGGAGGAKTSKGSSKKCGKLKAPAAAGAKA"
+        "GAGKAAQSGDYGGAGDDYVLGSLRVSGSGGGGAGKTVKCVFLDEDDDDDDDDDELQLQIK"
+        "QEPDEEDEEPPHQQLLQPPGQQPSQLLRRYNVAKVPASPTLSSSAESPEGASLYDEVRAG"
+        "ATSGAGGGSRLYYSFKNITKQHPPPLAQPALSPASSRSVSTSSSSSSGSSSGSSGEDADD"
+        "LMFDLSLNFSQSAHSASEQQLGGGAAAGNLSLSLVDKDLDSFSEGSLGSHFEFPDYCTPE"
+        "LSEMIAGDWLEANFSDLVFTY"
+    )
+    assert_allclose(p(big_seq), 46685.97)


### PR DESCRIPTION
## Summary by Sourcery

Refactor molecular weight calculation logic and tests, deprecate outdated WeightCalculator parameters, improve Sequence.mw input handling, and add new ambiguity-handling tests.

New Features:
- Add tests for Sequence.mw ambiguity handling covering strip and random methods

Bug Fixes:
- Fix Sequence.mw to pass the sequence string to the underlying moltype.mw call instead of the Sequence object

Enhancements:
- Deprecate old WeightCalculator init parameters and rename them to lowercase with a warning
- Simplify WeightCalculator summation logic by using a direct comprehension
- Refactor molecular weight tests to use plain test functions and a concatenated string variable instead of a TestCase subclass