### PR TITLE
MAINT: actually use decorator syntax ... doh!

### DIFF
--- a/src/cogent3/data/molecular_weight.py
+++ b/src/cogent3/data/molecular_weight.py
@@ -39,12 +39,11 @@ class WeightCalculator:
     """Calculates molecular weight of a non-degenerate sequence."""
 
     # refactor: array
-    c3warn.deprecated_args(
+    @c3warn.deprecated_args(
         "2025.9",
         reason="pep8",
         old_new=[("Weights", "weights"), ("Correction", "correction")],
     )
-
     def __init__(self, weights: dict[str, float], correction: float) -> None:
         """Returns a new WeightCalculator object (class, so serializable)."""
         self.weights = weights

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -502,6 +502,7 @@ def test_mw_method():
     assert numpy.allclose(with_strip, expect)
     with_random = seq.mw(method="random")
     assert not numpy.allclose(with_random, expect)
+    assert with_random > with_strip
 
 
 def test_can_match():


### PR DESCRIPTION
## Summary by Sourcery

Apply decorator syntax for deprecated_args in WeightCalculator and strengthen molecular weight test

Enhancements:
- Use @c3warn.deprecated_args decorator syntax on WeightCalculator.__init__

Tests:
- Add assertion that random molecular weight calculation exceeds stripped weight in test_mw_method