### PR TITLE
ENH: make alphabets responsible for checking seq validity

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -443,7 +443,7 @@ class SeqsData(SeqsDataABC):
 
         Raises
         ------
-        c3_alphabet.AlphabetError if the check fails
+        AlphabetError if the check fails
         """
         self._alphabet = alphabet
         self._offset = offset or {}
@@ -619,14 +619,8 @@ class SeqsData(SeqsDataABC):
             as_new_alpha = self.alphabet.convert_seq_array_to(
                 seq=seq_data,
                 alphabet=alphabet,
-                check_valid=False,
+                check_valid=check_valid,
             )
-            if check_valid and not alphabet.is_valid(as_new_alpha):
-                msg = (
-                    f"Changing from old alphabet={self.alphabet} to new "
-                    f"{alphabet=} is not valid for this data"
-                )
-                raise c3_alphabet.AlphabetError(msg)
             new_data[seqid] = as_new_alpha
 
         return self.copy(
@@ -3742,12 +3736,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
         names = tuple(data.keys())
         array_seqs = numpy.empty((len(names), align_len), dtype=alphabet.dtype)
         for i, name in enumerate(names):
-            array_seqs[i] = alphabet.to_indices(data[name])
-            if not alphabet.is_valid(data[name]):
-                msg = f"Sequence {name} contains invalid characters."
-                raise c3_alphabet.AlphabetError(
-                    msg,
-                )
+            array_seqs[i] = alphabet.to_indices(data[name], validate=True)
 
         array_seqs.flags.writeable = False
         return cls(
@@ -4119,12 +4108,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
 
         new_seqs = dict(zip(self.names, self._gapped, strict=False))
         for name, seq in seqs.items():
-            seq = self.alphabet.to_indices(seq)
-            if not self.alphabet.is_valid(seq):
-                msg = f"Sequence {name!r} contains invalid characters."
-                raise c3_alphabet.AlphabetError(
-                    msg,
-                )
+            seq = self.alphabet.to_indices(seq, validate=True)
             seq.flags.writeable = False
             new_seqs[name] = seq
 
@@ -4178,14 +4162,8 @@ class AlignedSeqsData(AlignedSeqsDataABC):
             as_new_alpha = self.alphabet.convert_seq_array_to(
                 seq=seq_data,
                 alphabet=alphabet,
-                check_valid=False,
+                check_valid=check_valid,
             )
-            if check_valid and not alphabet.is_valid(as_new_alpha):
-                msg = (
-                    f"Changing from old alphabet={self.alphabet} to new "
-                    f"{alphabet=} is not valid for this data"
-                )
-                raise c3_alphabet.AlphabetError(msg)
             gapped[i] = as_new_alpha
 
         return self.__class__(

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -121,6 +121,7 @@ class AlphabetABC(ABC, Generic[StrOrBytes]):
         | list[str | bytes]
         | tuple[str | bytes, ...]
         | NumpyIntArrayType,
+        validate: bool = True,
     ) -> NumpyIntArrayType: ...
 
     @abstractmethod
@@ -393,8 +394,18 @@ class CharAlphabet(
         | tuple[str | bytes, ...]
         | list[str | bytes]
         | NumpyIntArrayType,
+        validate: bool = True,
     ) -> NumpyIntArrayType:
-        """returns a sequence of indices for the characters in seq"""
+        """returns a sequence of indices for the characters in seq
+
+        Parameters
+        ----------
+        seq
+            sequence to convert to a numpy array
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+        """
         if isinstance(seq, tuple):
             indices: list[int] = []
             for c in seq:
@@ -407,10 +418,14 @@ class CharAlphabet(
         if isinstance(seq, bytes):
             # any non-canonical characters should lie outside the range
             # we replace these with a single value
-            return self._bytes2arr(seq)
+            seq = self._bytes2arr(seq)
 
         if isinstance(seq, numpy.ndarray):
-            return seq.astype(self.dtype)
+            seq = seq.astype(self.dtype)
+            if validate and not self.is_valid(seq):
+                msg = "sequence has invalid characters"
+                raise AlphabetError(msg)
+            return seq
 
         msg = f"{type(seq)} is invalid"
         raise TypeError(msg)
@@ -502,7 +517,7 @@ class CharAlphabet(
     def is_valid(self, seq: str | bytes | NumpyIntArrayType) -> bool:
         """seq is valid for alphabet"""
         if isinstance(seq, (str, bytes)):
-            seq = self.to_indices(seq)
+            seq = self.to_indices(seq, validate=False)
 
         if isinstance(seq, numpy.ndarray):
             return bool(seq.min() >= 0 and seq.max() < len(self) if len(seq) else True)
@@ -866,7 +881,11 @@ def kmer_indices_to_seq(
 
 class KmerAlphabetABC(ABC, Generic[StrOrBytes]):
     @abstractmethod
-    def to_index(self, seq: str | bytes | NumpyIntArrayType) -> int: ...
+    def to_index(
+        self,
+        seq: str | bytes | NumpyIntArrayType,
+        validate: bool = True,
+    ) -> int: ...
 
     @abstractmethod
     def from_index(self, kmer_index: int) -> str | NumpyIntArrayType: ...
@@ -1033,6 +1052,7 @@ class KmerAlphabet(
         | tuple[str | bytes, ...]
         | list[str | bytes]
         | NumpyIntArrayType,
+        validate: bool = True,
         independent_kmer: bool = True,
     ) -> NumpyIntArrayType:
         """returns a sequence of k-mer indices
@@ -1041,6 +1061,9 @@ class KmerAlphabet(
         ----------
         seq
             a sequence of monomers
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
         independent_kmer
             if True, returns non-overlapping k-mers
 
@@ -1052,13 +1075,14 @@ class KmerAlphabet(
         a k-mer contains a non-canonical and non-gap character,
         it is assigned an index of (num. monomer states**k) + 1.
         If self.gap_char is None, then both of the above cases
-        are defined as (num. monomer states**k)."""
+        are defined as (num. monomer states**k).
+        """
         # TODO: handle case of non-modulo sequences
         if isinstance(seq, (tuple, list)):
             return numpy.array([self.to_index(c) for c in seq], dtype=self.dtype)
 
         if isinstance(seq, (str, bytes)):
-            seq = self.monomers.to_indices(seq)
+            seq = self.monomers.to_indices(seq, validate=validate)
 
         if isinstance(seq, numpy.ndarray):
             size = len(seq) - self.k + 1
@@ -1067,7 +1091,7 @@ class KmerAlphabet(
             result = numpy.zeros(size, dtype=self.dtype)
             gap_char_index = self.monomers.gap_index or -1
             gap_index = self.gap_index or -1
-            return seq_to_kmer_indices(
+            seq = seq_to_kmer_indices(
                 seq,
                 result,
                 self._coeffs,
@@ -1077,6 +1101,7 @@ class KmerAlphabet(
                 gap_index=gap_index,
                 independent_kmer=independent_kmer,
             )
+            return seq
 
         msg = f"{type(seq)} is invalid"
         raise TypeError(msg)
@@ -1134,7 +1159,11 @@ class KmerAlphabet(
         monomers = self.monomers.with_gap_motif(missing_char=missing)
         return monomers.get_kmer_alphabet(self.k, include_gap=True)
 
-    def to_index(self, seq: str | bytes | NumpyIntArrayType) -> int:
+    def to_index(
+        self,
+        seq: str | bytes | NumpyIntArrayType,
+        validate: bool = True,
+    ) -> int:
         """encodes a k-mer as a single integer
 
         Parameters
@@ -1143,7 +1172,9 @@ class KmerAlphabet(
             sequence to be encoded, can be either a string or numpy array
         overlapping
             if False, performs operation on sequential k-mers, e.g. codons
-
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
 
         Notes
         -----
@@ -1151,9 +1182,10 @@ class KmerAlphabet(
         returns num_states**k if a k-mer contains a gap character,
         otherwise returns num_states**k + 1 if a k-mer contains a
         non-canonical character. If self.gap_char is not defined,
-        returns num_states**k for both cases."""
+        returns num_states**k for both cases.
+        """
         if isinstance(seq, (str, bytes)):
-            seq = self.monomers.to_indices(seq)
+            seq = self.monomers.to_indices(seq, validate=validate)
 
         if isinstance(seq, numpy.ndarray):
             if len(seq) != self.k:
@@ -1343,9 +1375,27 @@ class SenseCodonAlphabet(
         return None
 
     def to_indices(  # type: ignore[override]
-        self, seq: str | list[str] | tuple[str, ...] | NumpyIntArrayType
+        self,
+        seq: str | list[str] | tuple[str, ...] | NumpyIntArrayType,
+        validate: bool = True,
     ) -> NumpyIntArrayType:
-        """returns a sequence of codon indices"""
+        """returns a sequence of codon indices
+
+        Parameters
+        ----------
+        seq
+            input sequence to be converted to a numpy array of uint
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        TypeError
+            if seq is unsupported type
+        AlphabetError
+            if resulting sequence is not valid
+        """
 
         if isinstance(seq, str):
             seq = [seq[i : i + 3] for i in range(0, len(seq), 3)]
@@ -1355,17 +1405,45 @@ class SenseCodonAlphabet(
             seq = [self.monomers.from_indices(c) for c in seq.reshape(size, 3)]
 
         if isinstance(seq, (list, tuple)):
-            return numpy.array([self.to_index(c) for c in seq], dtype=self.dtype)
+            seq = numpy.array(
+                [self.to_index(c, validate=validate) for c in seq], dtype=self.dtype
+            )
+
+            if validate and not self.is_valid(seq):
+                msg = "sequence has invalid characters"
+                raise AlphabetError(msg)
+            return seq
 
         msg = f"{type(seq)} is invalid"
         raise TypeError(msg)
 
-    def to_index(self, codon: str) -> int:  # type: ignore
-        """encodes a codon as a single integer"""
+    def to_index(
+        self,
+        codon: str,
+        validate: bool = True,
+    ) -> int:  # type: ignore
+        """encodes a codon as a single integer
+
+        Parameters
+        ----------
+        codon
+            string to be converted into index
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        ValueError
+            if codon is not of length 3
+        AlphabetError
+            if codon contains an invalid nucleotide or is not present in
+            the code
+        """
         if len(codon) != 3:
             msg = f"{codon=!r} is not of length 3"
             raise ValueError(msg)
-        if not self.monomers.is_valid(codon):
+        if validate and not self.monomers.is_valid(codon):
             msg = f"{codon=!r} elements not nucleotides"
             raise AlphabetError(msg)
 

--- a/src/cogent3/core/genetic_code.py
+++ b/src/cogent3/core/genetic_code.py
@@ -261,7 +261,7 @@ class GeneticCode:
 
         # convert to indices and then bytes
         if incomplete_ok:
-            seq = self.codons.to_indices(dna)
+            seq = self.codons.to_indices(dna, validate=False)
             missing = seq >= len(self.codons)
         else:
             codons = self.get_alphabet(
@@ -269,7 +269,7 @@ class GeneticCode:
                 include_gap=True,
                 include_missing=True,
             )
-            seq = codons.to_indices(dna)
+            seq = codons.to_indices(dna, validate=False)
             missing = seq >= len(codons)
         # any codon indices include missing data, they will have an index ==
         # length of the alphabet employed, so we need to modify that index

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -759,10 +759,25 @@ class MolType(Generic[StrOrBytes]):
         """
         return callable(self._complement)
 
-    def has_ambiguity(self, seq: str | bytes | NumpyIntArrayType) -> bool:
-        """whether sequence has an ambiguity character"""
+    def has_ambiguity(
+        self, seq: str | bytes | NumpyIntArrayType, validate: bool = True
+    ) -> bool:
+        """whether sequence has an ambiguity character
+
+        Parameters
+        ----------
+        seq
+            input sequence to be converted to a numpy array of uint
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy alphabet.is_valid()
+        """
         if isinstance(seq, str):
-            return any(self.is_ambiguity(c) for c in seq) if self.ambiguities else False
+            return (
+                any(self.is_ambiguity(c, validate=validate) for c in seq)
+                if self.ambiguities
+                else False
+            )
 
         if isinstance(seq, bytes):
             return self.has_ambiguity(seq.decode("utf8"))
@@ -781,7 +796,21 @@ class MolType(Generic[StrOrBytes]):
         raise TypeError(msg)
 
     def rc(self, seq: str, validate: bool = True) -> str:
-        """reverse reverse complement of a sequence"""
+        """reverse reverse complement of a sequence
+
+        Parameters
+        ----------
+        seq
+            sequence to be reversed
+        validate
+            if True, checks the sequence is validated against the most
+            degenerate alphabet
+
+        Raises
+        ------
+        AlphabetError
+            if invalid characters present
+        """
         if validate and not self.is_valid(seq):
             msg = f"{seq[:4]!r} not valid for moltype {self.name!r}"
             raise c3_alphabet.AlphabetError(
@@ -793,7 +822,23 @@ class MolType(Generic[StrOrBytes]):
     def is_degenerate(
         self, seq: str | bytes | NumpyIntArrayType, validate: bool = True
     ) -> bool:
-        """checks if a sequence contains degenerate characters"""
+        """checks if a sequence contains degenerate characters
+
+        Parameters
+        ----------
+        seq
+            sequence to be evaluated
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        TypeError
+            if seq is not a supported type
+        AlphabetError
+            if invalid characters present
+        """
         if not isinstance(seq, (str, bytes, numpy.ndarray)):
             msg = f"{type(seq)} not supported"
             raise TypeError(msg)
@@ -805,7 +850,7 @@ class MolType(Generic[StrOrBytes]):
             )
 
         if isinstance(seq, (str, bytes)):
-            seq = self.most_degen_alphabet().to_indices(seq)
+            seq = self.most_degen_alphabet().to_indices(seq, validate=validate)
 
         if self.degen_alphabet is None:
             return False
@@ -817,7 +862,23 @@ class MolType(Generic[StrOrBytes]):
     def is_gapped(
         self, seq: str | bytes | NumpyIntArrayType, validate: bool = True
     ) -> bool:
-        """checks if a sequence contains gaps"""
+        """checks if a sequence contains gaps
+
+        Parameters
+        ----------
+        seq
+            sequence to be evaluated
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        TypeError
+            if seq is not a supported type
+        AlphabetError
+            if invalid characters present
+        """
         if not isinstance(seq, (str, bytes, numpy.ndarray)):
             msg = f"{type(seq)} not supported"
             raise TypeError(msg)
@@ -845,15 +906,16 @@ class MolType(Generic[StrOrBytes]):
         include_gap: bool = True,
         validate: bool = True,
     ) -> list[int]:
-        """Return List of position indexs of degenerate characters in the sequence.
+        """Return list of position indexs of degenerate characters in the sequence.
 
         Parameters
         ----------
-        seq : str | bytes | NumpyIntArrayType
+        seq
             the sequence to be used for getting degenerate positions
-        include_gap : bool, optional
-            if True, then the gap state together with ’canonical’ sates (A,C,G,T for DNA) will be considered non-ambiguous.
-        validate : bool, optional
+        include_gap
+            if True, then the gap state together with 'canonical' sates
+            (A,C,G,T for DNA) will be considered non-ambiguous.
+        validate
             if True, checks the sequence is validated for the alphabet
         """
         if validate and not self.is_valid(seq):
@@ -885,7 +947,23 @@ class MolType(Generic[StrOrBytes]):
     def degap(
         self, seq: str | bytes | NumpyIntArrayType, validate: bool = True
     ) -> str | bytes | NumpyIntArrayType:
-        """removes all gap and missing characters from a sequence"""
+        """removes all gap and missing characters from a sequence
+
+        Parameters
+        ----------
+        seq
+            sequence to degapped
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        TypeError
+            if seq is not a supported type
+        AlphabetError
+            if invalid characters present
+        """
         # refactor: design
         # cache translation callables (using alpabet.convert_alphabet)
         # previous implementation had support for tuples -- is this necessary?
@@ -927,8 +1005,13 @@ class MolType(Generic[StrOrBytes]):
         query_motif
             the motif being queried.
         validate
-            if True, checks the sequence is validated against the most
-            degenerate alphabet
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        AlphabetError
+            if invalid characters present
         """
         if not self.ambiguities:
             return False
@@ -964,6 +1047,14 @@ class MolType(Generic[StrOrBytes]):
         allow_gap
             whether the gap character is allowed in output. Only
             applied when alphabet is None.
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        AlphabetError
+            if invalid characters present
 
         Notes
         -----
@@ -1055,6 +1146,7 @@ class MolType(Generic[StrOrBytes]):
             assert self.degen_gapped_alphabet is not None
             return self.degen_gapped_alphabet.to_indices(
                 self.strip_degenerate(self.degen_gapped_alphabet.array_to_bytes(seq)),
+                validate=False,
             )
         msg = f"{type(seq)} not supported"
         raise TypeError(msg)
@@ -1069,7 +1161,9 @@ class MolType(Generic[StrOrBytes]):
         if isinstance(seq, bytes):
             assert self.degen_gapped_alphabet is not None
             return self.degen_gapped_alphabet.array_to_bytes(
-                self._strip_bad(self.degen_gapped_alphabet.to_indices(seq)),
+                self._strip_bad(
+                    self.degen_gapped_alphabet.to_indices(seq, validate=False)
+                ),
             )
 
         if isinstance(seq, str):
@@ -1095,7 +1189,9 @@ class MolType(Generic[StrOrBytes]):
         if isinstance(seq, bytes):
             assert self.degen_gapped_alphabet is not None
             return self.degen_gapped_alphabet.array_to_bytes(
-                self._strip_bad_and_gaps(self.degen_gapped_alphabet.to_indices(seq)),
+                self._strip_bad_and_gaps(
+                    self.degen_gapped_alphabet.to_indices(seq, validate=False)
+                ),
             )
 
         if isinstance(seq, str):
@@ -1181,6 +1277,7 @@ class MolType(Generic[StrOrBytes]):
                 self.random_disambiguate(
                     self.degen_gapped_alphabet.array_to_bytes(seq)
                 ),
+                validate=False,
             )
 
         msg = f"{type(seq)} not supported"
@@ -1202,14 +1299,32 @@ class MolType(Generic[StrOrBytes]):
         assert self.degen_gapped_alphabet is not None
         return numpy.sum(seq == self.degen_gapped_alphabet.gap_index)
 
-    def count_degenerate(self, seq: str | bytes) -> int:
-        """returns the number of degenerate characters in a sequence"""
+    def count_degenerate(self, seq: str | bytes, validate: bool = True) -> int:
+        """returns the number of degenerate characters in a sequence
+
+        Parameters
+        ----------
+        seq
+            sequence to degapped
+        validate
+            raises an AlphabetError if the resulting sequence does not
+            satisfy self.is_valid()
+
+        Raises
+        ------
+        TypeError
+            if seq is not a supported type
+        c3_alphabet.AlphabetError
+            if invalid characters present
+        """
         if isinstance(seq, str):
             seq = seq.encode("utf8")
 
         if isinstance(seq, bytes):
             assert self.degen_gapped_alphabet is not None
-            return self._count_degenerate(self.degen_gapped_alphabet.to_indices(seq))
+            return self._count_degenerate(
+                self.degen_gapped_alphabet.to_indices(seq, validate=validate)
+            )
 
         msg = f"{type(seq)} not supported"
         raise TypeError(msg)

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -2942,6 +2942,7 @@ class SeqView(SeqViewABC):
             self.parent[
                 self.slice_record.start : self.slice_record.stop : self.slice_record.step
             ],
+            validate=False,
         )
 
     @property

--- a/tests/test_core/test_alphabet.py
+++ b/tests/test_core/test_alphabet.py
@@ -97,7 +97,7 @@ def test_charalphabet_to_indices_non_canonical(gap):
     # canonical
     canonical = list(f"TCAG{gap}")
     alpha = c3_alphabet.CharAlphabet(canonical, gap=gap or None)
-    got = alpha.to_indices("ACNGT")
+    got = alpha.to_indices("ACNGT", validate=False)
     assert got.max() >= len(canonical)
 
 
@@ -264,8 +264,8 @@ def test_seq_to_kmer_indices_handle_missing(gap_index):
 def test_kmer_alpha_to_indices_to_index_with_gap(gap):
     alpha = c3_alphabet.CharAlphabet(list(f"TCAG{gap}"), gap=gap or None)
     dinucs = alpha.get_kmer_alphabet(k=2, include_gap=bool(gap))
-    got1 = int(dinucs.to_indices("--")[0])
-    got2 = dinucs.to_index("--")
+    got1 = int(dinucs.to_indices("--", validate=False)[0])
+    got2 = dinucs.to_index("--", validate=False)
     assert got1 == got2 == 16
 
 
@@ -443,7 +443,7 @@ def test_kmer_alphabet_to_indices_invalid():
 def test_kmer_alphabet_is_valid(seq):
     dna = c3_moltype.get_moltype("dna")
     dinuc_alpha = dna.alphabet.get_kmer_alphabet(k=2, include_gap=False)
-    dinucs = dinuc_alpha.to_indices(seq)
+    dinucs = dinuc_alpha.to_indices(seq, validate=False)
     assert dinuc_alpha.is_valid(dinucs)
 
 
@@ -820,3 +820,48 @@ def test_consistent_dtype(alpha, cast):
     seq = cast(seq)
     indices = alpha.to_indices(seq)
     assert indices.dtype == alpha.dtype
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        c3_moltype.DNA.alphabet,
+        c3_moltype.DNA.alphabet.get_kmer_alphabet(k=2),
+        c3_moltype.DNA.alphabet.get_kmer_alphabet(k=3),
+        c3_genetic_code.DEFAULT.get_alphabet(include_stop=False),
+    ],
+)
+def test_to_indices_validate(alpha):
+    raw_seq = "ATGT%G"
+    # by default we raise an exception
+    with pytest.raises(c3_alphabet.AlphabetError):
+        alpha.to_indices(raw_seq, validate=True)
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        c3_moltype.DNA.alphabet,
+        c3_moltype.DNA.alphabet.get_kmer_alphabet(k=2),
+        c3_moltype.DNA.alphabet.get_kmer_alphabet(k=3),
+    ],
+)
+def test_to_indices_no_validate(alpha):
+    raw_seq = "ATGT%G"
+    got = alpha.to_indices(raw_seq, validate=False)
+    assert isinstance(got, numpy.ndarray)
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        c3_moltype.DNA.alphabet,
+        c3_moltype.DNA.alphabet.get_kmer_alphabet(k=2),
+        c3_moltype.DNA.alphabet.get_kmer_alphabet(k=3),
+    ],
+)
+def test_to_indices_no_validate_codon(alpha):
+    # still raises AlphabetError because no such codon
+    raw_seq = "ATGT%G"
+    with pytest.raises(c3_alphabet.AlphabetError):
+        alpha.to_indices(raw_seq, validate=True)

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -79,7 +79,7 @@ def test_complement(name, seq, data_type):
 
 def make_typed(seq, data_type, moltype):
     if data_type is numpy.ndarray:
-        seq = moltype.most_degen_alphabet().to_indices(seq)
+        seq = moltype.most_degen_alphabet().to_indices(seq, validate=False)
     elif data_type is bytes:
         seq = seq.encode("utf-8")
     return seq
@@ -120,7 +120,7 @@ def test_is_not_degenerate(seq, data_type):
 
 def test_is_degenerate_invalid():
     with pytest.raises(TypeError):
-        c3_moltype.RNA.is_degenerate(list("GAG"))
+        c3_moltype.RNA.is_degenerate(list("GAG"), validate=False)
 
 
 @pytest.mark.parametrize("data_type", [str, bytes, numpy.ndarray])
@@ -498,7 +498,7 @@ def test_count_degenerate():
     assert d("GACUGCAUGCAUCGUACGUCAGUACCGA") == 0
     assert d("N") == 1
     assert d("NRY") == 3
-    assert d("ACGUAVCUAGCAUNUCAGUCAGyUACGUCAGS") == 4
+    assert d("ACGUAVCUAGCAUNUCAGUCAGYUACGUCAGS", validate=False) == 4
 
 
 def test_count_variants():

--- a/tests/test_evolve/test_coevolution.py
+++ b/tests/test_evolve/test_coevolution.py
@@ -26,7 +26,7 @@ def calc_mi_pair(alignment, pos1, pos2, normalised=False):
 
 @pytest.fixture(params=["AAAAA", "ACGT", "AACC", "ACGNNGG"])
 def column(request):
-    return get_moltype("dna").alphabet.to_indices(request.param)
+    return get_moltype("dna").most_degen_alphabet().to_indices(request.param)
 
 
 # revised code tests


### PR DESCRIPTION
When converting a sequence into an array, the alphabet.to_indices() methods should handle it.