### PR TITLE
MAINT: refactor Alignment.to_dict() for performance

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -7054,6 +7054,23 @@ class Alignment(SequenceCollection):
 
         return super().duplicated_seqs()
 
+    def to_dict(self, as_array: bool = False) -> dict[str, str | numpy.ndarray]:
+        """Return a dictionary of sequences.
+
+        Parameters
+        ----------
+        as_array
+            if True, sequences are returned as numpy arrays, otherwise as strings
+        """
+        arrayseqs = self.array_seqs
+        if as_array:
+            return {n: arrayseqs[i] for i, n in enumerate(self.names)}
+
+        return {
+            n: self.storage.alphabet.from_indices(arrayseqs[i])
+            for i, n in enumerate(self.names)
+        }
+
 
 @register_deserialiser(
     get_object_provenance(Alignment),


### PR DESCRIPTION
## Summary by Sourcery

Refactor Alignment.to_dict to improve performance and support returning sequences as numpy arrays via an `as_array` flag

New Features:
- Add `as_array` parameter to Alignment.to_dict to optionally return numpy arrays

Enhancements:
- Optimize Alignment.to_dict by using pre-fetched array sequences and direct enumeration for faster dictionary construction