### PR TITLE
ENH: added MolType.gapped_missing_alphabet property

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -575,6 +575,11 @@ class MolType(Generic[StrOrBytes]):
         return self._gapped
 
     @property
+    def gapped_missing_alphabet(self) -> c3_alphabet.CharAlphabet[StrOrBytes] | None:
+        """monomers + gap"""
+        return self._gapped_missing
+
+    @property
     def degen_gapped_alphabet(self) -> c3_alphabet.CharAlphabet[StrOrBytes] | None:
         """monomers + gap + ambiguous characters"""
         return self._degen_gapped

--- a/tests/test_core/test_moltype.py
+++ b/tests/test_core/test_moltype.py
@@ -622,6 +622,17 @@ def test_not_is_nucleic(moltype):
     assert not mt.is_nucleic
 
 
+@pytest.mark.parametrize("moltype", ["protein", "text", "protein_with_stop"])
+def test_gapped_missing_alphabet(moltype):
+    mt = c3_moltype.get_moltype(moltype)
+    assert mt.gapped_missing_alphabet
+
+
+def test_gapped_missing_alphabet_bytes():
+    mt = c3_moltype.get_moltype("bytes")
+    assert mt.gapped_missing_alphabet is None
+
+
 def test_moltype_coerce_seqs():
     dna = c3_moltype.get_moltype("dna")
     rna_seq = "AUUG"


### PR DESCRIPTION
## Summary by Sourcery

Add a new gapped_missing_alphabet property to MolType and validate its behavior across different moltypes

New Features:
- Add MolType.gapped_missing_alphabet property to expose the alphabet with missing characters

Tests:
- Add tests for gapped_missing_alphabet on protein, text, protein_with_stop types
- Add test to verify gapped_missing_alphabet is None for bytes moltype