### PR TITLE
MAINT: refactor variable pos numba funcs

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -5400,8 +5400,8 @@ class Alignment(SequenceCollection):
             return ()
 
         alpha = self.storage.alphabet
-        gap_index = alpha.gap_index if alpha.gap_index else len(alpha)
-        missing_index = alpha.missing_index if alpha.missing_index else len(alpha)
+        gap_index = alpha.gap_index or len(alpha)
+        missing_index = alpha.missing_index or len(alpha)
         if include_gap_motif and include_ambiguity:
             # allow all states
             func = None


### PR DESCRIPTION
## Summary by Sourcery

Refactor the variable_positions method to replace inline column-check logic with specialized numba-jitted helper functions and remove the deprecated allow-all function.

Enhancements:
- Precompute gap and missing symbol indices for use in variable position detection
- Dispatch variable position checks to specific JIT-compiled functions (_var_pos_canonical, _var_pos_not_gap, _var_pos_canonical_or_gap) based on include settings
- Eliminate the old inline logic and remove the unused _var_pos_allow_all helper