### PR TITLE
DEV: control tests using cogent3-h5seqs by version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ Changelog = "https://github.com/cogent3/cogent3/blob/develop/changelog.md"
 
 [project.optional-dependencies]
 test = [
-    #"cogent3-h5seqs",
+    "cogent3-h5seqs",
     "piqtree>=0.6; python_version >= '3.11'",
     "ruff==0.12.12",
     "kaleido",

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -26,7 +26,11 @@ from cogent3.util.deserialise import deserialise_object
 from cogent3.util.misc import get_object_provenance
 
 try:
-    import cogent3_h5seqs  # noqa: F401
+    import cogent3_h5seqs
+
+    vers = tuple(int(v) for v in cogent3_h5seqs.__version__.split(".")[:3])
+    if not (vers > (0, 6, 1)):
+        raise ImportError  # noqa: TRY301
 
     has_hf_seqs = True
 except ImportError:


### PR DESCRIPTION
## Summary by Sourcery

Gate alignment tests on cogent3-h5seqs >=0.6.2 and declare cogent3-h5seqs as a test dependency

Build:
- Uncomment and include cogent3-h5seqs in optional test dependencies

Tests:
- Add version-based import guard in test_alignment to skip tests on cogent3-h5seqs <= 0.6.1