### PR TITLE
Add default params for compatibility with sc-supertree

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2142,8 +2142,8 @@ class TreeBuilder:
         children: PySeq[PhyloNode] | None,
         name: str | None,
         params: dict[str, Any],
-        length: float | None,
-        support: float | None,
+        length: float | None = None,
+        support: float | None = None,
         name_loaded: bool = True,
     ) -> PhyloNode:
         """Callback for newick parser"""


### PR DESCRIPTION
Hello, 
I was working through an example with [sc-supertree](https://pypi.org/project/sc-supertree/), which uses cogent3, when I came across an error:
```TypeError: TreeBuilder.create_edge() missing 2 required positional arguments: 'length' and 'support'```
I don't know the history here. e.g. if this package was developed against an earlier version of cogent3 that had a different signature or these parameters previously had default `None` values, or something else. 

This PR gives default null values to these two optional parameters and allows `sc-supertree` to work as expected.

## Summary by Sourcery

Add default None values for length and support parameters in create_edge to maintain backward compatibility

Bug Fixes:
- Provide default None for create_edge length parameter
- Provide default None for create_edge support parameter