### PR TITLE
MAINT: remove NucleicAcidSequenceMixin.__str__

### DIFF
--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1955,13 +1955,6 @@ class ProteinWithStopSequence(Sequence):
 class NucleicAcidSequenceMixin:
     """Mixin class for DNA and RNA sequences."""
 
-    def __str__(self) -> str:
-        result = str(self._seq)
-        if self._seq.is_reversed:
-            with contextlib.suppress(TypeError):
-                result = self.moltype.complement(result)
-        return result
-
     def can_pair(self, other: Self) -> bool:
         """Returns True if self and other could pair.
 
@@ -2211,13 +2204,13 @@ class NucleicAcidSequenceMixin:
         return cat.G_fit()
 
 
-class DnaSequence(Sequence, NucleicAcidSequenceMixin):
+class DnaSequence(NucleicAcidSequenceMixin, Sequence):
     """Holds the standard DNA sequence."""
 
     # constructed by DNA moltype
 
 
-class RnaSequence(Sequence, NucleicAcidSequenceMixin):
+class RnaSequence(NucleicAcidSequenceMixin, Sequence):
     """Holds the standard RNA sequence."""
 
     # constructed by RNA moltype


### PR DESCRIPTION
[CHANGED] the inheritance order for DnaSequence and RnaSequence
     meant NucleicAcidSequenceMixin.__str__ was never called,
     and when the order was changed it became clear it was
     incorrect! Thanks to @rmcar17 for identifying this
     inconsistency.

## Summary by Sourcery

Remove the flawed __str__ override from NucleicAcidSequenceMixin and swap the inheritance order for DnaSequence and RnaSequence to correct the method resolution order

Bug Fixes:
- Drop the incorrect __str__ implementation from NucleicAcidSequenceMixin

Enhancements:
- Reorder DnaSequence and RnaSequence to inherit from NucleicAcidSequenceMixin before Sequence