### PR TITLE
BUG: Fix unclosed Connection warnings

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: "Run nox for ${{ matrix.python-version }}"
         env:
-          PYTHONTRACEMALLOC: "20"
+          PYTHONTRACEMALLOC: "3"
         shell: bash
         run: |
           dn=$(pwd)

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -44,6 +44,8 @@ jobs:
           uv tool install -p venv nox
 
       - name: "Run nox for ${{ matrix.python-version }}"
+        env:
+          PYTHONTRACEMALLOC: "20"
         shell: bash
         run: |
           dn=$(pwd)

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -693,7 +693,7 @@ class SqliteAnnotationDbMixin:
             self._db_wrapper = db
             self._init_tables()
             return
-        print(type(db))
+
         if db and not self.compatible(db):
             msg = f"cannot initialise annotation db from {type(db)}"
             raise TypeError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,13 @@ def HOME_TMP_DIR(DATA_DIR) -> pathlib.Path:
         yield HOME / dn
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _try_cleaning_up_on_autouse_fixture_teardown():
+    yield
+    for _ in range(10):
+        gc.collect()
+
+
 def pytest_sessionfinish(session, exitstatus):
     for _ in range(10):
         gc.collect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,4 +20,5 @@ def HOME_TMP_DIR(DATA_DIR) -> pathlib.Path:
 
 
 def pytest_sessionfinish(session, exitstatus):
-    gc.collect()
+    for _ in range(10):
+        gc.collect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import pathlib
 
 import pytest
@@ -16,3 +17,7 @@ def HOME_TMP_DIR(DATA_DIR) -> pathlib.Path:
     HOME = pathlib.Path("~")
     with tempfile.TemporaryDirectory(dir=HOME.expanduser()) as dn:
         yield HOME / dn
+
+
+def pytest_sessionfinish(session, exitstatus):
+    gc.collect()

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -132,7 +132,7 @@ def test_constructor_db_instance_works(db_name, cls, request):
 def test_constructor_db_connection_works(db_name, cls, request):
     # only compatible db's used to init
     db = request.getfixturevalue(db_name)
-    cls(db=db.db)
+    cls(db=db._db_wrapper)
 
 
 def test_gff_describe(gff_db):
@@ -981,7 +981,7 @@ def test_equal():
     db3 = BasicAnnotationDb()
     assert db1 != db2
     # we define equality by same class AND same db instance
-    db3._db = db2._db
+    db3._db_wrapper = db2._db_wrapper
     assert db2 == db3
 
 


### PR DESCRIPTION
The problem with closing the Connection of deletion of an annotation db is that the same underlying Connection object could exist in a different annotation db. For example, the `__setstate__` method constructs a new annotation db object (including a new _db Connection) before updating `self`'s `__dict__` with that of the other object. If a connection is closed upon the deletion of an annotation db, then `__setstate__` would destroy the temporarily created annotation db, which would then close the connection of self's db.

The best workaround I considered was to create a wrapper class for storing Connections, and closing the Connection only on the deletion of the wrapper object. In the above scenario for `__setstate__`, the same instance of the wrapper class is propagated from `new` to `self` instead of the underlying Connection. When `new` is destroyed on function exit, the `__del__` method on `DBWrapper` is not called because the same instance still exists under `self`.

The change is backwards incompatible. Previously, it was possible to construct an annotation db with `db` set to a Connection object. However, this feature was only used in a single test and it is possible to construct it with the DBWrapper instead (which is also safer if only the wrapper is allowed to close the connection). It also involves the renaming of a semi-private attribute.

## Summary by Sourcery

Introduce a DBWrapper class to encapsulate sqlite3 connections and avoid unclosed Connection warnings by closing only when the wrapper is garbage-collected, and refactor AnnotationDb to use this wrapper throughout its internal state management.

Bug Fixes:
- Prevent premature closing of shared sqlite Connections during annotation db deletion and state restoration.

Enhancements:
- Replace the internal _db attribute with a DBWrapper and update methods (__getstate__, __setstate__, __deepcopy__, _setup_db, db property, close, and constructors) to use the wrapper for connection lifecycle management.

Tests:
- Update tests to construct and compare AnnotationDb instances using the new DBWrapper instead of raw sqlite3.Connection.