### PR TITLE
MAINT: refactor PhyloNode.sorted() to iterative algoritm

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -1166,7 +1166,7 @@ class PhyloNode:
                 child_info = [(scores[ch], rebuilt[ch]) for ch in node.children]
                 # Sort children by score, None is treated as +infinity
                 child_info.sort(key=lambda x: (infinity if x[0] is None else x[0]))
-                children = tuple(child.deepcopy() for _, child in child_info)
+                children = tuple(child for _, child in child_info)
                 tree = constructor(node, children, None)
                 non_null = [s for s, _ in child_info if s is not None]
                 score = non_null[0] if non_null else None


### PR DESCRIPTION
[CHANGED] use the existing postorder() traversal algorithm, which is
    iterative, rather than doing a recursive algorithm. The latter
    will not scale well with large tree.

## Summary by Sourcery

Refactor PhyloNode.sorted() to use an iterative postorder traversal instead of recursion for better performance on large trees

Enhancements:
- Replace private recursive _sorted method with an iterative postorder-based algorithm to score and rebuild nodes
- Refactor sorted() to use score_map and a single-pass traversal for tip ordering, improving scalability with large trees