### PR TITLE
ENH: added a new plugin hook for counting kmers and implemented method on SequenceCollection

### DIFF
--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -5,6 +5,9 @@ import typing
 import stevedore
 
 if typing.TYPE_CHECKING:  # pragma: no cover
+    import numpy
+    import numpy.typing as npt
+
     from cogent3.core.alignment import (
         AlignedSeqsDataABC,
         Alignment,
@@ -53,6 +56,60 @@ def get_quick_tree_hook(
         raise ValueError(msg)
 
     return cogent3.get_app("quick_tree")
+
+
+P = typing.ParamSpec("P")
+
+
+TAppAPI = typing.Callable[
+    typing.Concatenate[int, P],
+    typing.Callable[[list[str]], "npt.NDArray[numpy.integer]"],
+]
+
+
+def get_count_kmers_hook(
+    *,
+    name: str | None = None,
+    **kwargs,  # noqa: ANN003
+) -> TAppAPI | None:
+    """returns app instance registered for count_kmers matching name
+
+    Parameters
+    ----------
+    name
+        name of package to get the app from
+    **kwargs
+        additional arguments to pass to the app
+
+    Notes
+    -----
+    The app constructor must take keyword arguments and the
+    instance must take a list of strings as input and return
+    a numpy array of integers.
+
+    Returns
+    -------
+    Returns the first found app instance, or one matching name
+    or None if no app found.
+    """
+    mgr = stevedore.hook.HookManager(
+        namespace=HOOK_ENTRY_POINT,
+        name="count_kmers",
+        invoke_on_load=False,
+    )
+    if name != "cogent3":
+        for extension in mgr.extensions:
+            if name and extension.module_name.startswith(name):
+                return extension.plugin(**kwargs)
+            # return first one if no name specified
+            return extension.plugin(**kwargs)
+
+        if name:
+            msg = f"Could not find count_kmers plugin for {name!r}"
+            raise ValueError(msg)
+
+    # we don't have a cogent3 app for this, we just use the builtin function
+    return None
 
 
 # registry for parsing sequence file formats

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -2495,6 +2495,57 @@ class SequenceCollection(AnnotatableMixin):
             omit.extend(group[1:])
         return self.take_seqs(omit, negate=True)
 
+    def count_kmers(
+        self,
+        k: int = 1,
+        use_hook: str | None = None,
+        **kwargs,  # noqa: ANN003
+    ) -> NumpyIntArrayType:
+        """return kmer counts for each sequence
+
+        Parameters
+        ----------
+        k
+            length of kmers to count
+        use_hook
+            name of a third-party package that implements the quick_tree
+            hook. If not specified, defaults to the first available hook or
+            the cogent3 quick_tree() app. To force default, set
+            use_hook="cogent3".
+        **kwargs
+            additional arguments to pass to the hook app constructor
+
+        Notes
+        -----
+        Only states in moltype.alphabet are allowed in a kmer (the canonical
+        states). If using cogent3, to get the order of kmers as strings, use
+        self.moltype.alphabet.get_kmer_alphabet(k). See the documentation
+        for details of any third-party hooks.
+
+        Returns
+        -------
+        numpy array of shape (num_seqs, num_kmers)
+        0th axis is in the order of self.names, 1st axis is in the order
+        of the kmer alphabet.
+        """
+        from cogent3._plugin import get_count_kmers_hook
+
+        kwargs = {"k": k, **kwargs}
+
+        app = get_count_kmers_hook(name=use_hook, **kwargs)
+        if app is not None:
+            # we call main method directly so errors are raised here
+            return typing.cast("NumpyIntArrayType", app.main(list(self.seqs)))
+
+        shape = (self.num_seqs, len(self.moltype.alphabet) ** k)
+        result = numpy.empty(shape, dtype=int)
+        for i, name in enumerate(self.names):
+            # following may be made more efficient by directly reading from storage
+            # but this is simpler and handles strand transformations etc
+            seq = numpy.array(self.seqs[name])
+            result[i, :] = c3_sequence.count_kmers(seq, len(self.moltype.alphabet), k)
+        return result
+
 
 @register_deserialiser(
     get_object_provenance(SequenceCollection),

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -6416,3 +6416,15 @@ def test_asd_get_positions_err(dna_alphabet, bas_pos):
     asd = c3_alignment.AlignedSeqsData.from_seqs(data=data, alphabet=dna_alphabet)
     with pytest.raises(IndexError):
         _ = asd.get_positions(asd.names, bas_pos)
+
+
+@pytest.mark.parametrize("k", [1, 2])
+@pytest.mark.parametrize(
+    "data",
+    [["ATCGATCGA", "TAGCTAGC"], ["ATCGATCGA", "NNN"], ["ATCGATCGA", ""], ["", ""]],
+)
+def test_coll_count_kmers(k, data):
+    coll = c3_alignment.make_unaligned_seqs(data, moltype="dna")
+    expect = numpy.array([seq.count_kmers(k=k) for seq in coll.seqs])
+    got = coll.count_kmers(k=k)
+    assert numpy.allclose(got, expect)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -3117,6 +3117,14 @@ def test_count_kmers_use_hook_wrong_name():
         seq.count_kmers(k=3, use_hook="invalid name")
 
 
+def test_count_kmers_gt_seq():
+    k = 2
+    seq = cogent3.get_dataset("brca1")["Human"].seq[: k - 1]
+    got = seq.count_kmers(k=k)
+    assert got.size == 4**k
+    assert numpy.allclose(got, 0)
+
+
 def test_count_kmers_use_hook_none():
     seq = cogent3.get_dataset("brca1")["Human"].seq
     got = seq.count_kmers(k=3, use_hook=None)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -3111,6 +3111,18 @@ def test_count_kmers(k):
     assert (got == expect).all()
 
 
+def test_count_kmers_use_hook_wrong_name():
+    seq = cogent3.get_dataset("brca1")["Human"].seq
+    with pytest.raises(ValueError):
+        seq.count_kmers(k=3, use_hook="invalid name")
+
+
+def test_count_kmers_use_hook_none():
+    seq = cogent3.get_dataset("brca1")["Human"].seq
+    got = seq.count_kmers(k=3, use_hook=None)
+    assert got.sum() > 0
+
+
 def test_count_kmers_seq_gt_k():
     seq = cogent3.get_dataset("brca1")["Human"].seq[:3]
     k = 4


### PR DESCRIPTION
## Summary by Sourcery

Add a plugin hook for k-mer counting and integrate it into SequenceCollection and Sequence classes with a built-in fallback implementation

New Features:
- Introduce get_count_kmers_hook in the plugin system to load third-party k-mer counting apps
- Implement count_kmers methods on SequenceCollection and Sequence that invoke a plugin or fall back to the built-in counter

Tests:
- Add tests for SequenceCollection count_kmers consistency with per-sequence counts
- Add tests for invalid hook name errors and default fallback behavior when use_hook is None