### PR TITLE
DEV: Add mypy CI check

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -58,6 +58,26 @@ jobs:
           flag-name: run-${{matrix.python-version}}-${{matrix.os}}
           file: "tests/lcov-${{matrix.os}}-${{matrix.python-version}}.lcov"
 
+  type_check:
+    name: Type Check
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      
+      - name: "Run Type Checking for ${{ matrix.python-version }}" 
+        run: |
+          pip install -e .[typing]
+          mypy src/cogent3/core/alignment.py src/cogent3/core/alphabet.py src/cogent3/core/annotation.py src/cogent3/core/genetic_code.py src/cogent3/core/location.py src/cogent3/core/moltype.py src/cogent3/core/seq_storage.py src/cogent3/core/sequence.py src/cogent3/core/seqview.py src/cogent3/core/slice_record.py src/cogent3/core/tree.py
+
+
   finish:
     name: "Finish Coveralls"
     needs: tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "scitrack",
     "stevedore",
     "tqdm",
-    "typing_extensions",
+    "typing_extensions"
 ]
 # remember to update version in requires-python and classifiers
 requires-python = ">=3.11,<3.14"
@@ -62,6 +62,7 @@ test = [
     "tinydb",
     "nox"
 ]
+typing = ["mypy==1.18.2", "plotly-stubs"]
 doc = [
     "click",
     "cogent3[extra]",
@@ -102,7 +103,8 @@ dev = [
     "scriv",
     "types-tqdm",
     "cogent3[doc]",
-    "cogent3[test]"
+    "cogent3[test]",
+    "cogent3[typing]"
 ]
 
 [tool.flit.sdist]


### PR DESCRIPTION
## Summary by Sourcery

Add static type checking via mypy to the project's CI pipeline and update dependencies accordingly

Build:
- Add a “typing” extra in pyproject.toml with mypy and plotly-stubs and include it in dev dependencies

CI:
- Introduce a new GitHub Actions “Type Check” job to run mypy on core modules using Python 3.13