### PR TITLE
MAINT: refactor storage.get_hash() implementation and use

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -589,7 +589,13 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         """returns the names of duplicated sequences"""
         seq_hashes: defaultdict[str, list[str]] = defaultdict(list)
         for n, n2 in self.name_map.items():
-            h = cast("str", self.storage.get_hash(n2))
+            h = cast("str | None", self.storage.get_hash(n2))
+            if h is None:
+                cls = self.__class__.__name__
+                msg = (
+                    f"{cls} has an inconsistent state, no sequence found for name={n!r}"
+                )
+                raise RuntimeError(msg)
             seq_hashes[h].append(n)
         return [v for v in seq_hashes.values() if len(v) > 1]
 


### PR DESCRIPTION
[CHANGED] we're not doing anything with the hashes aside from
    using them in figuring out duplicate sequences, so no value
    to storing in a dict

## Summary by Sourcery

Refactor sequence storage to drop hash caching and recompute hashes on demand, unify get_hash behavior across aligned and unaligned data, truncate array_hash64 output, update duplicated_seqs to error on missing sequences, and add corresponding tests.

Bug Fixes:
- Make duplicated_seqs raise a RuntimeError when get_hash returns None due to inconsistent storage state

Enhancements:
- Remove internal hash cache and compute sequence hashes on each get_hash call
- Update get_hash to return None for unknown sequence IDs and unify signature for aligned and unaligned storage
- Truncate array_hash64 output to the first 16 hex characters

Tests:
- Add tests for storage.get_hash behavior including nonexistent keys
- Add tests for duplicated_seqs error on inconsistent storage
- Add test ensuring duplicated_seqs uses storage.get_hash implementation