### PR TITLE
ENH: added PhyloNode.renamed_nodes() method, fixes #2488

### DIFF
--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -2021,6 +2021,19 @@ class PhyloNode:
             dists[tip.name] = cum_sum
         return dists
 
+    def renamed_nodes(self, name_map: dict[str, str]) -> Self:
+        """returns a copy of the tree with nodes renamed according to name_map
+
+        Parameters
+        ----------
+        name_map
+            dict of {old_name: new_name, ...}
+        """
+        new_tree = self.deepcopy()
+        for node in new_tree.preorder():
+            node.name = name_map.get(node.name, node.name)
+        return new_tree
+
 
 T = TypeVar("T", bound=PhyloNode)
 

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -2640,3 +2640,40 @@ def test_ladderise_multifurcating_depth5(treestring):
     expected_newick = "(A,B,(C,D,(E,F)));"
     assert result_newick == expected_newick, f"{treestring} → {result_newick}"
     assert ladderised.same_topology(tree)
+
+
+@pytest.mark.parametrize(
+    "treestring",
+    [
+        "((C,D,(E,F)),A,B);",
+        "((A,B)AB,(C,D)CD)",
+    ],
+)
+def test_renamed_nodes(treestring):
+    tree = make_tree(treestring=treestring)
+    node_names = tree.get_node_names()
+    expected = [n.lower() for n in node_names]
+    name_map = dict(zip(node_names, expected, strict=True))
+    rn_tree = tree.renamed_nodes(name_map)
+    names = set(rn_tree.get_node_names())
+    assert names == set(expected)
+    assert rn_tree is not tree
+
+
+@pytest.mark.parametrize(
+    "treestring",
+    [
+        "((C,D,(E,F)),A,B);",
+        "((A,B)AB,(C,D)CD)",
+    ],
+)
+def test_renamed_nodes_just_tips(treestring):
+    tree = make_tree(treestring=treestring)
+    node_names = [n.name for n in tree.preorder() if not n.is_tip()]
+    tip_names = tree.get_tip_names()
+    expected = [n.lower() for n in tip_names]
+    name_map = dict(zip(tip_names, expected, strict=True))
+    rn_tree = tree.renamed_nodes(name_map)
+    names = set(rn_tree.get_node_names())
+    assert names == set(expected) | set(node_names)
+    assert rn_tree is not tree


### PR DESCRIPTION
## Summary by Sourcery

Introduce renamed_nodes method on PhyloNode to produce a renamed copy of a tree based on a name-mapping, and add tests to verify full-node and tip-only renaming behavior

New Features:
- Add PhyloNode.renamed_nodes method to deepcopy a tree and rename nodes according to a provided mapping

Tests:
- Add test to ensure renamed_nodes correctly renames all nodes and returns a distinct tree
- Add test to ensure renamed_nodes can selectively rename only tip nodes while preserving internal node names