### PR TITLE
ENH: improve feature querying performance with large collections

### DIFF
--- a/src/cogent3/core/seq_storage.py
+++ b/src/cogent3/core/seq_storage.py
@@ -305,11 +305,10 @@ class SeqsData(SeqsDataABC):
 
     def get_view(self, seqid: str) -> SeqDataView:
         """reurns view of sequence data for seqid"""
-        seq_len = len(self._data[seqid])
         return SeqDataView(
             parent=self,
             seqid=seqid,
-            parent_len=seq_len,
+            parent_len=self.get_seq_length(seqid),
             alphabet=self.alphabet,
         )
 

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -5700,9 +5700,9 @@ def test_alignment_to_rich_dict_round_trip_offset(mk_cls):
     offsets = {"seq1": 10, "seq2": 20}
     aln = mk_cls(data, moltype="dna", offset=offsets)
     rd = aln.to_rich_dict()
-    got = deserialise_object(rd)._seqs_data.offset
+    got = deserialise_object(rd).storage.offset
     expect = {"seq1": 0, "seq2": 0}
-    assert got == expect
+    assert {k: got[k] for k in expect} == expect
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[CHANGED] directly use storage get_seq_length() method
  rather than costly creating instances.

[CHANGED] if no seqids provided, find seqids that match the
  other conditions and use those

[CHANGED] refactor get_view(), use the storage.get_seq_length()
  method to avoid code duplication.

[CHANGED] modify test of offset attribute to support defaultdict
  usage

## Summary by Sourcery

Enhance performance of feature querying and sequence length retrieval by leveraging storage.get_seq_length() and direct seqid filtering, and update tests to accommodate defaultdict-based offsets.

Enhancements:
- Use storage.get_seq_length() instead of sequence instantiation for sequence length calculations in __repr__ and get_view
- Optimize get_features to pre-filter seqids via annotation_db when seqid is None to reduce Sequence instantiation overhead on large collections
- Adjust alignment offset test to use storage.offset and compare relevant keys to support defaultdict usage