### PR TITLE
Resolve sqlite resource warnings in tests

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -419,6 +419,10 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
     def __ne__(self, other: object) -> bool:
         return not self == other
 
+    def __del__(self):
+        if self._annotation_db:
+            self._annotation_db = None
+
     @property
     @abstractmethod
     def modified(self) -> bool: ...
@@ -5394,8 +5398,9 @@ def merged_db_collection(
         if first is None or db is None or first is db:
             continue
         first.update(db)
+        db.close()
 
-    return cast("SupportsFeatures", merged)
+    return cast("SupportsFeatures | None", merged)
 
 
 @dataclasses.dataclass

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -744,7 +744,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
 
         seq1: c3_sequence.Sequence | Aligned = self.seqs[name1]
         seq2: c3_sequence.Sequence | Aligned = self.seqs[name2]
-        if not self._annotation_db:
+        if not self.has_annotation_db():
             annotated = False
         else:
             annotated = any(
@@ -853,7 +853,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
 
         init_kwargs = self._get_init_kwargs()
         init_kwargs["name_map"] = selected_name_map
-        if self._annotation_db:
+        if self.has_annotation_db():
             if copy_annotations:
                 ann_db = type(self.annotation_db)()
                 ann_db.update(
@@ -932,7 +932,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         seq: c3_sequence.Sequence | Aligned = self.seqs[seqname]
         if isinstance(seq, Aligned):
             seq = seq.seq
-        if copy_annotations and self._annotation_db:
+        if copy_annotations and self.has_annotation_db():
             # we need to copy the sequence too to break the link to self.annotation_db
             seq = seq.copy(exclude_annotations=True)
             seq.annotation_db = type(self.annotation_db)()
@@ -1122,7 +1122,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             # no matching ID's, nothing to do
             return
 
-        if not self._annotation_db:
+        if not self.has_annotation_db():
             self.replace_annotation_db(type(seq_db)())
 
         if self.annotation_db.compatible(
@@ -1581,6 +1581,10 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         for group in dupes:
             omit.extend(group[1:])
         return self.take_seqs(omit, negate=True)
+
+    def has_annotation_db(self) -> bool:
+        """returns True if self has annotation db"""
+        return bool(self._annotation_db)
 
 
 class SequenceCollection(CollectionBase[c3_sequence.Sequence]):
@@ -2339,7 +2343,7 @@ class SequenceCollection(CollectionBase[c3_sequence.Sequence]):
         strictly starting after start will be returned.
         """
 
-        if not self._annotation_db:
+        if not self.has_annotation_db():
             return None
 
         if seqid and (seqid not in self.names):
@@ -3395,7 +3399,7 @@ class Alignment(CollectionBase[Aligned]):
         yield a sequence segment that is consistently oriented irrespective
         of strand of the current instance.
         """
-        if not self._annotation_db:
+        if not self.has_annotation_db():
             return None
 
         seqid_to_seqname = {v: k for k, v in self._name_map.items()}
@@ -3468,7 +3472,7 @@ class Alignment(CollectionBase[Aligned]):
         """
         del kwargs
 
-        if not self._annotation_db or not len(self._annotation_db):
+        if not self.has_annotation_db() or not len(self._annotation_db):
             return None
 
         # we only do on-alignment in here
@@ -4908,7 +4912,9 @@ class Alignment(CollectionBase[Aligned]):
         init_args.pop("slice_record")  # slice is realised
         init_args["moltype"] = other.moltype
         init_args["seqs_data"] = seq_data
-        init_args["annotation_db"] = other.annotation_db
+        init_args["annotation_db"] = (
+            other.annotation_db if other.has_annotation_db() else None
+        )
         return self.__class__(**init_args)
 
     def copy(self, copy_annotations: bool = False) -> Self:
@@ -5370,6 +5376,9 @@ def merged_db_collection(
     merged = None
     for seq in seqs:
         if not isinstance(seq, c3_sequence.Sequence):
+            continue
+
+        if not seq.has_annotation_db():
             continue
 
         db: SqliteAnnotationDbMixin | None = cast(

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -2139,7 +2139,7 @@ class AnnotatableMixin:
         if not self._annotation_db:
             # if no annotation db is set, use the default
             self._annotation_db.append(value)
-        else:
+        elif self._annotation_db[0] is not value:
             # we close the current annotation db and replace it
             self._annotation_db[0].close()
             self._annotation_db[0] = value

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import collections
+import contextlib
 import copy
 import inspect
 import io
@@ -25,6 +26,7 @@ from typing import (
 import numpy
 import numpy.typing as npt
 
+import cogent3.util.warning as c3warn
 from cogent3._version import __version__
 from cogent3.core.location import Strand, deserialise_map_spans
 from cogent3.parse.gff import GffRecordABC, merged_gff_records
@@ -810,7 +812,9 @@ class SqliteAnnotationDbMixin:
             columns=columns,
             allow_partial=allow_partial,
         )
-        yield from self._execute_sql(sql, values=vals)
+        with contextlib.suppress(sqlite3.ProgrammingError):
+            # garbage collection issue
+            yield from self._execute_sql(sql, values=vals)
 
     # Return type is instead larger than FeatureDataType
     def _get_feature_by_id(
@@ -2010,24 +2014,26 @@ def update_file_format(
         anno_db.write(backup_path)
 
     conn = anno_db.db
+    table_names = anno_db.table_names
+    del anno_db
     conn.create_function("update_array_format", 1, _update_array_format)
     cursor = None
-    for table_name in anno_db.table_names:
-        cursor = conn.cursor()
-        array_columns = [
-            r["name"]
-            for r in cursor.execute(f"PRAGMA table_info({table_name});").fetchall()
-            if r["type"] == "array"
-        ]
+    for table_name in table_names:
+        with conn:
+            cursor = conn.cursor()
+            array_columns = [
+                r["name"]
+                for r in cursor.execute(f"PRAGMA table_info({table_name});").fetchall()
+                if r["type"] == "array"
+            ]
 
-        for column in array_columns:
-            cursor.execute(
-                f"UPDATE {table_name} SET {column}=update_array_format({column});",
-            )
-        conn.commit()
-    if cursor:
-        cursor.close()
-    anno_db.close()
+            for column in array_columns:
+                cursor.execute(
+                    f"UPDATE {table_name} SET {column}=update_array_format({column});",
+                )
+            conn.commit()
+            cursor.close()
+    conn.close()
 
 
 DEFAULT_ANNOTATION_DB = BasicAnnotationDb
@@ -2082,7 +2088,7 @@ class AnnotatableMixin:
         return self._annotation_db[0]
 
     @annotation_db.setter
-    def annotation_db(self, value: SupportsFeatures) -> None:
+    def annotation_db(self, value: SupportsFeatures | None) -> None:
         # Without knowing the contents of the db we cannot
         # establish whether self.moltype is compatible, so
         # we rely on the user to get that correct
@@ -2134,7 +2140,8 @@ class AnnotatableMixin:
             # if no annotation db is set, use the default
             self._annotation_db.append(value)
         else:
-            # we replace the current annotation db
+            # we close the current annotation db and replace it
+            self._annotation_db[0].close()
             self._annotation_db[0] = value
 
         return

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -1330,6 +1330,7 @@ class SqliteAnnotationDbMixin:
         """closes the db"""
         if self._db is not None:
             self._db.close()
+            self._db = None
 
     def _make_index(self, *, table_name: str, col_names: tuple[str, ...]) -> None:
         """index columns for faster search"""
@@ -1951,6 +1952,11 @@ def _update_array_format(data: bytes) -> bytes:
         return array_to_sqlite(sqlite_to_array(data))
 
 
+@c3warn.deprecated_callable(
+    version="2026.31",
+    reason="Removing support for migrating old format",
+    is_discontinued=True,
+)
 def update_file_format(
     source_path: PathType,
     db_class: type[BasicAnnotationDb | GenbankAnnotationDb | GffAnnotationDb],

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -246,6 +246,10 @@ class Sequence(AnnotatableMixin):
             annotation_db
         )
 
+    def __del__(self):
+        if self._annotation_db:
+            self._annotation_db = None
+
     def __str__(self) -> str:
         result = numpy.array(self)
         return self.moltype.most_degen_alphabet().from_indices(result)

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -350,11 +350,7 @@ class Sequence(AnnotatableMixin):
             offset = int(self._seq.slice_record.parent_start)
             data |= {"annotation_offset": offset}
 
-        if (
-            hasattr(self, "annotation_db")
-            and self.annotation_db
-            and not exclude_annotations
-        ):
+        if self.has_annotation_db() and not exclude_annotations:
             data["annotation_db"] = self.annotation_db.to_rich_dict()
 
         return data
@@ -593,7 +589,8 @@ class Sequence(AnnotatableMixin):
             name=self.name,
             info=self.info,
         )
-        result.annotation_db = self.annotation_db
+        if self.has_annotation_db():
+            result.annotation_db = self.annotation_db
         return result
 
     def gap_indices(self) -> NumpyIntArrayType:
@@ -1110,7 +1107,7 @@ class Sequence(AnnotatableMixin):
         of strand of the current instance.
         """
 
-        if self._annotation_db is None:
+        if not self.has_annotation_db():
             return None
 
         start = start or 0
@@ -1376,12 +1373,13 @@ class Sequence(AnnotatableMixin):
             parent_len=len(seq),
             alphabet=moltype.most_degen_alphabet(),
         )
+        db = self.annotation_db if self.has_annotation_db() else None
         return moltype.make_seq(
             seq=sv,
             name=self.name,
             check_seq=False,
             info=self.info,
-            annotation_db=self.annotation_db,
+            annotation_db=db,
         )
 
     def copy_annotations(self, seq_db: SqliteAnnotationDbMixin) -> None:
@@ -1405,7 +1403,7 @@ class Sequence(AnnotatableMixin):
         if not seq_db.num_matches(seqid=self.name):
             return
 
-        if self._annotation_db and not self.annotation_db.compatible(seq_db):
+        if self.has_annotation_db() and not self.annotation_db.compatible(seq_db):
             msg = f"type {type(seq_db)} != {type(self.annotation_db)}"
             raise TypeError(msg)
 
@@ -1431,13 +1429,18 @@ class Sequence(AnnotatableMixin):
         # constructor from its current state.
         offset = self.annotation_offset if sliced else 0
         data = self._seq.copy(sliced=sliced)
+        db = (
+            self.annotation_db
+            if self.has_annotation_db() and not exclude_annotations
+            else None
+        )
         return self.__class__(
             moltype=self.moltype,
             seq=data,
             name=self.name,
             info=self.info,
             annotation_offset=offset,
-            annotation_db=None if exclude_annotations else self.annotation_db,
+            annotation_db=db,
         )
 
     def with_masked_annotations(
@@ -1498,7 +1501,9 @@ class Sequence(AnnotatableMixin):
             name=self.name,
             info=self.info,
         )
-        new.annotation_db = self.annotation_db
+        if self.has_annotation_db():
+            new.annotation_db = self.annotation_db
+
         return new
 
     def gapped_by_map_segment_iter(
@@ -1595,7 +1600,7 @@ class Sequence(AnnotatableMixin):
             msg = "cannot slice using list or tuple"
             raise TypeError(msg)
 
-        if self._annotation_db and preserve_offset:
+        if self.has_annotation_db() and preserve_offset:
             new.replace_annotation_db(self.annotation_db, check=False)
 
         if is_float(index):
@@ -1741,7 +1746,8 @@ class Sequence(AnnotatableMixin):
             cum_gap_lengths=cum_lengths,
             parent_length=len(seq),
         )
-        seq.annotation_db = self.annotation_db
+        if self.has_annotation_db():
+            seq.annotation_db = self.annotation_db
         return indel_map, seq
 
     def is_annotated(
@@ -1756,7 +1762,7 @@ class Sequence(AnnotatableMixin):
             amend condition to return True only if the sequence is
             annotated with one of provided biotypes.
         """
-        if not self._annotation_db:
+        if not self.has_annotation_db():
             return False
         with contextlib.suppress(AttributeError):
             return (
@@ -1998,6 +2004,10 @@ class Sequence(AnnotatableMixin):
             ),
         )
 
+    def has_annotation_db(self) -> bool:
+        """returns True if self has annotation db"""
+        return bool(self._annotation_db)
+
 
 class ProteinSequence(Sequence):
     """Holds the standard Protein sequence."""
@@ -2082,12 +2092,13 @@ class NucleicAcidSequenceBase(Sequence):
 
     def rc(self) -> Self:
         """Converts a nucleic acid sequence to its reverse complement."""
+        db = self.annotation_db if self.has_annotation_db() else None
         return self.__class__(
             moltype=self.moltype,
             seq=self._seq[::-1],
             name=self.name,
             info=self.info,
-            annotation_db=self.annotation_db,
+            annotation_db=db,
         )
 
     def has_terminal_stop(
@@ -2177,7 +2188,8 @@ class NucleicAcidSequenceBase(Sequence):
             name=self.name,
             info=self.info,
         )
-        result.annotation_db = self.annotation_db
+        if self.has_annotation_db():
+            result.annotation_db = self.annotation_db
         return result
 
     def get_translation(

--- a/tests/test_app/test_sqlite_data_store.py
+++ b/tests/test_app/test_sqlite_data_store.py
@@ -94,7 +94,8 @@ def full_dstore_sqlite(db_dir, nc_objects, completed_objects, log_data):
     for id, data in completed_objects.items():
         dstore.write(unique_id=id, data=data)
     dstore.write_log(unique_id="scitrack.log", data=log_data)
-    return dstore
+    yield dstore
+    dstore.close()
 
 
 @pytest.fixture
@@ -162,6 +163,7 @@ def test_open_sqlite_db_rw():
         _RESULT_TABLE,
         "state",
     }
+    db.close()
 
 
 def test_rw_sql_dstore_mem(completed_objects):

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -51,6 +51,18 @@ except ImportError:
     has_piqtree = False
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 @pytest.fixture(scope="session")
 def tmp_path(tmpdir_factory):
     return tmpdir_factory.mktemp("tmp_path")
@@ -120,9 +132,11 @@ def sdv_s2(dna_sd: c3_seq_storage.SeqsData) -> c3_seqview.SeqDataView:
 
 
 @pytest.fixture
-def seqs() -> c3_alignment.SequenceCollection:
+def seqs():
     data = {"seq1": "AAAAAA", "seq2": "TTTT", "seq3": "ATTCCCC"}
-    return c3_alignment.make_unaligned_seqs(data, moltype="dna")
+    result = c3_alignment.make_unaligned_seqs(data, moltype="dna")
+    yield result
+    close_dbs(result)
 
 
 @pytest.fixture
@@ -169,12 +183,16 @@ def ordered2():
 
 @pytest.fixture
 def gb_db(DATA_DIR):
-    return load_annotations(path=DATA_DIR / "annotated_seq.gb")
+    db = load_annotations(path=DATA_DIR / "annotated_seq.gb")
+    yield db
+    db.close()
 
 
 @pytest.fixture
 def gff_db(DATA_DIR):
-    return load_annotations(path=DATA_DIR / "simple.gff")
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    yield db
+    db.close()
 
 
 @pytest.fixture
@@ -191,7 +209,8 @@ def seqcoll_db(DATA_DIR):
     seq_coll.annotation_db = load_annotations(
         path=DATA_DIR / "c_elegans_WS199_shortened_gff.gff3",
     )
-    return seq_coll
+    yield seq_coll
+    close_dbs(seq_coll)
 
 
 def make_typed(seq, data_type, moltype):
@@ -1092,6 +1111,7 @@ def test_sequence_collection_take_seqs_copy_annotations(gff_db, mk_cls):
     # if copy annotations is false, the annotation db should be the same as original
     just_seq1 = seq_coll.take_seqs(names="test_seq", copy_annotations=False)
     assert just_seq1.annotation_db == gff_db
+    close_dbs(just_seq1, just_seq2, seq_coll)
 
 
 def test_sequence_collection_num_seqs():
@@ -2100,6 +2120,7 @@ def test_sequence_collection_get_seq_annotated():
     with_annos = seqs.get_seq("seq1")
     # the annotation db is identical to the one on the collection
     assert with_annos.annotation_db is seqs.annotation_db
+    close_dbs(seqs, with_annos)
 
 
 def _make_seq(name):
@@ -2123,6 +2144,7 @@ def test_sequence_collection_init_seqs_rc(rc):
     got = seq_coll.to_dict()
     expect = {k: str(v) for k, v in data.items()}
     assert got == expect
+    close_dbs(seq_coll)
 
 
 def test_sequence_collection_init_seqs_mixed_rc():
@@ -2134,6 +2156,7 @@ def test_sequence_collection_init_seqs_mixed_rc():
         seq_coll = c3_alignment.make_unaligned_seqs(data, moltype="dna")
     coll_db = seq_coll.annotation_db
     assert len(coll_db)
+    close_dbs(seq_coll, coll_db)
 
 
 def test_sequence_collection_copy_annotations_incompat_type_fails(seqcoll_db, seqs):
@@ -2243,6 +2266,7 @@ def test_sequence_collection_to_moltype_annotation_db(mk_cls):
     seqs.annotation_db = db
     dna = seqs.to_moltype("dna")
     assert len(dna.annotation_db) == 3
+    close_dbs(seqs, dna, db)
 
 
 @pytest.mark.parametrize(
@@ -3080,6 +3104,7 @@ def test_aligned_getitem_int(gapped_seqs_dict, seqid, i):
 def test_aligned_getitem_featuremap(raw_seq, coords):
     dna = c3_moltype.get_moltype("dna")
     im, seq = dna.make_seq(seq=raw_seq).parse_out_gaps()
+    assert not seq.has_annotation_db()
     gaps = numpy.array([im.gap_pos, im.cum_gap_lengths]).T
     asd = c3_seq_storage.AlignedSeqsData.from_seqs_and_gaps(
         seqs={"seq1": numpy.array(seq)},
@@ -3093,6 +3118,7 @@ def test_aligned_getitem_featuremap(raw_seq, coords):
     expect = "".join(raw_seq[s:e] for s, e in fmap.get_coordinates())
     got = ia[fmap]
     assert str(got) == expect
+    assert not aln.has_annotation_db()
 
 
 @pytest.fixture
@@ -4681,6 +4707,7 @@ def test_alignment_get_feature():
     db.add_feature(seqid="y", biotype="exon", name="A", spans=[(5, 8)])
     feat = next(iter(aln.get_features(seqid="y", biotype="exon", on_alignment=False)))
     assert feat.get_slice().to_dict() == {"x": "AAA", "y": "CCT"}
+    close_dbs(aln, db)
 
 
 def test_alignment_distance_matrix():
@@ -5494,6 +5521,9 @@ def test_alignment_apply_scaled_gaps_aa_to_codon(codon_and_aa_alns):
     ungapped = codon.degap()
     scaled = aa.apply_scaled_gaps(ungapped, aa_to_codon=True)
     assert scaled.to_dict() == codon.to_dict()
+    assert not codon.has_annotation_db()
+    assert not aa.has_annotation_db()
+    assert not scaled.has_annotation_db()
 
 
 def test_alignment_apply_scaled_gaps_codon_to_aa(codon_and_aa_alns):
@@ -5547,6 +5577,7 @@ def test_alignment_copy(simple_aln):
     assert set(copied.names) == set(renamed.names)
     # and can get a sequence with a new name
     assert str(copied.seqs["A"]) == str(renamed.seqs["A"])
+    close_dbs(simple_aln, got)
 
 
 def test_alignment_copy_rc(simple_aln):
@@ -5561,7 +5592,6 @@ def test_alignment_deepcopy(simple_aln):
     # all data structures should be different IDs
     assert got.name_map is not simple_aln.name_map
     assert got.info is not simple_aln.info
-    assert got.annotation_db is not simple_aln.annotation_db
     assert got._slice_record is not simple_aln._slice_record
     assert got._seqs_data is not simple_aln._seqs_data
 
@@ -5751,6 +5781,7 @@ def test_alignment_to_rich_dict_round_trip_annotation_db(gff_db, mk_cls):
     rd = aln.to_rich_dict()
     got = deserialise_object(rd)
     assert len(got.annotation_db) == 0
+    close_dbs(aln, got)
 
 
 def test_deserialise_alignment():
@@ -6254,6 +6285,7 @@ def test_renamed_take_seqs(renamed_seqs):
 def test_renamed_degap(renamed_seqs):
     coll, data = renamed_seqs
     got = coll.degap()
+    assert not got.has_annotation_db()
     assert set(got.storage.names) == {k.lower() for k in data}
     assert set(got.names) == {k.upper() for k in data}
 
@@ -6324,9 +6356,11 @@ def test_alignment_copy_handling_annot_db():
     orig_db = aln.annotation_db
     copied_aln = aln.copy(copy_annotations=True)
     assert orig_db is not copied_aln.annotation_db
+    close_dbs(copied_aln)
 
     copied_aln = aln.copy(copy_annotations=False)
     assert copied_aln.annotation_db is orig_db
+    close_dbs(aln, copied_aln, orig_db)
 
 
 def test_empty_aln_to_pretty():
@@ -6560,3 +6594,4 @@ def test_load_unaligned_glob(DATA_DIR):
     )
     assert isinstance(seqcoll, c3_alignment.SequenceCollection)
     assert len(seqcoll.names) > 1
+    assert not seqcoll.has_annotation_db()

--- a/tests/test_core/test_aln_annotation.py
+++ b/tests/test_core/test_aln_annotation.py
@@ -14,9 +14,23 @@ from cogent3.core.annotation_db import (
 DNA = c3_moltype.get_moltype("dna")
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 @pytest.fixture
 def gff_db(DATA_DIR):
-    return load_annotations(path=DATA_DIR / "simple.gff")
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    yield db
+    close_dbs(db)
 
 
 def makeSampleSequence(name, with_gaps=False):
@@ -52,12 +66,16 @@ def makeSampleAlignment():
 @pytest.fixture
 def ann_aln1():
     # synthetic annotated alignment
-    return makeSampleAlignment()
+    aln = makeSampleAlignment()
+    yield aln
+    close_dbs(aln)
 
 
 @pytest.fixture
 def ann_seq():
-    return makeSampleSequence("seq1")
+    aln = makeSampleSequence("seq1")
+    yield aln
+    close_dbs(aln)
 
 
 def _make_seq(name):
@@ -84,6 +102,7 @@ def test_init_seqs_have_annotations(mk_cls):
         seq = seq_coll.get_seq(name)
         db = seq.annotation_db
         assert db is coll_db
+    close_dbs(coll_db)
 
 
 @pytest.mark.parametrize(
@@ -99,6 +118,7 @@ def test_constructing_collections(mk_cls):
     got = coll.annotation_db.num_matches()
 
     assert got == expect
+    close_dbs(coll)
 
 
 @pytest.mark.parametrize(
@@ -112,6 +132,7 @@ def test_init_annotated_seqs(mk_cls):
     coll = mk_cls({"seq1": seq}, moltype="dna")
     features = list(coll.get_features(biotype="exon"))
     assert len(features) == 1
+    close_dbs(coll)
 
 
 @pytest.mark.parametrize(
@@ -126,6 +147,8 @@ def test_sequence_collection_add_feature(mk_cls):
     # if seqid is not in seqs, raise error
     with pytest.raises(ValueError):
         _ = seqs.add_feature(seqid="bad_seq", biotype="xyz", name="abc", spans=[(1, 2)])
+
+    close_dbs(seqs)
 
 
 @pytest.mark.parametrize(
@@ -158,6 +181,7 @@ def test_sequence_collection_get_annotations_from_any_seq(mk_cls):
     got = list(seqs.get_features(name="annotation3"))
     assert len(got) == 1
     assert "biotype='exon', name='annotation3', map=[3:6]/9" in str(got[0])
+    close_dbs(seqs)
 
 
 @pytest.mark.parametrize("rc", [False, True])
@@ -179,6 +203,7 @@ def test_alignment_get_slice(rc):
     got_aln = feature.get_slice()
     got_seq = got_aln.get_seq("test_seq")
     assert str(got_seq) == str(seq[5:9])
+    close_dbs(aln)
 
 
 def test_align_get_features():
@@ -194,6 +219,7 @@ def test_align_get_features():
     assert len(sl) == (7 - 2)
     # returns correct value
     assert sl.to_dict() == {"seq1": "G--AC", "seq2": "GGGCC"}
+    close_dbs(aln)
 
 
 @pytest.fixture(scope="session")
@@ -201,7 +227,9 @@ def seqcoll_db():
     fasta_path = os.path.join("data/c_elegans_WS199_dna_shortened.fasta")
     gff3_path = os.path.join("data/c_elegans_WS199_shortened_gff.gff3")
     seq = load_seq(fasta_path, moltype="dna", annotation_path=gff3_path)
-    return c3_alignment.make_unaligned_seqs({seq.name: seq}, moltype="dna")
+    result = c3_alignment.make_unaligned_seqs({seq.name: seq}, moltype="dna")
+    yield result
+    close_dbs(result)
 
 
 def test_seqcoll_query(seqcoll_db):
@@ -217,7 +245,7 @@ def test_seqcoll_query(seqcoll_db):
     assert len(matches) == 3
 
 
-def test_feature_projection_ungapped(ann_aln):
+def test_feature_projection_ungapped():
     # projection onto ungapped sequence
     ann_aln = makeSampleAlignment()
     expecteds = {"FAKE01": "CCCAAAATTTTTT", "FAKE02": "CCC-----TTTTT"}
@@ -231,6 +259,7 @@ def test_feature_projection_ungapped(ann_aln):
     assert str(got) == expected
     assert seq_ltr.seqid == seq_name
     assert seq_ltr.parent == ann_aln.get_seq(seq_name)
+    close_dbs(ann_aln)
 
 
 def test_feature_projection_gapped(ann_aln1):
@@ -264,6 +293,7 @@ def test_get_feature():
     feat = next(iter(aln.get_features(seqid="y", biotype="exon", on_alignment=False)))
     sliced = feat.get_slice()
     assert sliced.to_dict() == {"x": "AAA", "y": "CCT"}
+    close_dbs(aln)
 
 
 def test_aln_feature_to_dict():
@@ -287,6 +317,7 @@ def test_aln_feature_to_dict():
     f = aln.make_feature(feature=feature_data)
     d = f.to_dict()
     assert d == expect
+    close_dbs(aln)
 
 
 @pytest.mark.parametrize("rev", [False, True])
@@ -319,6 +350,7 @@ def test_features_survives_aligned_seq_rename(rev, make_cls):
     got = next(iter(seqs.get_features(name="gene1")))
     sliced = str(got.get_slice()).splitlines()[-1]
     assert sliced == "C" * 15
+    close_dbs(seqs)
 
 
 def test_alignment_annotations():
@@ -351,6 +383,8 @@ def test_alignment_annotations():
         expected = seq_expecteds[annot_type]
         assert observed == expected
 
+    close_dbs(aln)
+
 
 @pytest.mark.parametrize(
     "mk_cls",
@@ -370,6 +404,7 @@ def test_add_to_seq_updates_coll(mk_cls):
     assert len(seq_coll.annotation_db) == len(x.annotation_db) == 0
     x.add_feature(biotype="exon", name="E1", spans=[(3, 8)])
     assert len(seq_coll.annotation_db) == len(x.annotation_db) == 1
+    close_dbs(seq_coll)
 
 
 @pytest.mark.parametrize(
@@ -383,8 +418,11 @@ def test_annotation_db_assign_none(mk_cls):
     seq_coll.add_feature(seqid="seq1", biotype="xyz", name="abc", spans=[(1, 2)])
     seq_coll.add_feature(seqid="seq2", biotype="xyzzz", name="abc", spans=[(1, 2)])
     assert seq_coll.annotation_db is not None
+    # we have to close here to avoid resource
+    close_dbs(seq_coll)
     seq_coll.annotation_db = None
     assert not len(seq_coll.annotation_db)
+    close_dbs(seq_coll)
 
 
 @pytest.mark.parametrize(
@@ -425,6 +463,7 @@ def test_region_union_on_alignment(annot_type, rved):
     got = new.to_dict()
     expected = aln_expecteds[annot_type]
     assert expected == got, (annot_type, expected, got)
+    close_dbs(aln)
 
 
 def test_annotate_matches_to():
@@ -451,6 +490,7 @@ def test_annotate_matches_to():
     )
     got = [a.get_slice() for a in annot]
     assert got == matches[:1]
+    close_dbs(aln)
 
     # handles regex from aa
     aln = c3_alignment.make_aligned_seqs({"x": "TTCCACTTCCGCTT"}, moltype="dna")
@@ -460,6 +500,7 @@ def test_annotate_matches_to():
     aln.seqs["x"].annotate_matches_to(aa_regex, "domain", "test", allow_multiple=False)
     a = next(iter(aln.get_features(seqid="x")))
     assert str(aln[a].seqs["x"]) == "TTCCACTTC"
+    close_dbs(aln)
 
 
 @pytest.mark.parametrize(
@@ -481,6 +522,8 @@ def test_features_invalid_seqid(mk_cls):
         # seqid does not exist
         list(seqs.get_features(name="gene1", seqid="blah"))
 
+    close_dbs(seqs)
+
 
 @pytest.mark.parametrize(
     "mk_cls",
@@ -495,11 +538,13 @@ def test_copy_annotations(gff_db, mk_cls):
     expect = seq_coll.annotation_db.num_matches() + gff_db.num_matches()
     seq_coll.copy_annotations(gff_db)
     assert seq_coll.annotation_db.num_matches() == expect
+    close_dbs(seq_coll)
 
     # copy annotations with no current annotations
     seq_coll = mk_cls(data, moltype="rna")
     seq_coll.copy_annotations(gff_db)
     assert seq_coll.annotation_db.num_matches() == gff_db.num_matches()
+    close_dbs(seq_coll)
 
 
 @pytest.mark.parametrize(
@@ -516,6 +561,7 @@ def test_copy_annotations_same_annotations(gff_db, mk_cls):
     seq_coll.copy_annotations(gff_db)
 
     assert seq_coll.annotation_db.num_matches() == gff_db.num_matches()
+    close_dbs(seq_coll)
 
 
 @pytest.mark.parametrize(
@@ -532,6 +578,7 @@ def test_copy_annotations_none_matching(gff_db, mk_cls):
     assert gff_db.num_matches() > 0
     seq_coll.copy_annotations(gff_db)
     assert seq_coll.annotation_db.num_matches() == expect
+    close_dbs(seq_coll)
 
 
 @pytest.mark.parametrize(
@@ -544,6 +591,7 @@ def test_copy_annotations_no_db(gff_db, mk_cls):
 
     seq_coll.copy_annotations(gff_db)
     assert seq_coll.annotation_db.num_matches() == gff_db.num_matches()
+    close_dbs(seq_coll)
 
 
 def test_project_features_onto_specified_seqid():
@@ -559,6 +607,7 @@ def test_project_features_onto_specified_seqid():
     assert len(exons) == 1
     assert str(aln.get_seq("y")[exons[0].map.without_gaps()]), "TTT"
     assert "biotype='exon', name='fred', map=[-2-, 4:7]/8" in str(exons[0])
+    close_dbs(aln)
 
 
 def test_project_features_no_features_for_specified_seqid():
@@ -573,6 +622,7 @@ def test_project_features_no_features_for_specified_seqid():
     projected_features = aln.get_projected_features(seqid="seq2", biotype="exon")
 
     assert len(projected_features) == 0
+    close_dbs(db)
 
 
 @pytest.fixture
@@ -588,7 +638,9 @@ def ann_aln():
         seqid="x",
     )
     db.add_feature(seqid="y", biotype="repeat", name="frog", spans=[(5, 7)])
-    return c3_alignment.make_aligned_seqs(orig_data, moltype="dna", annotation_db=db)
+    aln = c3_alignment.make_aligned_seqs(orig_data, moltype="dna", annotation_db=db)
+    yield aln
+    close_dbs(aln)
 
 
 def test_annotated_region_masks(ann_aln):
@@ -680,6 +732,7 @@ def test_annotated_region_masks(ann_aln):
     assert masked.to_dict() == {"x": "?-???AAAAA???AA", "y": "-T----TTTT?-?TT"}
     masked = aln.with_masked_annotations(["repeat", "exon"], shadow=True)
     assert masked.to_dict() == {"x": "C-CCC?????GGG??", "y": "-?----????G-G??"}
+    close_dbs(aln)
 
 
 def test_with_masked_one_seqid():
@@ -698,6 +751,7 @@ def test_with_masked_one_seqid():
     masked = aln.with_masked_annotations(biotypes="repeat", mask_char="?", seqid="y")
     expect = {"x": raw_data["x"], "y": "AA???-----?????GGGGGGGGGGCC--"}
     assert masked.to_dict() == expect
+    close_dbs(aln)
 
 
 @pytest.mark.parametrize("shadow", [True, False])
@@ -711,6 +765,7 @@ def test_with_masked_missing_feature(ann_aln1, shadow):
         shadow=shadow,
     )
     assert masked.to_dict() == expect
+    close_dbs(aln)
 
 
 def test_masking_strand_agnostic_aln():
@@ -745,6 +800,7 @@ def test_masking_strand_agnostic_aln():
         "x": "TTT??????????TTTTTTTTTT?????TTTT????TT",
         "y": str(rc.seqs["y"]),
     }
+    close_dbs(db)
 
 
 def test_nested_annotated_region_masks():
@@ -775,6 +831,7 @@ def test_nested_annotated_region_masks():
     got = masked.to_dict()
     assert got["x"] == "?-???AAAAATTTAA"
     assert got["y"] == "-T----TTTTG-GTT"
+    close_dbs(db)
 
 
 @pytest.mark.parametrize("aligned", [True, False])
@@ -801,6 +858,7 @@ def test_mixed_strand_get_feature(aligned):
     expect = DNA.rc(plus["s2"].replace("-", ""))[3:6]
     got = f.get_slice()
     assert got == expect
+    close_dbs(seqcoll)
 
 
 def test_alignment_mixed_strand_get_feature1():
@@ -839,6 +897,7 @@ def test_alignment_mixed_strand_get_feature1():
     f = next(iter(rc.get_features(biotype="CDS")))
     faln = f.get_slice(allow_gaps=True)
     assert faln.to_dict() == expect
+    close_dbs(aln)
 
 
 def test_alignment_mixed_strand_get_feature2():
@@ -883,6 +942,7 @@ def test_alignment_mixed_strand_get_feature2():
     f = next(iter(rc.get_features(biotype="CDS")))
     faln = f.get_slice(allow_gaps=True)
     assert faln.to_dict() == expect_gapped
+    close_dbs(aln)
 
 
 @pytest.mark.parametrize("rc", [True, False])
@@ -916,6 +976,7 @@ def test_alignment_mixed_strand_masked_annotations(rc):
     assert str(s2) == s2_expect
     s3 = aln.seqs["s3"]
     assert str(s3) == s3_expect
+    close_dbs(aln)
 
 
 def test_slice_featuremap():
@@ -964,6 +1025,7 @@ def test_shadow_name():
     assert s.name == f"not {name}"
     s = f.shadow(name="newname")
     assert s.name == "newname"
+    close_dbs(seq)
 
 
 def test_one_span_name():
@@ -979,6 +1041,7 @@ def test_one_span_name():
     assert ospan.name == f"one-span {name}"
     s = f.as_one_span(name="newname")
     assert s.name == "newname"
+    close_dbs(seq)
 
 
 @pytest.mark.parametrize(
@@ -1002,6 +1065,7 @@ def test_get_feature_seqs_offset(mk_cls):
     got = feature[0].get_slice()
     got = got if mk_cls == c3_alignment.make_unaligned_seqs else got.get_seq("s1")
     assert str(got) == "AAGTA"
+    close_dbs(coll)
 
 
 @pytest.mark.parametrize(
@@ -1034,3 +1098,4 @@ def test_get_feature_seqs_offset_minus_strand(mk_cls):
     got = feature[0].get_slice()
     got = got if mk_cls == c3_alignment.make_unaligned_seqs else got.get_seq("s1")
     assert str(got) == expect
+    close_dbs(coll)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -1,6 +1,5 @@
 import io
 import pathlib
-import warnings
 
 import numpy
 import pytest
@@ -14,7 +13,6 @@ from cogent3.core.annotation_db import (
     _matching_conditions,
     _rename_column_if_exists,
     load_annotations,
-    update_file_format,
 )
 from cogent3.parse import genbank
 from cogent3.util import deserialise
@@ -1077,134 +1075,7 @@ def test_read_old_format(db_name, cls, tmp_path, request):
     with pytest.warns(UserWarning):
         new_tables = new_db.to_rich_dict()["tables"]
     assert new_tables == old_tables
-
-
-@pytest.mark.parametrize(
-    ("db_name", "cls", "backup"),
-    [
-        ("gb_db", GenbankAnnotationDb, True),
-        ("gff_db", GffAnnotationDb, True),
-        ("gb_db", GenbankAnnotationDb, False),
-        ("gff_db", GffAnnotationDb, False),
-    ],
-)
-def test_update_file_format(db_name, cls, backup, tmp_path, request):
-    db = request.getfixturevalue(db_name)
-    old_tables = db.to_rich_dict()["tables"]
-
-    path = tmp_path / f"old_format_{db_name}.db"
-
-    # Convert to old numpy format
-    table_name = db_name.split("_")[0]
-    convert_spans_column(db, table_name)
-    db.write(path)
-
-    with open(path, "rb") as f:
-        old_format_bytes = f.read()
-
-    # The file should be updated without warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        update_file_format(path, cls, backup=backup)
-
-    backup_path = tmp_path / f"old_format_{db_name}.db.bak"
-    if backup:
-        # Check the backup hasn't been modified
-        with open(backup_path, "rb") as f:
-            assert old_format_bytes == f.read()
-    else:
-        # A backup file should not exist
-        assert not backup_path.exists()
-
-    # The file should have been modified
-    with open(path, "rb") as f:
-        assert old_format_bytes != f.read()
-
-    # Reading the new file (when spans is loaded) should not produce warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-
-        new_db = cls(source=path)
-        new_tables = new_db.to_rich_dict()["tables"]
-
-    # The tables should remain the same
-    assert old_tables == new_tables
-    db.close()
-
-
-@pytest.mark.parametrize(
-    ("db_name", "cls"),
-    [("gb_db", GenbankAnnotationDb), ("gff_db", GffAnnotationDb)],
-)
-def test_update_file_format_twice_fails(db_name, cls, tmp_path, request):
-    db = request.getfixturevalue(db_name)
-
-    path = tmp_path / f"old_format_{db_name}.db"
-
-    # Convert to old numpy format
-    table_name = db_name.split("_")[0]
-    convert_spans_column(db, table_name)
-    db.write(path)
-
-    update_file_format(path, cls, backup=True)
-    with pytest.raises(FileExistsError):
-        update_file_format(path, cls, backup=True)
-
-
-@pytest.mark.parametrize(
-    ("db_name", "cls", "backup"),
-    [
-        ("gb_db", GenbankAnnotationDb, True),
-        ("gff_db", GffAnnotationDb, True),
-        ("gb_db", GenbankAnnotationDb, False),
-        ("gff_db", GffAnnotationDb, False),
-    ],
-)
-def test_update_file_format_does_not_modify_correct_file(
-    db_name,
-    cls,
-    backup,
-    tmp_path,
-    request,
-):
-    db = request.getfixturevalue(db_name)
-
-    path = tmp_path / f"correct_format_{db_name}.db"
-    db.write(path)
-
-    with open(path, "rb") as f:
-        old_bytes = f.read()
-
-    # Updating the file format should not produce warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        update_file_format(path, cls, backup=backup)
-
-    # The file should have remained the same
-    with open(path, "rb") as f:
-        assert old_bytes == f.read()
-
-
-@pytest.mark.parametrize(
-    ("db_name", "cls", "backup"),
-    [
-        ("gb_db", GenbankAnnotationDb, True),
-        ("gff_db", GffAnnotationDb, True),
-        ("gb_db", GenbankAnnotationDb, False),
-        ("gff_db", GffAnnotationDb, False),
-    ],
-)
-def test_update_file_format_fake_path(db_name, cls, backup, tmp_path):
-    path = tmp_path / f"non_existent_{db_name}.db"
-    with pytest.raises(OSError):
-        update_file_format(path, cls, backup=backup)
-
-    # The path should not have been created in the process
-    assert not path.exists()
-    if backup:
-        # The backup file path should also not exist
-        backup_path = tmp_path / f"non_existent_{db_name}.db.bak"
-        assert not backup_path.exists()
+    close_dbs(new_db, db)
 
 
 @pytest.fixture

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -20,6 +20,18 @@ from cogent3.util import deserialise
 DNA = cogent3.get_moltype("dna")
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 @pytest.fixture
 def gff_db(DATA_DIR):
     path = DATA_DIR / "c_elegans_WS199_shortened_gff.gff3"
@@ -46,25 +58,36 @@ def seq_db(DATA_DIR):
 
     seq.annotation_db = db
 
-    return seq
+    yield seq
+    db.close()
 
 
 @pytest.fixture
 def seq():
-    return cogent3.make_seq("ATTGTACGCCTTTTTTATTATT", name="test_seq", moltype="dna")
+    seq = cogent3.make_seq("ATTGTACGCCTTTTTTATTATT", name="test_seq", moltype="dna")
+    yield seq
+    if seq.has_annotation_db():
+        try:
+            seq.annotation_db.close()
+        except AttributeError:
+            # handles funky test condition
+            pass
 
 
 @pytest.fixture
 def anno_db() -> BasicAnnotationDb:
     # an empty db that we can add to
-    return BasicAnnotationDb()
+    db = BasicAnnotationDb()
+    yield db
+    db.close()
 
 
 @pytest.fixture
 def simple_seq_gff_db(DATA_DIR):
     seq = cogent3.make_seq("ATTGTACGCCTTTTTTATTATT", name="test_seq", moltype="dna")
     seq.annotation_db = load_annotations(path=DATA_DIR / "simple.gff")
-    return seq
+    yield seq
+    seq.annotation_db.close()
 
 
 def test_assign_valid_db(seq, anno_db):
@@ -115,7 +138,8 @@ def test_constructor_wrong_db_schema(db_name, cls, request):
 def test_constructor_db_instance_works(db_name, cls, request):
     # only compatible db's used to init
     db = request.getfixturevalue(db_name)
-    cls(db=db)
+    n = cls(db=db)
+    n.close()
 
 
 @pytest.mark.parametrize(
@@ -222,6 +246,7 @@ def test_gff_get_children_empty(DATA_DIR):
     db = load_annotations(path=DATA_DIR / "simple2.gff")
     got = list(db.get_feature_children(name="childless"))
     assert got == []
+    db.close()
 
 
 def test_gff_get_parent_empty(DATA_DIR):
@@ -229,6 +254,7 @@ def test_gff_get_parent_empty(DATA_DIR):
     db = load_annotations(path=DATA_DIR / "simple2.gff")
     got = list(db.get_feature_parent(name="parentless"))
     assert got == []
+    db.close()
 
 
 def test_gff_get_children_non_existent(DATA_DIR):
@@ -236,6 +262,7 @@ def test_gff_get_children_non_existent(DATA_DIR):
     db = load_annotations(path=DATA_DIR / "simple2.gff")
     got = list(db.get_feature_children(name="nonexistendID"))
     assert got == []
+    db.close()
 
 
 def test_gff_get_parent_non_existent(DATA_DIR):
@@ -243,6 +270,7 @@ def test_gff_get_parent_non_existent(DATA_DIR):
     db = load_annotations(path=DATA_DIR / "simple2.gff")
     got = list(db.get_feature_parent(name="nonexistendID"))
     assert got == []
+    db.close()
 
 
 def test_gff_counts(gff_db):
@@ -288,13 +316,16 @@ def test_gff_find_user_features(gff_db):
 
 
 def test_empty_data():
-    _ = GffAnnotationDb()
+    db = GffAnnotationDb()
+    db.close()
 
 
 # testing GenBank files
 @pytest.fixture
 def gb_db(DATA_DIR):
-    return load_annotations(path=DATA_DIR / "annotated_seq.gb")
+    db = load_annotations(path=DATA_DIR / "annotated_seq.gb")
+    yield db
+    db.close()
 
 
 def test_load_annotations_multi(DATA_DIR):
@@ -303,6 +334,7 @@ def test_load_annotations_multi(DATA_DIR):
     expect = len(one) + len(two)
     got = load_annotations(path=DATA_DIR / "simple*.gff")
     assert len(got) == expect
+    close_dbs(one, two, got)
 
 
 def test_load_annotations_chunked(gff_db, DATA_DIR):
@@ -317,6 +349,7 @@ def test_load_annotations_chunked(gff_db, DATA_DIR):
     got = next(iter(db.get_features_matching(name=name)))
     assert got.pop("spans") == expect.pop("spans")
     assert got == expect
+    db.close()
 
 
 @pytest.mark.parametrize(("parent_biotype", "name"), [("gene", "CNA00110")])
@@ -447,6 +480,7 @@ def test_feature_strand():
     assert str(plus.get_slice()) == plus_seq
     minus = next(iter(rced.get_features(name="minus")))
     assert str(minus.get_slice()) == minus_seq
+    db.close()
 
 
 def test_feature_nucleic():
@@ -488,6 +522,7 @@ def test_add_feature_with_parent():
     got = next(iter(db.get_features_matching(name="GG")))
     child = next(iter(db.get_feature_children(got["name"])))
     assert child["name"] == "child"
+    db.close()
 
 
 def test_get_features_matching_matching_features(anno_db: GffAnnotationDb, seq):
@@ -618,7 +653,8 @@ def test_get_features_matching_multiple_biotype_set(
 
 def test_get_features_matching_start_stop_seqview(DATA_DIR, seq):
     """testing that get_features_matching adjusts"""
-    seq.annotation_db = load_annotations(path=DATA_DIR / "simple.gff")
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    seq.annotation_db = db
     seq_features = list(seq.get_features(start=0, stop=3, allow_partial=True))
     assert len(seq_features) == 3
 
@@ -630,6 +666,7 @@ def test_get_features_matching_start_stop_seqview(DATA_DIR, seq):
         subseq.get_features(start=3, stop=10, allow_partial=True),
     )
     assert len(seq_features_features) == 1
+    close_dbs(db)
 
 
 def test_get_slice():
@@ -685,6 +722,7 @@ def test_get_slice_annotation_offset_not_set():
     assert not len(got.annotation_db)
     f = list(got.get_features(biotype="gene"))
     assert not f
+    close_dbs(got)
 
 
 def test_feature_get_children(seq_db):
@@ -778,7 +816,8 @@ def test_sequence_collection_annotate_from_gff(DATA_DIR):
     """
     seqs = {"test_seq": "ATCGATCGATCG", "test_seq2": "GATCGATCGATC"}
     seq_coll = cogent3.make_unaligned_seqs(seqs, moltype="dna")
-    seq_coll.annotation_db = cogent3.load_annotations(path=DATA_DIR / "simple.gff")
+    db = cogent3.load_annotations(path=DATA_DIR / "simple.gff")
+    seq_coll.annotation_db = db
 
     # the seq for which the seqid was provided is annotated
     seq = seq_coll.get_seq("test_seq")
@@ -795,21 +834,22 @@ def test_sequence_collection_annotate_from_gff(DATA_DIR):
 
     # the seq for which the seqid was NOT provided also has a reference to the same db
     seq2 = seq_coll.get_seq("test_seq2")
-    assert seq2.annotation_db is not None
     # querying on that sequence returns []
     got = list(seq2.get_features(biotype="CDS"))
     assert not got
+    db.close()
 
 
 def test_seq_coll_query(DATA_DIR):
     """obtain same results when querying from collection as from seq"""
     seqs = {"test_seq": "ATCGATCGATCG", "test_seq2": "GATCGATCGATC"}
     seq_coll = cogent3.make_unaligned_seqs(seqs, moltype="dna")
-    seq_coll.annotation_db = cogent3.load_annotations(path=DATA_DIR / "simple.gff")
+    db = cogent3.load_annotations(path=DATA_DIR / "simple.gff")
+    seq_coll.annotation_db = db
 
     seq = seq_coll.get_seq("test_seq")
     # the seq for which the seqid was provided is annotated
-    assert seq.annotation_db is not None
+    assert seq.has_annotation_db()
     # TODO gah this test fails when allow_partial=False because start / stop
     # not used by seqcoll method
     expect = {
@@ -828,6 +868,7 @@ def test_seq_coll_query(DATA_DIR):
 
     got = list(seq.get_features(biotype="CpG"))
     assert len(got) == 1
+    db.close()
 
 
 def test_gff_update_existing(gff_db, gff_small_db):
@@ -915,6 +956,7 @@ def test_deepcopy(gff_db):
     assert new.num_matches() == gff_db.num_matches() + 1
     assert len(list(new.get_features_matching(name="copied-exon"))) == 1
     assert len(list(gff_db.get_features_matching(name="copied-exon"))) == 0
+    close_dbs(new)
 
 
 def test_pickling(gff_db):
@@ -930,6 +972,7 @@ def test_pickling(gff_db):
         strand="+",
     )
     assert recon.num_matches() == gff_db.num_matches() + 1
+    close_dbs(recon)
 
 
 @pytest.mark.parametrize("db_name", ["gff_db", "gb_db"])
@@ -949,6 +992,7 @@ def test_deserialise(db_name, request):
     assert got is not db
     assert isinstance(got, type(db))
     assert got.num_matches() == db.num_matches()
+    close_dbs(got, db)
 
 
 def test_querying_attributes_gb(gb_db):
@@ -978,9 +1022,12 @@ def test_equal():
     db2 = BasicAnnotationDb()
     db3 = BasicAnnotationDb()
     assert db1 != db2
-    # we define equality by same class AND same db instance
+    # we define equality by same class AND same db instance, so we close the db
+    db3.close()
+    # then override a private attribute for this test
     db3._db = db2._db
     assert db2 == db3
+    close_dbs(db1, db2, db3)
 
 
 @pytest.mark.parametrize("other", [GenbankAnnotationDb, GffAnnotationDb])
@@ -991,6 +1038,7 @@ def test_compatible_symmetric(other):
     assert basic.compatible(other)
     assert other.compatible(other)
     assert other.compatible(basic)
+    close_dbs(basic, other)
 
 
 @pytest.mark.parametrize("other", [GenbankAnnotationDb, GffAnnotationDb])
@@ -1001,6 +1049,7 @@ def test_compatible_not_symmetric(other):
     assert not basic.compatible(other, symmetric=False)
     assert other.compatible(other, symmetric=False)
     assert other.compatible(basic, symmetric=False)
+    close_dbs(basic, other)
 
 
 def test_incompatible():
@@ -1008,6 +1057,7 @@ def test_incompatible():
     gb = GenbankAnnotationDb()
     assert not gff.compatible(gb)
     assert not gb.compatible(gff)
+    close_dbs(gff, gb)
 
 
 @pytest.mark.parametrize("wrong_type", [{}, BasicAnnotationDb().db])
@@ -1015,6 +1065,7 @@ def test_incompatible_invalid_type(wrong_type):
     db = BasicAnnotationDb()
     with pytest.raises(TypeError):
         db.compatible(wrong_type)
+    db.close()
 
 
 def _custom_namer(data):
@@ -1031,14 +1082,17 @@ def test_gb_namer(DATA_DIR):
     db = GenbankAnnotationDb(data=data, namer=_custom_namer, seqid=got[0]["locus"])
     # there are 2 repeat regions, which we don't catch with our namer
     assert db.num_matches(name="default name") == 2
+    close_dbs(db)
 
 
+@pytest.fixture
 def test_write(gb_db, tmp_path):
     outpath = tmp_path / "ondisk.gbkdb"
     gb_db.write(outpath)
     got = GenbankAnnotationDb(source=outpath)
     assert got.to_rich_dict()["tables"] == gb_db.to_rich_dict()["tables"]
     assert isinstance(got, GenbankAnnotationDb)
+    close_dbs(got, gb_db)
 
 
 def convert_to_old_np_format(data: bytes) -> bytes:
@@ -1087,13 +1141,13 @@ def test_load_anns_with_write(DATA_DIR, tmp_dir):
     inpath = DATA_DIR / "simple.gff"
     outpath = tmp_dir / "simple.gffdb"
     orig = load_annotations(path=inpath, write_path=outpath)
-    orig.db.close()
     expect = load_annotations(path=inpath)
     got = GffAnnotationDb(source=outpath)
     assert len(got) == len(expect)
     got_data = got.to_rich_dict()
     expect_data = expect.to_rich_dict()
     assert got_data["tables"] == expect_data["tables"]
+    close_dbs(got, orig, expect)
 
 
 def test_load_anns_from_json(DATA_DIR, tmp_dir):
@@ -1107,6 +1161,7 @@ def test_load_anns_from_json(DATA_DIR, tmp_dir):
     got = load_annotations(path=outpath)
     assert len(got) == len(orig)
     assert got.to_rich_dict() == orig.to_rich_dict()
+    close_dbs(got, orig)
 
 
 def test_gff_end_renamed_to_stop(gff_db, tmp_path):
@@ -1128,6 +1183,7 @@ def test_gff_end_renamed_to_stop(gff_db, tmp_path):
     del new_rich_dict["init_args"]
 
     assert new_rich_dict == correct_rich_dict
+    close_dbs(loaded_gff_db, gff_db)
 
 
 def test_gb_end_renamed_to_stop(gb_db, tmp_path):
@@ -1149,6 +1205,7 @@ def test_gb_end_renamed_to_stop(gb_db, tmp_path):
     del new_rich_dict["init_args"]
 
     assert new_rich_dict == correct_rich_dict
+    close_dbs(loaded_gb_db, gb_db)
 
 
 def test_gbdb_get_children_fails_no_coords(gb_db):
@@ -1178,12 +1235,14 @@ def test_subset_gff3_db(gff_db, integer):
     # manual inspection of the original GFF3 file indicates 7 records
     # BUT the CDS records get merged into a single row
     assert len(subset) == 6
+    subset.close()
 
 
 def test_subset_empty_db(gff_db):
     subset = gff_db.subset(seqid="X", start=40, stop=70, allow_partial=True)
     # no records
     assert not len(subset)
+    subset.close()
 
 
 def test_subset_gff3_db_with_user(gff_db):
@@ -1199,12 +1258,14 @@ def test_subset_gff3_db_with_user(gff_db):
     # manual inspection of the original GFF3 file indicates 7 records
     # BUT the CDS records get merged into a single row
     assert len(subset) == 7
+    subset.close()
 
 
 def test_subset_gb_db(gb_db):
     subset = gb_db.subset(biotype="gene")
     # manual inspection of the original annotated gb file indicates 2 genes
     assert len(subset) == 2
+    subset.close()
 
 
 def test_subset_gff3_db_source(gff_db, tmp_dir):
@@ -1223,6 +1284,7 @@ def test_subset_gff3_db_source(gff_db, tmp_dir):
     # manual inspection of the original GFF3 file indicates 7 records
     # BUT the CDS records get merged into a single row
     assert len(subset) == 6
+    subset.close()
 
 
 @pytest.mark.parametrize(
@@ -1261,7 +1323,7 @@ def test_db_close(request, db):
 
     db = request.getfixturevalue(db)
     db.close()
-    with pytest.raises(sqlite3.ProgrammingError):
+    with pytest.raises((sqlite3.ProgrammingError, sqlite3.DatabaseError)):
         _ = list(db.get_features_matching(biotype="gene"))
 
 
@@ -1282,6 +1344,7 @@ def test_db_make_index(request, db, col):
     result = ann_db._execute_sql(sql_template % ann_db.table_names[0]).fetchone()
     got = tuple(result)[:3]
     assert got in expect
+    ann_db.close()
 
 
 @pytest.mark.parametrize("db", ["gff_db", "gb_db"])
@@ -1289,6 +1352,7 @@ def test_db_repr(request, db):
     ann_db = request.getfixturevalue(db)
     got = repr(ann_db)
     assert isinstance(got, str)
+    ann_db.close()
 
 
 @pytest.fixture
@@ -1304,3 +1368,4 @@ def test_load_annotations_home_dir(home_gff, transform):
     got = load_annotations(path=transform(home_gff))
     assert len(got) == 6
     assert isinstance(got, GffAnnotationDb)
+    got.close()

--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -14,6 +14,18 @@ ASCII = cogent3.get_moltype("text")
 DNA = cogent3.get_moltype("dna")
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 class FeaturesTest(TestCase):
     """Tests of features in core"""
 
@@ -31,84 +43,117 @@ class FeaturesTest(TestCase):
             spans=[(12, 17)],
         )
 
-    def test_exon_extraction(self):
-        """exon feature used to slice or directly access sequence"""
-        # The corresponding sequence can be extracted either with
-        # slice notation or by asking the feature to do it,
-        # since the feature knows what sequence it belongs to.
 
-        assert str(self.s[self.exon1]) == "CCCCC"
-        assert str(self.exon1.get_slice()) == "CCCCC"
+@pytest.fixture
+def s():
+    return DNA.make_seq(
+        seq="AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA",
+        name="Orig",
+    )
 
-    def test_get_features(self):
-        """correctly identifies all features of a given type"""
 
-        # Usually the only way to get a Feature object like exon1
-        # is to ask the sequence for it. There is one method for querying
-        # annotations by type and optionally by name:
+@pytest.fixture
+def ann_s(s):
+    s.add_feature(
+        biotype="repeat",
+        name="bob",
+        spans=[(12, 17)],
+    )
+    s.add_feature(biotype="exon", name="fred", spans=[(10, 15)])
+    s.add_feature(biotype="exon", name="trev", spans=[(30, 40)])
+    yield s
+    close_dbs(s)
 
-        exons = list(self.s.get_features(biotype="exon"))
-        assert str(exons).startswith(
-            "[Feature(seqid='Orig', biotype='exon', name='fred', map=[10:15]/48, parent=DnaSequence",
-        )
 
-    def test_union(self):
-        """combines multiple features into one"""
+@pytest.fixture
+def exon1(ann_s):
+    return next(iter(ann_s.get_features(biotype="exon", name="fred")))
 
-        # To construct a pseudo-feature covering (or excluding)
-        # multiple features, use get_region_covering_all:
 
-        exons = list(self.s.get_features(biotype="exon"))
-        exon1 = exons.pop(0)
-        combined = exon1.union(exons)
-        assert str(combined.get_slice()) == "CCCCCTTTTTAAAAA"
+def test_exon_extraction(ann_s, exon1):
+    """exon feature used to slice or directly access sequence"""
+    # The corresponding sequence can be extracted either with
+    # slice notation or by asking the feature to do it,
+    # since the feature knows what sequence it belongs to.
 
-    def test_shadow(self):
-        """combines multiple features into shadow"""
+    assert str(ann_s[exon1]) == "CCCCC"
+    assert str(exon1.get_slice()) == "CCCCC"
 
-        # To construct a pseudo-feature covering (or excluding)
-        # multiple features, use get_region_covering_all:
 
-        exons = list(self.s.get_features(biotype="exon"))
-        expect = str(
-            self.s[: exons[0].map.start]
-            + self.s[exons[0].map.end : exons[1].map.start]
-            + self.s[exons[1].map.end :],
-        )
-        exon1 = exons.pop(0)
-        shadow = exon1.union(exons).shadow()
-        assert str(shadow.get_slice()) == expect
+def test_get_features(ann_s):
+    """correctly identifies all features of a given type"""
 
-    def test_annotate_matches_to(self):
-        """annotate_matches_to attaches annotations correctly to a Sequence"""
-        seq = DNA.make_seq(seq="TTCCACTTCCGCTT", name="x")
-        pattern = "CCRC"
-        annot = seq.annotate_matches_to(
-            pattern=pattern,
-            biotype="domain",
-            name="fred",
-            allow_multiple=True,
-        )
-        assert [a.get_slice() for a in annot] == ["CCAC", "CCGC"]
-        annot = seq.annotate_matches_to(
-            pattern=pattern,
-            biotype="domain",
-            name="fred",
-            allow_multiple=False,
-        )
-        assert len(annot) == 1
-        fred = annot[0].get_slice()
-        assert str(fred) == "CCAC"
-        # For Sequence objects of a non-IUPAC MolType, annotate_matches_to
-        # should return an empty annotation.
-        seq = ASCII.make_seq(seq="TTCCACTTCCGCTT")
-        annot = seq.annotate_matches_to(
-            pattern=pattern,
-            biotype="domain",
-            name="fred",
-            allow_multiple=False,
-        )
-        assert annot == []
+    # Usually the only way to get a Feature object like exon1
+    # is to ask the sequence for it. There is one method for querying
+    # annotations by type and optionally by name:
+
+    exons = list(ann_s.get_features(biotype="exon"))
+    assert str(exons).startswith(
+        "[Feature(seqid='Orig', biotype='exon', name='fred', map=[10:15]/48, parent=DnaSequence",
+    )
+
+
+def test_union(ann_s):
+    """combines multiple features into one"""
+
+    # To construct a pseudo-feature covering (or excluding)
+    # multiple features, use get_region_covering_all:
+
+    exons = list(ann_s.get_features(biotype="exon"))
+    exon1 = exons.pop(0)
+    combined = exon1.union(exons)
+    assert str(combined.get_slice()) == "CCCCCTTTTTAAAAA"
+
+
+def test_shadow(ann_s):
+    """combines multiple features into shadow"""
+
+    # To construct a pseudo-feature covering (or excluding)
+    # multiple features, use get_region_covering_all:
+
+    exons = list(ann_s.get_features(biotype="exon"))
+    expect = str(
+        ann_s[: exons[0].map.start]
+        + ann_s[exons[0].map.end : exons[1].map.start]
+        + ann_s[exons[1].map.end :],
+    )
+    exon1 = exons.pop(0)
+    shadow = exon1.union(exons).shadow()
+    assert str(shadow.get_slice()) == expect
+
+
+def test_annotate_matches_to():
+    """annotate_matches_to attaches annotations correctly to a Sequence"""
+    seq = DNA.make_seq(seq="TTCCACTTCCGCTT", name="x")
+    pattern = "CCRC"
+    annot = seq.annotate_matches_to(
+        pattern=pattern,
+        biotype="domain",
+        name="fred",
+        allow_multiple=True,
+    )
+    assert [a.get_slice() for a in annot] == ["CCAC", "CCGC"]
+    annot = seq.annotate_matches_to(
+        pattern=pattern,
+        biotype="domain",
+        name="fred",
+        allow_multiple=False,
+    )
+    assert len(annot) == 1
+    fred = annot[0].get_slice()
+    assert str(fred) == "CCAC"
+    close_dbs(seq)
+    # For Sequence objects of a non-IUPAC MolType, annotate_matches_to
+    # should return an empty annotation.
+    seq = ASCII.make_seq(seq="TTCCACTTCCGCTT")
+    annot = seq.annotate_matches_to(
+        pattern=pattern,
+        biotype="domain",
+        name="fred",
+        allow_multiple=False,
+    )
+    assert annot == []
+    close_dbs(seq)
 
 
 def test_copy_annotations():
@@ -122,6 +167,7 @@ def test_copy_annotations():
     aln.copy_annotations(db)
     feat = next(iter(aln.get_features(seqid="y", biotype="exon")))
     assert feat.get_slice().to_dict() == {"x": "AAA", "y": "CCT"}
+    close_dbs(aln, db)
 
 
 def test_copy_annotations_onto_seq():
@@ -136,6 +182,7 @@ def test_copy_annotations_onto_seq():
     y.copy_annotations(db)
     feat = next(iter(aln.get_features(seqid="y", biotype="exon")))
     assert feat.get_slice().to_dict() == {"x": "AAA", "y": "CCT"}
+    close_dbs(aln, db)
 
 
 def test_feature_residue():
@@ -167,6 +214,7 @@ def test_feature_residue():
     rc_exons = next(iter(aln_rc.get_features(biotype="exon")))
     assert rc_exons.get_slice().to_dict() == {"x": "CCCC", "y": "----"}
     assert rc_exons.as_one_span().get_slice().to_dict() == {"x": "C-CCC", "y": "-T---"}
+    close_dbs(aln, aln_rc)
 
 
 @pytest.fixture
@@ -183,7 +231,8 @@ def ann_seq():
         spans=[(10, 15), (30, 40)],
         parent_id="a-gene",
     )
-    return s
+    yield s
+    close_dbs(s)
 
 
 def test_get_features_no_matches(ann_seq):
@@ -228,6 +277,7 @@ def test_feature_query_child_seq():
     child = child[0]
     assert child.name == "child"
     assert str(child.get_slice()) == str(s[3:6])
+    close_dbs(s)
 
 
 def test_feature_query_parent_seq():
@@ -239,6 +289,7 @@ def test_feature_query_parent_seq():
     parent = parent[0]
     assert parent.name == "GG"
     assert str(parent.get_slice()) == str(s[0:10])
+    close_dbs(s)
 
 
 def test_feature_query_child_aln():
@@ -253,6 +304,7 @@ def test_feature_query_child_aln():
     child = child[0]
     assert child.name == "child"
     assert child.get_slice().to_dict() == aln[3:6].to_dict()
+    close_dbs(aln)
 
 
 def test_feature_query_parent_aln():
@@ -267,6 +319,7 @@ def test_feature_query_parent_aln():
     parent = parent[0]
     assert parent.name == "GG"
     assert parent.get_slice().to_dict() == aln[0:10].to_dict()
+    close_dbs(aln)
 
 
 def test_aln_feature_lost_spans():
@@ -281,6 +334,7 @@ def test_aln_feature_lost_spans():
     aln.annotation_db = db
     copied = list(aln.get_features(seqid="y", biotype="repeat"))
     assert not copied
+    close_dbs(aln, db)
 
 
 def test_terminal_gaps():
@@ -305,6 +359,7 @@ def test_terminal_gaps():
     aln.annotation_db = db
     aln_exons = list(aln.get_features(seqid="x", biotype="exon"))
     assert aln_exons[0].get_slice().to_dict() == {"x": "AAAAA", "y": "--T--"}
+    close_dbs(aln, db)
 
 
 def test_feature_from_alignment():
@@ -337,6 +392,7 @@ def test_feature_from_alignment():
     assert len(exons) == 1
     assert str(aln.get_seq("y")[exons[0].map.without_gaps()]), "TTT"
     assert "biotype='exon', name='fred', map=[-2-, 4:7]/8" in str(exons[0])
+    close_dbs(aln, db)
 
 
 def test_nested_get_slice():
@@ -350,6 +406,7 @@ def test_nested_get_slice():
     s.add_feature(biotype="repeat", name="bob", spans=[(12, 17)], parent_id="fred")
     f = next(iter(ex.get_children()))
     assert str(s[f]) == str(s[12:17])
+    close_dbs(s)
 
 
 def test_masking_strand_agnostic_seq():
@@ -373,6 +430,7 @@ def test_masking_strand_agnostic_seq():
     masked = minus.with_masked_annotations("CDS")
     assert len(masked) == len(minus)
     assert str(masked) == "TTT??????????TTTTTTTTTT?????TTTT????TT"
+    close_dbs(plus, minus)
 
 
 def test_masking_strand_agnostic_aln():
@@ -402,6 +460,7 @@ def test_masking_strand_agnostic_aln():
         "x": "TTT??????????TTTTTTTTTT?????TTTT????TT",
         "y": str(rc.get_seq("y")),
     }
+    close_dbs(aln, rc)
 
 
 def test_feature_out_range():
@@ -414,6 +473,7 @@ def test_feature_out_range():
     db.add_feature(seqid="x", biotype="exon", name="A", spans=[(5, 8)])
     f = list(aln.get_features(seqid="x", biotype="exon"))
     assert not f
+    close_dbs(aln, db)
 
 
 @pytest.mark.parametrize("cast", [list, numpy.array])
@@ -429,6 +489,7 @@ def test_search_with_ints(cast):
         seq.get_features(biotype="exon", allow_partial=True, start=start, stop=stop),
     )
     assert len(feats) == 1
+    close_dbs(seq, db)
 
 
 def test_roundtripped_alignment_with_slices():
@@ -452,6 +513,7 @@ def test_roundtripped_alignment_with_slices():
     new = deserialise_object(sub_aln.to_json())
     feats = list(new.get_features(biotype="exon", allow_partial=True))
     assert not feats
+    close_dbs(aln, db)
 
 
 def test_feature_reverse():
@@ -478,6 +540,7 @@ def test_feature_reverse():
     minus = plus.rc()
     minus_cds = next(iter(minus.get_features(biotype="CDS")))
     assert str(minus_cds.get_slice()) == "GGGGCCCCCTTTTTTTTTT"
+    close_dbs(plus, minus)
 
 
 @pytest.mark.parametrize("moltype", ["protein", "bytes", "text"])
@@ -492,6 +555,7 @@ def test_rc_feature_on_wrong_moltype(moltype):
     )
     with pytest.raises((TypeError, AttributeError)):
         cds.get_slice()
+    close_dbs(seq)
 
 
 def test_feature_equal(ann_seq):
@@ -544,6 +608,7 @@ def test_seq_degap_preserves_annotations():
     s1.add_feature(biotype="exon", name="A", spans=[(10, 15)])
     dg = s1.degap()
     assert len(s1.annotation_db) == len(dg.annotation_db)
+    close_dbs(s1, dg)
 
 
 @pytest.mark.parametrize("aligned", [True, False])
@@ -563,6 +628,7 @@ def test_align_degap_preserves_annotations(aligned):
     got = coll.degap()
     assert got.annotation_db is coll.annotation_db
     assert len(got.annotation_db) == 1
+    close_dbs(coll, got, db)
 
 
 @pytest.fixture

--- a/tests/test_core/test_maps.py
+++ b/tests/test_core/test_maps.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import cogent3
 from cogent3.core.location import FeatureMap, Span
@@ -6,46 +6,60 @@ from cogent3.core.location import FeatureMap, Span
 DNA = cogent3.get_moltype("dna")
 
 
-class MapTest(unittest.TestCase):
-    """Testing annotation of and by maps"""
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
 
-    def test_spans(self):
-        # a simple two part map of length 10
-        map = FeatureMap.from_locations(locations=[(0, 5), (5, 10)], parent_length=10)
-        # try different spans on the above map
-        for (start, end), expected in [
-            ((0, 4), "[0:4]"),
-            ((0, 5), "[0:5]"),
-            ((0, 6), "[0:5, 5:6]"),
-            ((5, 10), "[5:10]"),
-            ((-1, 10), "[-1-, 0:5, 5:10]"),
-            ((5, 11), "[5:10, -1-]"),
-            ((0, 10), "[0:5, 5:10]"),
-            ((10, 0), "[10:5, 5:0]"),
-        ]:
-            r = repr(Span(start, end, reverse=start > end).remap_with(map))
-            if r != expected:
-                self.fail(repr((r, expected)))
+        db.close()
 
-    def test_get_by_annotation(self):
-        seq = DNA.make_seq(seq="ATCGATCGAT" * 5, name="base")
-        seq.add_feature(biotype="test_type", name="test_label", spans=[(5, 10)])
-        seq.add_feature(biotype="test_type", name="test_label2", spans=[(15, 18)])
 
-        answer = list(seq.get_features(biotype="test_type"))
-        assert len(answer) == 2
-        assert str(seq[answer[0]]) == "TCGAT"
-        assert str(seq[answer[1]]) == "TCG"
+@pytest.mark.parametrize(
+    ("coord", "expected"),
+    [
+        ((0, 4), "[0:4]"),
+        ((0, 5), "[0:5]"),
+        ((0, 6), "[0:5, 5:6]"),
+        ((5, 10), "[5:10]"),
+        ((-1, 10), "[-1-, 0:5, 5:10]"),
+        ((5, 11), "[5:10, -1-]"),
+        ((0, 10), "[0:5, 5:10]"),
+        ((10, 0), "[10:5, 5:0]"),
+    ],
+)
+def test_spans(coord, expected):
+    # a simple two part map of length 10
+    fmap = FeatureMap.from_locations(locations=[(0, 5), (5, 10)], parent_length=10)
+    start, end = coord
+    # try different spans on the above map
+    r = repr(Span(start, end, reverse=start > end).remap_with(fmap))
+    assert r == expected, repr((r, expected))
 
-        answer = list(seq.get_features(biotype="test_type", name="test_label"))
-        assert len(answer) == 1
-        assert str(seq[answer[0]]) == "TCGAT"
 
-        # test ignoring of a partial annotation
-        sliced_seq = seq[:17]
-        answer = list(sliced_seq.get_features(biotype="test_type", allow_partial=False))
-        assert len(answer) == 1
-        assert str(sliced_seq[answer[0]]) == "TCGAT"
+def test_get_by_annotation():
+    seq = DNA.make_seq(seq="ATCGATCGAT" * 5, name="base")
+    seq.add_feature(biotype="test_type", name="test_label", spans=[(5, 10)])
+    seq.add_feature(biotype="test_type", name="test_label2", spans=[(15, 18)])
+
+    answer = list(seq.get_features(biotype="test_type"))
+    assert len(answer) == 2
+    assert str(seq[answer[0]]) == "TCGAT"
+    assert str(seq[answer[1]]) == "TCG"
+
+    answer = list(seq.get_features(biotype="test_type", name="test_label"))
+    assert len(answer) == 1
+    assert str(seq[answer[0]]) == "TCGAT"
+
+    # test ignoring of a partial annotation
+    sliced_seq = seq[:17]
+    answer = list(sliced_seq.get_features(biotype="test_type", allow_partial=False))
+    assert len(answer) == 1
+    assert str(sliced_seq[answer[0]]) == "TCGAT"
+    close_dbs(seq, sliced_seq)
 
 
 def test_get_by_seq_annotation_allow_gaps():
@@ -72,3 +86,4 @@ def test_get_by_seq_annotation_allow_gaps():
     # otherwise we only get the exact positions represented
     got = f.get_slice(allow_gaps=False).to_dict()
     assert got == {"b": "AT", "a": "AT"}
+    close_dbs(aln)

--- a/tests/test_core/test_seq_annotation.py
+++ b/tests/test_core/test_seq_annotation.py
@@ -8,6 +8,18 @@ DNA = c3_moltype.get_moltype("dna")
 ASCII = c3_moltype.get_moltype("text")
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 def makeSampleSequence(name, with_gaps=False):
     raw_seq = "AACCCAAAATTTTTTGGGGGGGGGGCCCC"
     cds = (15, 25)
@@ -23,7 +35,9 @@ def makeSampleSequence(name, with_gaps=False):
 
 @pytest.fixture
 def ann_seq():
-    return makeSampleSequence("seq1")
+    seq = makeSampleSequence("seq1")
+    yield seq
+    close_dbs(seq)
 
 
 def test_seq_feature_to_dict():
@@ -46,6 +60,7 @@ def test_seq_feature_to_dict():
     c = seq.add_feature(**got)
     assert c.to_dict() == expect
     assert str(f.get_slice()) == str(c.get_slice())
+    close_dbs(seq)
 
 
 @pytest.mark.parametrize("rev", [False, True])
@@ -76,6 +91,7 @@ def test_features_survives_seq_rename(rev):
     got = next(iter(sliced.get_features(name="domain1")))
     got = got.get_slice()
     assert str(got) == domain_expect
+    close_dbs(seq)
 
 
 def test_annotate_matches_to():
@@ -100,6 +116,7 @@ def test_annotate_matches_to():
 
     fred = annot[0].get_slice()
     assert str(fred) == "CCAC"
+    close_dbs(seq)
 
     # For Sequence objects of a non-IUPAC MolType, annotate_matches_to
     # should return an empty annotation.
@@ -111,6 +128,7 @@ def test_annotate_matches_to():
         allow_multiple=False,
     )
     assert annot == []
+    close_dbs(seq)
 
 
 @pytest.mark.parametrize("annot_type", ["CDS", "5'UTR"])
@@ -163,6 +181,7 @@ def test_gbdb_get_children_get_parent(DATA_DIR):
     (child,) = list(orig.get_children("CDS"))
     parent, *_ = list(child.get_parent())
     assert parent == orig
+    close_dbs(seq)
 
 
 def test_feature_names_seq():
@@ -181,6 +200,7 @@ def test_feature_names_seq():
     s = seq[f]
     assert s.name == "s1-cds"
     assert s.name == f.name
+    close_dbs(seq)
 
 
 def test_seq_with_masked_annotations():
@@ -194,6 +214,7 @@ def test_seq_with_masked_annotations():
     shadow = seq.with_masked_annotations(biotypes="CDS", shadow=True)
     expect = "?" * start + raw_seq[start:stop] + "?" * (len(raw_seq) - stop)
     assert str(shadow) == expect
+    close_dbs(seq)
 
 
 @pytest.mark.parametrize("shadow", [True, False])
@@ -202,6 +223,7 @@ def test_seq_with_masked_annotations_missing_feature(shadow):
     raw_seq = str(seq)
     masked = seq.with_masked_annotations(biotypes="not-present", shadow=shadow)
     assert str(masked) == raw_seq
+    close_dbs(seq)
 
 
 def test_is_annotated():
@@ -209,6 +231,7 @@ def test_is_annotated():
     s = c3_moltype.DNA.make_seq(seq="ACGGCTGAAGCGCTCCGGGTTTAAAACG", name="s1")
     _ = s.add_feature(biotype="gene", name="blah", spans=[(0, 10)])
     assert s.is_annotated()
+    close_dbs(s)
 
 
 @pytest.mark.parametrize("biotype", ["gene", "exon", ("gene", "exon")])
@@ -218,6 +241,7 @@ def test_is_annotated_biotype(biotype):
     _ = s.add_feature(biotype="gene", name="blah", spans=[(0, 10)])
     _ = s.add_feature(biotype="exon", name="blah", spans=[(0, 10)])
     assert s.is_annotated(biotype=biotype)
+    close_dbs(s)
 
 
 def test_not_is_annotated():
@@ -240,6 +264,7 @@ def test_not_is_annotated():
         spans=[(0, 10)],
     )
     assert not s.is_annotated(biotype="gene")
+    close_dbs(s)
     s.annotation_db = None
     assert not s.is_annotated()
 
@@ -249,6 +274,7 @@ def test_annotation_db_lazy_evaluation():
     assert isinstance(s._annotation_db, list)
     # now if we invoke the property we get an actual db instance created
     assert isinstance(s.annotation_db, anndb_module.SupportsFeatures)
+    close_dbs(s)
 
 
 def test_init_with_annotationdb():
@@ -256,6 +282,7 @@ def test_init_with_annotationdb():
     s = c3_moltype.DNA.make_seq(seq="AC", name="s1", annotation_db=anndb)
     assert isinstance(s.annotation_db, anndb_module.GffAnnotationDb)
     assert s.annotation_db is anndb
+    close_dbs(s)
 
 
 def test_init_with_annotation_offset():
@@ -290,6 +317,7 @@ def test_init_with_annotation_offset_plus_strand():
     )
     ft = list(s.get_features(biotype="gene"))[0]
     assert str(ft.get_slice()) == expect
+    close_dbs(db)
 
 
 def test_init_with_annotation_offset_minus_strand():
@@ -311,3 +339,4 @@ def test_init_with_annotation_offset_minus_strand():
     )
     ft = list(rc.get_features(biotype="gene"))[0]
     assert str(ft.get_slice()) == c3_moltype.DNA.rc(expect)
+    close_dbs(db)

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -18,6 +18,18 @@ from cogent3.util.deserialise import deserialise_object
 from cogent3.util.misc import get_object_provenance
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 @pytest.fixture
 def dna_alphabet():
     return c3_moltype.DNA.degen_gapped_alphabet
@@ -90,6 +102,7 @@ def test_sequence_copy(moltype):
     got2_slice = str(got_annot2.get_slice())
     assert annot1_slice == got1_slice
     assert annot2_slice == got2_slice
+    close_dbs(s, got)
 
 
 @pytest.mark.parametrize(
@@ -156,6 +169,7 @@ def test_sequence_to_moltype():
     assert str(got[fred]) == "TTTTTTTTTT"
     trev = next(iter(got.get_features(name="trev")))
     assert str(got[trev]) == "AAAA"
+    close_dbs(s, got)
 
 
 @pytest.mark.parametrize("invalid_moltype", [None, ""])
@@ -2086,6 +2100,7 @@ def test_annotation_from_slice_with_stride():
     s1 = seq[1::2]
     f = next(iter(s1.get_features(name="ex1")))
     assert str(f.get_slice()) == "CCC"
+    close_dbs(seq)
 
 
 def test_absolute_position_base_cases(one_seq):
@@ -2275,6 +2290,7 @@ def test_annotate_gff_nested_features(DATA_DIR):
     assert len(ann) == 2
     exon_seqs = ("TTTTTTTTT", "GGGGG")
     assert tuple(str(ex.get_slice()) for ex in exons) == exon_seqs
+    close_dbs(seq)
 
 
 def test_to_moltype_dna():
@@ -2437,6 +2453,7 @@ def test_get_drawable(DATA_DIR):
     # and their names should indicate they're incomplete
     for trace in full.traces:
         assert "(incomplete)" in trace.text
+    close_dbs(seq)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -18,6 +18,18 @@ from cogent3.draw.drawable import (
 from cogent3.util.union_dict import UnionDict
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 def load_alignment(annotate1=False, annotate2=False):
     """creates an alignment with None, one or two sequences annotated"""
     db = GffAnnotationDb()
@@ -307,6 +319,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         dp = aln.dotplot(name1=aln.names[0], name2=aln.names[1])
         self._check_drawable_attrs(dp.figure, "scatter")
         assert isinstance(dp, Dotplot)
+        close_dbs(aln)
 
         # seq1 annotated
         aln = load_alignment(annotate1=True)
@@ -316,6 +329,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         self._check_drawable_attrs(fig, "scatter")
         assert dp.left_track is None
         assert isinstance(dp.bottom_track, Drawable)
+        close_dbs(aln)
 
         # seq2 annotated
         aln = load_alignment(annotate2=True)
@@ -325,6 +339,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         self._check_drawable_attrs(fig, "scatter")
         assert dp.bottom_track is None
         assert isinstance(dp.left_track, Drawable)
+        close_dbs(aln)
 
         # both annotated
         aln = load_alignment(True, True)
@@ -334,6 +349,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         self._check_drawable_attrs(fig, "scatter")
         assert isinstance(dp.bottom_track, Drawable)
         assert isinstance(dp.left_track, Drawable)
+        close_dbs(aln)
 
     def test_annotated_dotplot_remove_tracks(self):  # ported
         """removing annotation tracks from dotplot should work"""
@@ -364,6 +380,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         assert dp._traces == []
         assert dp.figure is not orig_fig
         assert isinstance(dp.figure, UnionDict)
+        close_dbs(aln)
 
     def test_count_gaps_per_seq(self):  # ported
         """creation of drawables works"""
@@ -374,6 +391,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         assert not hasattr(counts, "drawable")
         self._check_drawable_styles(aln.count_gaps_per_seq, styles)
         self._check_drawable_styles(aln.count_gaps_per_seq, styles)
+        close_dbs(aln)
 
     def test_coevo_drawables(self):  # ported
         """coevolution produces drawables"""
@@ -384,6 +402,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         assert not hasattr(coevo, "drawable")
         self._check_drawable_styles(aln.coevolution, styles, show_progress=False)
         self._check_drawable_styles(aln.coevolution, styles, show_progress=False)
+        close_dbs(aln)
 
     def test_coevo_annotated(self):  # ported
         """coevolution on alignment with annotated seqs should add to heatmap plot"""
@@ -394,6 +413,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         assert isinstance(drawable, AnnotatedDrawable)
         assert isinstance(drawable.left_track, Drawable)
         assert isinstance(drawable.bottom_track, Drawable)
+        close_dbs(aln)
 
     def test_information_plot(self):  # ported
         """infoprmation plot makes a drawable"""
@@ -403,6 +423,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         self._check_drawable_attrs(drawable.figure, "scatter")
         drawable = aln.information_plot()
         self._check_drawable_attrs(drawable.figure, "scatter")
+        close_dbs(aln)
 
     def test_get_drawable(self):  # ported
         """sliced alignment with features returns a drawable"""
@@ -418,6 +439,7 @@ class AlignmentDrawablesTests(BaseDrawablesTests):
         aln.annotation_db = db
         g = aln.get_drawable()
         assert isinstance(g, Drawable)
+        close_dbs(aln)
 
 
 class TableDrawablesTest(BaseDrawablesTests):

--- a/tests/test_draw/test_new_draw_integration.py
+++ b/tests/test_draw/test_new_draw_integration.py
@@ -10,6 +10,18 @@ from cogent3.draw.drawable import AnnotatedDrawable, Drawable
 from cogent3.util.union_dict import UnionDict
 
 
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
+
+
 @pytest.fixture
 def seqs_dict():
     return {
@@ -24,11 +36,13 @@ def seqs_dict():
 
 @pytest.fixture
 def annotated_seq(DATA_DIR):
-    return load_seq(
+    result = load_seq(
         DATA_DIR / "c_elegans_WS199_dna_shortened.fasta",
         annotation_path=DATA_DIR / "c_elegans_WS199_shortened_gff.gff3",
         moltype="dna",
     )
+    yield result
+    close_dbs(result)
 
 
 @pytest.fixture
@@ -36,11 +50,11 @@ def load_alignment():
     """Fixture to create an alignment with None, one, or two sequences annotated."""
 
     def _load_alignment(annotate1=False, annotate2=False):
-        db = GffAnnotationDb()
-
         path = str(pathlib.Path(__file__).parent.parent / "data/brca1_5.paml")
         aln = load_aligned_seqs(path, moltype="dna")
         aln = aln.omit_gap_pos()
+        db = GffAnnotationDb() if annotate1 or annotate2 else None
+
         if annotate1:
             db.add_feature(
                 seqid=aln.names[0],
@@ -169,6 +183,8 @@ def test_dotplot_unaligned_no_aligned_path():
 )
 def test_dotplot_annotated(annotated_seq, with_annotations, mk_cls):
     if not with_annotations:
+        db = annotated_seq.annotation_db
+        db.close()
         annotated_seq.replace_annotation_db(None)  # this drops all annotations
 
     coll = mk_cls({"c_elegans": annotated_seq}, moltype="dna")
@@ -178,6 +194,7 @@ def test_dotplot_annotated(annotated_seq, with_annotations, mk_cls):
     expect = base | {"gene"} if with_annotations else base
     got = {tr["name"] for tr in fig.data}
     assert got == expect
+    close_dbs(coll, annotated_seq)
 
 
 @pytest.mark.parametrize(
@@ -235,6 +252,7 @@ def test_dotplot_with_diff_annotation_permutations(load_alignment):
     check_drawable_attrs(fig, "scatter")
     assert dp.left_track is None
     assert isinstance(dp.bottom_track, Drawable)
+    close_dbs(aln)
 
     # seq2 annotated
     aln = load_alignment(annotate2=True)
@@ -244,6 +262,7 @@ def test_dotplot_with_diff_annotation_permutations(load_alignment):
     check_drawable_attrs(fig, "scatter")
     assert dp.bottom_track is None
     assert isinstance(dp.left_track, Drawable)
+    close_dbs(aln)
 
     # both annotated
     aln = load_alignment(annotate1=True, annotate2=True)
@@ -253,6 +272,7 @@ def test_dotplot_with_diff_annotation_permutations(load_alignment):
     check_drawable_attrs(fig, "scatter")
     assert isinstance(dp.bottom_track, Drawable)
     assert isinstance(dp.left_track, Drawable)
+    close_dbs(aln)
 
 
 def test_annotated_dotplot_remove_tracks(load_alignment):
@@ -284,6 +304,7 @@ def test_annotated_dotplot_remove_tracks(load_alignment):
     assert dp._traces == []
     assert dp.figure is not orig_fig
     assert isinstance(dp.figure, UnionDict)
+    close_dbs(aln)
 
 
 def test_sequence_collection_dotplot_annotated_no_matcing_seqids():
@@ -298,6 +319,7 @@ def test_sequence_collection_dotplot_annotated_no_matcing_seqids():
     got = seqs.dotplot(show_progress=False, biotype="exon")
     assert not isinstance(got, AnnotatedDrawable)
     assert isinstance(got, Dotplot)
+    close_dbs(seqs, db)
 
 
 def test_sequence_collection_dotplot_annotated_select_biotype():
@@ -317,6 +339,7 @@ def test_sequence_collection_dotplot_annotated_select_biotype():
     assert isinstance(got, AnnotatedDrawable)
     # we get one trace with that biotype as the name
     assert sum(tr.name == "exon" for tr in got.figure.data)
+    close_dbs(seqs, db)
 
 
 def test_count_gaps_per_seq(load_alignment):
@@ -337,6 +360,7 @@ def test_coevo_drawables(load_alignment):
     coevo = aln.coevolution(show_progress=False)
     assert not (hasattr(coevo, "drawable"))
     check_drawable_styles(aln.coevolution, styles, show_progress=False)
+    close_dbs(aln)
 
 
 def test_coevo_annotated(load_alignment):
@@ -348,6 +372,7 @@ def test_coevo_annotated(load_alignment):
     assert isinstance(drawable, AnnotatedDrawable)
     assert isinstance(drawable.left_track, Drawable)
     assert isinstance(drawable.bottom_track, Drawable)
+    close_dbs(aln)
 
 
 def test_information_plot(load_alignment):
@@ -372,6 +397,7 @@ def test_get_drawable():
     aln.annotation_db = db
     got = aln.get_drawable()
     assert got is not None
+    close_dbs(aln)
 
 
 def test_seqlogo(seqs_dict):

--- a/tests/test_parse/test_cigar.py
+++ b/tests/test_parse/test_cigar.py
@@ -90,3 +90,4 @@ class TestCigar(unittest.TestCase):
                 end=end,
             )
             assert cmp_aln.to_dict() == slice_aln.to_dict(), (start, end)
+        db.close()

--- a/tests/test_parse/test_gbseq.py
+++ b/tests/test_parse/test_gbseq.py
@@ -174,3 +174,4 @@ class ParseGBseq(TestCase):
             assert name == "AY286018.1"
             assert sample_seq == seq.to_fasta(block_size=len(sample_seq))
             assert seq.annotation_db.num_matches() == 4
+            seq.annotation_db.close()

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -8,7 +8,18 @@ import pytest
 
 from cogent3.parse import genbank
 
+
 # ruff: noqa: SIM905
+def close_dbs(*objs):
+    for obj in objs:
+        if not hasattr(obj, "has_annotation_db"):
+            db = obj
+        elif obj.has_annotation_db():
+            db = obj.annotation_db
+        else:
+            continue
+
+        db.close()
 
 
 class GenBankTests(TestCase):
@@ -437,7 +448,7 @@ def test_location_list_get_coordinates():
     assert spans == [(5669, 5918), (5964, 6126)]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def rich_gb():
     with open("data/annotated_seq.gb") as infile:
         parser = genbank.rich_parser(infile)
@@ -470,6 +481,8 @@ def test_rich_parser(rich_gb):
         got = cds[locus].get_slice().trim_stop_codon().get_translation()
         assert str(got) == expects[locus]
 
+    close_dbs(rich_gb)
+
 
 def test_rich_parser_moltype(rich_gb):
     """correctly handles moltypes"""
@@ -482,6 +495,7 @@ def test_rich_parser_moltype(rich_gb):
     assert rich_gb.moltype.label == "dna"
     got = {f.name for f in rich_gb.get_features(biotype="mRNA")}
     assert got == feature_ids
+    close_dbs(rich_gb)
 
 
 @pytest.mark.parametrize("moltype", ["dna", "rna", "text"])
@@ -494,12 +508,14 @@ def test_moltype_overrides(moltype, rich_gb):
     assert rich_gb.annotation_db.num_matches() == got_2.annotation_db.num_matches()
 
     assert got_2.moltype.label == moltype
+    close_dbs(rich_gb, got_2)
 
 
 def test_rich_parser_info(rich_gb):
     """seq.info stores genbank_record"""
     assert "genbank_record" in rich_gb.info
     assert rich_gb.info.genbank_record["locus"] == rich_gb.name
+    close_dbs(rich_gb)
 
 
 def test_rich_genbank_just_seq():
@@ -507,7 +523,7 @@ def test_rich_genbank_just_seq():
         parser = genbank.rich_parser(infile, just_seq=True)
         seq = next(s for l, s in parser)
 
-    assert not seq.annotation_db
+    assert not seq.has_annotation_db()
 
 
 @pytest.fixture(params=("\r\n", "\n"))

--- a/tests/test_parse/test_tinyseq.py
+++ b/tests/test_parse/test_tinyseq.py
@@ -35,3 +35,4 @@ class ParseTinyseq(TestCase):
             assert name == "AY286018.1"
             assert sample_seq == seq.to_fasta(block_size=len(sample_seq))
             assert seq.annotation_db.num_matches() == 2
+            seq.annotation_db.close()


### PR DESCRIPTION
## Summary by Sourcery

Improve lifecycle and safety of SQLite-backed annotation databases across core sequence/alignment code and tests to eliminate resource warnings and handle closed/old-format databases more robustly.

Bug Fixes:
- Ensure annotation databases and SQLite connections are explicitly closed or detached in tests and core code, preventing resource leaks and sqlite3 warnings.
- Guard annotation queries against use-after-close by suppressing sqlite3.ProgrammingError in low-level record iteration and by checking for the presence of annotation DBs before use.
- Relax db-close tests to accept both sqlite3.ProgrammingError and sqlite3.DatabaseError when querying closed databases.

Enhancements:
- Introduce has_annotation_db helpers on sequence and alignment types and use them consistently instead of truthiness checks when working with annotation databases.
- Adjust sequence and alignment copying, reverse complementing, degapping, type conversion, and gap-scaling logic to propagate annotation databases only when present, and to detach them safely in destructors.
- Refine BasicAnnotationDb.close and update_file_format to null out internal connections, close them deterministically, and mark update_file_format as deprecated, while simplifying table iteration and avoiding holding annotation DB instances unnecessarily.
- Improve merged_db_collection to skip sequences without annotation DBs, close merged/consumed DBs, and return None when no merged database is produced.

Tests:
- Update and extend fixtures and tests across core, draw, parse, and app modules to use context-like patterns and helper functions for closing annotation DBs, and to assert on has_annotation_db where appropriate.
- Remove or refactor update_file_format behavioural tests in line with its deprecation and new connection-handling semantics.