### PR TITLE
Update annotation handling ABC, fixes #2489

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 
     from cogent3.core.alignment import Alignment, SequenceCollection
-    from cogent3.core.annotation_db import SupportsFeatures
+    from cogent3.core.annotation_db import AnnotationDbABC
     from cogent3.core.moltype import MolTypeLiteral
     from cogent3.core.sequence import Sequence
 
@@ -107,7 +107,7 @@ def make_seq(
     name: str | None = None,
     moltype: "MolTypeLiteral | None" = None,
     annotation_offset: int = 0,
-    annotation_db: "SupportsFeatures | None" = None,
+    annotation_db: "AnnotationDbABC | None" = None,
     **kwargs: typing.Any,  # noqa: ANN401
 ):  # refactor: type hinting, need to capture optional args and the return type
     """
@@ -182,7 +182,7 @@ def _load_genbank_seq(
     filename: os.PathLike,
     parser_kw: dict,
     just_seq: bool = False,
-) -> tuple[str, "str | bytes | npt.NDArray[numpy.integer]", "SupportsFeatures | None"]:
+) -> tuple[str, "str | bytes | npt.NDArray[numpy.integer]", "AnnotationDbABC | None"]:
     """utility function for loading sequences"""
     from cogent3.core.annotation_db import GenbankAnnotationDb
     from cogent3.parse.genbank import iter_genbank_records

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 
 from scitrack import get_text_hexdigest
 
-from cogent3.util import warning as c3warn
 from cogent3.util.deserialise import deserialise_object
 from cogent3.util.io import get_format_suffixes, open_
 from cogent3.util.parallel import is_master_process
@@ -788,93 +787,6 @@ def convert_directory_datastore(
     for fn in filenames:
         out_dstore.write(unique_id=fn.name, data=fn.read_text())
     return out_dstore
-
-
-@c3warn.deprecated_callable(
-    version="2026.1",
-    reason="tinydb conversions no longer supported",
-    is_discontinued=True,
-)
-def convert_tinydb_to_sqlite(
-    source: Path, dest: Path | None = None
-) -> DataStoreABC:  # pragma: no cover
-    from datetime import datetime
-    from fnmatch import translate
-
-    from .composable import CachingLogger, _make_logfile_name
-    from .data_store import load_record_from_json
-    from .io import write_db
-    from .sqlite_data_store import _LOG_TABLE, DataStoreSqlite
-
-    try:
-        from tinydb import Query, TinyDB
-        from tinydb.middlewares import CachingMiddleware
-        from tinydb.storages import JSONStorage
-    except ImportError as e:
-        msg = "You need to install tinydb to be able to migrate to new datastore."
-        raise ImportError(
-            msg,
-        ) from e
-
-    source = Path(source)
-    storage = CachingMiddleware(JSONStorage)
-    tinydb = TinyDB(str(source), storage=storage)
-    pattern = translate("*")
-    query = Query().identifier.matches(pattern)
-
-    id_list = []
-    data_list = []
-    lock_id = None
-    for record in tinydb.search(query):
-        if record["identifier"] == "LOCK":
-            lock_id = record["pid"]
-            continue
-        id_list.append(record["identifier"])
-        data_list.append(load_record_from_json(record))
-
-    dest = dest or Path(source.parent) / f"{source.stem}.sqlitedb"
-    if dest.exists():
-        msg = f"Destination file {dest!s} already exists. Delete or define new dest."
-        raise OSError(
-            msg,
-        )
-
-    LOGGER = CachingLogger(create_dir=True)
-    log_file_path = source.parent / _make_logfile_name("convert_tinydb_to_sqlite")
-    LOGGER.log_file_path = log_file_path
-
-    dstore = DataStoreSqlite(source=dest, mode=OVERWRITE)
-    writer = write_db(data_store=dstore)
-    for id_, data, _ in data_list:
-        if id_.endswith(".log"):
-            cmnd = f"UPDATE {_LOG_TABLE} SET data =?, log_name =?"
-            values = (data, id_)
-            with contextlib.suppress(ValueError):
-                date = datetime.strptime(
-                    data.split("\t", maxsplit=1)[0],
-                    "%Y-%m-%d %H:%M:%S",
-                )
-                cmnd = f"{cmnd}, date=?"
-                values += (date,)
-
-            cmnd = f"{cmnd} WHERE log_id=?"
-            values += (dstore._log_id,)
-
-            dstore.db.execute(cmnd, values)
-        else:
-            writer.main(data, identifier=id_)
-
-    # add a new log, recording this conversion
-    LOGGER.shutdown()
-    dstore.close()
-    dstore = DataStoreSqlite(source=dest, mode=APPEND)
-    dstore.write_log(unique_id=log_file_path.name, data=log_file_path.read_text())
-    log_file_path.unlink()
-    if lock_id is not None or dstore._lock_id:
-        cmnd = "UPDATE state SET lock_pid =? WHERE state_id == 1"
-        dstore.db.execute(cmnd, (lock_id,))
-
-    return dstore
 
 
 def make_record_for_json(identifier, data, completed):

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -37,9 +37,8 @@ from cogent3._version import __version__
 from cogent3.core.annotation import Feature
 from cogent3.core.annotation_db import (
     AnnotatableMixin,
+    AnnotationDbABC,
     FeatureDataType,
-    SqliteAnnotationDbMixin,
-    SupportsFeatures,
 )
 from cogent3.core.info import Info as InfoClass
 from cogent3.core.location import FeatureMap, IndelMap, Strand
@@ -104,12 +103,12 @@ class Aligned(AnnotatableMixin):
         data: AlignedDataViewABC,
         moltype: c3_moltype.MolType[str],
         name: str | None = None,
-        annotation_db: SupportsFeatures | list[SupportsFeatures] | None = None,
+        annotation_db: AnnotationDbABC | list[AnnotationDbABC] | None = None,
     ) -> None:
         self._data = data
         self._moltype = moltype
         self._name = name or data.seqid
-        self._annotation_db: list[SupportsFeatures] = self._init_annot_db_value(
+        self._annotation_db: list[AnnotationDbABC] = self._init_annot_db_value(
             annotation_db
         )
 
@@ -334,7 +333,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         moltype: c3_moltype.MolType[Any],
         info: dict[str, Any] | InfoClass | None = None,
         source: PathType | None = None,
-        annotation_db: SupportsFeatures | list[SupportsFeatures] | None = None,
+        annotation_db: AnnotationDbABC | list[AnnotationDbABC] | None = None,
         name_map: Mapping[str, str] | None = None,
         is_reversed: bool = False,
     ) -> None:
@@ -373,7 +372,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             "ref_name": "longest",
             "wrap": 60,
         }
-        self._annotation_db: list[SupportsFeatures] = self._init_annot_db_value(
+        self._annotation_db: list[AnnotationDbABC] = self._init_annot_db_value(
             annotation_db
         )
         self._seqs: _IndexableSeqs[TSequenceOrAligned]
@@ -861,7 +860,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             if copy_annotations:
                 ann_db = type(self.annotation_db)()
                 ann_db.update(
-                    annot_db=cast("SqliteAnnotationDbMixin", self.annotation_db),
+                    annot_db=cast("AnnotationDbABC", self.annotation_db),
                     seqids=list(selected_name_map),
                 )
             else:
@@ -941,7 +940,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             seq = seq.copy(exclude_annotations=True)
             seq.annotation_db = type(self.annotation_db)()
             seq.annotation_db.update(
-                annot_db=cast("SqliteAnnotationDbMixin", self.annotation_db),
+                annot_db=cast("AnnotationDbABC", self.annotation_db),
                 seqids=seqname,
             )
             return seq
@@ -1099,7 +1098,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         """
         return self.rc()
 
-    def copy_annotations(self, seq_db: SupportsFeatures) -> None:
+    def copy_annotations(self, seq_db: AnnotationDbABC) -> None:
         """copy annotations into attached annotation db
 
         Parameters
@@ -1111,8 +1110,8 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         -----
         Only copies annotations for records with seqid in self.names
         """
-        if not isinstance(seq_db, SupportsFeatures):
-            msg = f"type {type(seq_db)} does not match SupportsFeatures interface"
+        if not isinstance(seq_db, AnnotationDbABC):
+            msg = f"type {type(seq_db)} does not match AnnotationDbABC interface"
             raise TypeError(
                 msg,
             )
@@ -1130,11 +1129,11 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             self.replace_annotation_db(type(seq_db)())
 
         if self.annotation_db.compatible(
-            cast("SqliteAnnotationDbMixin", seq_db), symmetric=False
+            cast("AnnotationDbABC", seq_db), symmetric=False
         ):
             # our db contains the tables in other, so we update in place
             self.annotation_db.update(
-                annot_db=cast("SqliteAnnotationDbMixin", seq_db), seqids=self.names
+                annot_db=cast("AnnotationDbABC", seq_db), seqids=self.names
             )
         else:
             # we use the union method to define a new one
@@ -1142,8 +1141,8 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             # sequences
             self.replace_annotation_db(
                 cast(
-                    "SupportsFeatures",
-                    self.annotation_db.union(cast("SqliteAnnotationDbMixin", seq_db)),
+                    "AnnotationDbABC",
+                    self.annotation_db.union(cast("AnnotationDbABC", seq_db)),
                 ),
                 check=False,
             )
@@ -1606,7 +1605,7 @@ class SequenceCollection(CollectionBase[c3_sequence.Sequence]):
         moltype: c3_moltype.MolType[Any],
         info: dict[str, Any] | InfoClass | None = None,
         source: PathType | None = None,
-        annotation_db: SupportsFeatures | list[SupportsFeatures] | None = None,
+        annotation_db: AnnotationDbABC | list[AnnotationDbABC] | None = None,
         name_map: Mapping[str, str] | None = None,
         is_reversed: bool = False,
     ) -> None:
@@ -5354,7 +5353,7 @@ def make_name_map(data: dict[str, str | bytes | NumpyIntArrayType]) -> dict[str,
 def merged_db_collection(
     seqs: Mapping[str, str | bytes | NumpyIntArrayType | c3_sequence.Sequence]
     | Iterable[str | bytes | NumpyIntArrayType | c3_sequence.Sequence],
-) -> SupportsFeatures | None:
+) -> AnnotationDbABC | None:
     """return one AnnotationDb from a collection of sequences
 
     Parameters
@@ -5385,9 +5384,7 @@ def merged_db_collection(
         if not seq.has_annotation_db():
             continue
 
-        db: SqliteAnnotationDbMixin | None = cast(
-            "SqliteAnnotationDbMixin | None", seq.annotation_db
-        )
+        db: AnnotationDbABC | None = cast("AnnotationDbABC | None", seq.annotation_db)
 
         if first is None and db:
             # TODO gah should this be a copy so immutable?
@@ -5400,7 +5397,7 @@ def merged_db_collection(
         first.update(db)
         db.close()
 
-    return cast("SupportsFeatures | None", merged)
+    return cast("AnnotationDbABC | None", merged)
 
 
 @dataclasses.dataclass
@@ -5577,7 +5574,7 @@ def make_unaligned_seqs(
     label_to_name: Callable[[str], str] | None = None,
     info: dict[str, Any] | None = None,
     source: PathType | None = None,
-    annotation_db: SupportsFeatures | None = None,
+    annotation_db: AnnotationDbABC | None = None,
     offset: dict[str, int] | None = None,
     name_map: dict[str, str] | None = None,
     is_reversed: bool = False,
@@ -5784,7 +5781,7 @@ def make_aligned_seqs(
     label_to_name: Callable[[str], str] | None = None,
     info: dict[str, Any] | None = None,
     source: PathType | None = None,
-    annotation_db: SupportsFeatures | None = None,
+    annotation_db: AnnotationDbABC | None = None,
     offset: dict[str, int] | None = None,
     name_map: dict[str, str] | None = None,
     is_reversed: bool | None = None,
@@ -5867,7 +5864,7 @@ def make_aligned_seqs(
 
     moltype = c3_moltype.get_moltype(moltype)
     annotation_db = cast(
-        "SupportsFeatures",
+        "AnnotationDbABC",
         kwargs.pop("annotation_db", annotation_db)
         or merged_db_collection(
             data,

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -168,7 +168,6 @@ class SupportsQueryFeatures(Protocol):  # pragma: no cover
 
 @runtime_checkable
 class SupportsWriteFeatures(Protocol):  # pragma: no cover
-    # should be defined centrally
     def add_feature(
         self,
         *,
@@ -190,14 +189,14 @@ class SupportsWriteFeatures(Protocol):  # pragma: no cover
 
     def update(
         self,
-        annot_db: SqliteAnnotationDbMixin,
+        annot_db: AnnotationDbABC,
         seqids: str | PySeq[str] | None = None,
         **kwargs: Any,
     ) -> None:
         # update records with those from an instance of the same type
         ...
 
-    def union(self, annot_db: SqliteAnnotationDbMixin) -> SqliteAnnotationDbMixin:
+    def union(self, annot_db: AnnotationDbABC) -> AnnotationDbABC:
         # returns a new instance of the more complex class
         ...
 
@@ -209,6 +208,11 @@ class SupportsFeatures(
     Sized,
     Protocol,
 ):  # pragma: no cover
+    @c3warn.deprecated_callable(
+        version="2026.3", reason="use AnnotationDbABC instead", is_discontinued=True
+    )
+    def __init_subclass__(cls): ...
+
     # should be defined centrally
     def __len__(self) -> int:
         # the number of records
@@ -218,14 +222,12 @@ class SupportsFeatures(
         # equality based on class and identity of the bound db
         ...
 
-    def compatible(
-        self, other_db: SqliteAnnotationDbMixin, symmetric: bool = True
-    ) -> bool: ...
+    def compatible(self, other_db: AnnotationDbABC, symmetric: bool = True) -> bool: ...
 
     def to_rich_dict(self) -> dict[str, Any]: ...
 
 
-class AnnotationDbABC(abc.ABC, SupportsFeatures):
+class AnnotationDbABC(abc.ABC):
     @abc.abstractmethod
     def __len__(self) -> int: ...
 
@@ -246,6 +248,20 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         on_alignment: bool | None = None,
         allow_partial: bool = False,
     ) -> Iterator[FeatureDataType]: ...
+
+    def get_records_matching(
+        self,
+        *,
+        biotype: str | None = None,
+        seqid: str | None = None,
+        name: str | None = None,
+        start: int | None = None,
+        stop: int | None = None,
+        strand: str | None = None,
+        attributes: str | None = None,
+        on_alignment: bool | None = None,
+        allow_partial: bool = False,
+    ) -> Iterator[dict[str, Any]]: ...
 
     @abc.abstractmethod
     def get_feature_children(
@@ -316,9 +332,12 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         msg = f"{self.__class__.__name__!r} does not support add_records()"
         raise NotImplementedError(msg)
 
+    @abc.abstractmethod
+    def compatible(self, other_db: Self, symmetric: bool = True) -> bool: ...
+
     def update(
         self,
-        annot_db: SqliteAnnotationDbMixin,
+        annot_db: Self,
         seqids: str | PySeq[str] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -326,10 +345,13 @@ class AnnotationDbABC(abc.ABC, SupportsFeatures):
         msg = f"{self.__class__.__name__!r} does not support update()"
         raise NotImplementedError(msg)
 
-    def union(self, annot_db: SqliteAnnotationDbMixin) -> SqliteAnnotationDbMixin:
+    def union(self, annot_db: Self) -> Self:
         # override in subclass
         msg = f"{self.__class__.__name__!r} does not support union"
         raise NotImplementedError(msg)
+
+    @abc.abstractmethod
+    def close(self) -> None: ...
 
 
 def _make_table_sql(
@@ -1151,7 +1173,7 @@ class SqliteAnnotationDbMixin:
             checks only that tables of other_db equal, or are a subset, of
             mine
         """
-        if not isinstance(other_db, SupportsFeatures):
+        if not isinstance(other_db, AnnotationDbABC):
             msg = f"{type(other_db)} does not support features"
             raise TypeError(msg)
         mine = set(self.table_names)
@@ -1165,8 +1187,8 @@ class SqliteAnnotationDbMixin:
         **kwargs: Any,
     ) -> None:
         """update records with those from an instance of the same type"""
-        if not isinstance(annot_db, SupportsFeatures):
-            msg = f"{type(annot_db)} does not satisfy SupportsFeatures"
+        if not isinstance(annot_db, AnnotationDbABC):
+            msg = f"{type(annot_db)} does not satisfy AnnotationDbABC"
             raise TypeError(msg)
         if not self.compatible(annot_db, symmetric=False):
             msg = f"{type(self)} cannot be updated from {type(annot_db)}"
@@ -1190,8 +1212,8 @@ class SqliteAnnotationDbMixin:
         -------
         The class whose schema contains the other
         """
-        if annot_db and not isinstance(annot_db, SupportsFeatures):
-            msg = f"{type(annot_db)} does not satisfy SupportsFeatures"
+        if annot_db and not isinstance(annot_db, AnnotationDbABC):
+            msg = f"{type(annot_db)} does not satisfy AnnotationDbABC"
             raise TypeError(msg)
         if not annot_db:
             return copy.deepcopy(self)
@@ -1757,7 +1779,7 @@ def deserialise_gb_db(data: dict[str, Any]) -> GenbankAnnotationDb:
 
 
 @register_deserialiser("annotation_to_annotation_db")
-def convert_annotation_to_annotation_db(data: dict[str, Any]) -> SupportsFeatures:
+def convert_annotation_to_annotation_db(data: dict[str, Any]) -> AnnotationDbABC:
     db = BasicAnnotationDb()
 
     minus = Strand.MINUS
@@ -2056,11 +2078,11 @@ class AnnotatableMixin:
     """class handling an annotation database for a collection, aligned or sequence"""
 
     def __init__(self) -> None:
-        self._annotation_db: list[SupportsFeatures]
+        self._annotation_db: list[AnnotationDbABC] = []
 
     def _init_annot_db_value(
-        self, value: SupportsFeatures | list[SupportsFeatures] | None
-    ) -> list[SupportsFeatures]:
+        self, value: AnnotationDbABC | list[AnnotationDbABC] | None
+    ) -> list[AnnotationDbABC]:
         """returns the value for assignment to self._annotation_db given value
 
         Parameters
@@ -2080,7 +2102,7 @@ class AnnotatableMixin:
         return value
 
     @property
-    def annotation_db(self) -> SupportsFeatures:
+    def annotation_db(self) -> AnnotationDbABC:
         """the annotation database for the collection"""
         if not self._annotation_db:
             # if no annotation db is set, use the default
@@ -2088,12 +2110,12 @@ class AnnotatableMixin:
         return self._annotation_db[0]
 
     @annotation_db.setter
-    def annotation_db(self, value: SupportsFeatures | None) -> None:
+    def annotation_db(self, value: AnnotationDbABC | None) -> None:
         # Without knowing the contents of the db we cannot
         # establish whether self.moltype is compatible, so
         # we rely on the user to get that correct
         # one approach to support validation might be to add
-        # to the SupportsFeatures protocol a is_nucleic flag,
+        # to the AnnotationDbABC protocol a is_nucleic flag,
         # for both DNA and RNA. But if a user trys get_slice()
         # on a '-' strand feature, they will get a TypeError.
         # I think that's enough.
@@ -2101,7 +2123,7 @@ class AnnotatableMixin:
 
     def replace_annotation_db(
         self,
-        value: SupportsFeatures | list[SupportsFeatures] | None,
+        value: AnnotationDbABC | list[AnnotationDbABC] | None,
         check: bool = True,
     ) -> None:
         """public interface to assigning the annotation_db
@@ -2131,11 +2153,11 @@ class AnnotatableMixin:
             self._annotation_db = value
             return
 
-        if check and value and not isinstance(value, SupportsFeatures):
-            msg = f"{type(value)} does not satisfy SupportsFeatures"
+        if check and value and not isinstance(value, AnnotationDbABC):
+            msg = f"{type(value)} does not satisfy AnnotationDbABC"
             raise TypeError(msg)
 
-        value = cast("SupportsFeatures", value)
+        value = cast("AnnotationDbABC", value)
         if not self._annotation_db:
             # if no annotation db is set, use the default
             self._annotation_db.append(value)

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -249,6 +249,7 @@ class AnnotationDbABC(abc.ABC):
         allow_partial: bool = False,
     ) -> Iterator[FeatureDataType]: ...
 
+    @abc.abstractmethod
     def get_records_matching(
         self,
         *,

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -36,9 +36,8 @@ from cogent3.core import moltype as c3_moltype
 from cogent3.core.annotation import Feature
 from cogent3.core.annotation_db import (
     AnnotatableMixin,
+    AnnotationDbABC,
     FeatureDataType,
-    SqliteAnnotationDbMixin,
-    SupportsFeatures,
 )
 from cogent3.core.info import Info as InfoClass
 from cogent3.core.location import (
@@ -207,7 +206,7 @@ class Sequence(AnnotatableMixin):
         name: str | None = None,
         info: dict[str, Any] | InfoClass | None = None,
         annotation_offset: int = 0,
-        annotation_db: SupportsFeatures | None = None,
+        annotation_db: AnnotationDbABC | None = None,
     ) -> None:
         """Initialize a sequence.
 
@@ -242,7 +241,7 @@ class Sequence(AnnotatableMixin):
 
         self.info = InfoClass(**(info or {}))
         self._repr_policy = {"num_pos": 60}
-        self._annotation_db: list[SupportsFeatures] = self._init_annot_db_value(
+        self._annotation_db: list[AnnotationDbABC] = self._init_annot_db_value(
             annotation_db
         )
 
@@ -354,7 +353,11 @@ class Sequence(AnnotatableMixin):
             offset = int(self._seq.slice_record.parent_start)
             data |= {"annotation_offset": offset}
 
-        if self.has_annotation_db() and not exclude_annotations:
+        if (
+            self.has_annotation_db()
+            and not exclude_annotations
+            and hasattr(self.annotation_db, "to_rich_dict")
+        ):
             data["annotation_db"] = self.annotation_db.to_rich_dict()
 
         return data
@@ -1386,7 +1389,7 @@ class Sequence(AnnotatableMixin):
             annotation_db=db,
         )
 
-    def copy_annotations(self, seq_db: SqliteAnnotationDbMixin) -> None:
+    def copy_annotations(self, seq_db: AnnotationDbABC) -> None:
         """copy annotations into attached annotation db
 
         Parameters
@@ -1398,8 +1401,8 @@ class Sequence(AnnotatableMixin):
         -----
         Only copies annotations for records with seqid equal to self.name
         """
-        if not isinstance(seq_db, SupportsFeatures):
-            msg = f"type {type(seq_db)} does not match SupportsFeatures interface"
+        if not isinstance(seq_db, AnnotationDbABC):
+            msg = f"type {type(seq_db)} does not match AnnotationDbABC interface"
             raise TypeError(
                 msg,
             )

--- a/src/cogent3/maths/util.py
+++ b/src/cogent3/maths/util.py
@@ -52,7 +52,7 @@ def safe_log(data: NumpyArrayType) -> NumpyFloatArrayType:
     return result
 
 
-@c3warn.deprecated_callable(version="2026.1", reason="unused", is_discontinued=True)
+@c3warn.deprecated_callable(version="2026.3", reason="unused", is_discontinued=True)
 def row_uncertainty(a: NumpyArrayType) -> NumpyFloatArrayType:
     """Returns uncertainty (Shannon's entropy) for each row in a IN BITS
 
@@ -74,7 +74,7 @@ def row_uncertainty(a: NumpyArrayType) -> NumpyFloatArrayType:
         raise ValueError(msg)
 
 
-@c3warn.deprecated_callable(version="2026.1", reason="unused", is_discontinued=True)
+@c3warn.deprecated_callable(version="2026.3", reason="unused", is_discontinued=True)
 def column_uncertainty(a: NumpyArrayType) -> NumpyFloatArrayType:
     """Returns uncertainty (Shannon's entropy) for each column in a in BITS
 
@@ -96,7 +96,7 @@ def column_uncertainty(a: NumpyArrayType) -> NumpyFloatArrayType:
     return sum(safe_p_log_p(a), axis=0)
 
 
-@c3warn.deprecated_callable(version="2026.1", reason="unused", is_discontinued=True)
+@c3warn.deprecated_callable(version="2026.3", reason="unused", is_discontinued=True)
 def row_degeneracy(a: NumpyFloatArrayType, cutoff: float = 0.5) -> NumpyIntArrayType:
     """Returns the number of characters that's needed to cover >= cutoff
 
@@ -133,7 +133,7 @@ def row_degeneracy(a: NumpyFloatArrayType, cutoff: float = 0.5) -> NumpyIntArray
     return clip(array(degen) + 1, 0, a.shape[1])
 
 
-@c3warn.deprecated_callable(version="2026.1", reason="unused", is_discontinued=True)
+@c3warn.deprecated_callable(version="2026.3", reason="unused", is_discontinued=True)
 def column_degeneracy(a: NumpyFloatArrayType, cutoff: float = 0.5) -> NumpyIntArrayType:
     """Returns the number of characters that's needed to cover >= cutoff
 

--- a/src/cogent3/util/warning.py
+++ b/src/cogent3/util/warning.py
@@ -228,7 +228,7 @@ def deprecated_callable(
             "method" if sig & {"self", "cls", "klass"} else "function"
         )
         old = func.__name__
-        if old == "__init__":
+        if old in {"__init__", "__init_subclass__"}:
             # we're really deprecating a class, so get that name
             old = func.__qualname__.split(".")[-2]
             _type = "class"

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -6,10 +6,10 @@ import pytest
 
 import cogent3
 from cogent3.core.annotation_db import (
+    AnnotationDbABC,
     BasicAnnotationDb,
     GenbankAnnotationDb,
     GffAnnotationDb,
-    SupportsFeatures,
     _matching_conditions,
     _rename_column_if_exists,
     load_annotations,
@@ -391,7 +391,7 @@ def test_gb_get_parent(gb_db):
 
 def test_protocol_adherence(gff_db, gb_db):
     for db in (gff_db, gb_db):
-        assert isinstance(db, SupportsFeatures)
+        assert isinstance(db, AnnotationDbABC)
 
 
 def test_get_features_matching_no_annotation_db(seq):

--- a/tests/test_core/test_seq_annotation.py
+++ b/tests/test_core/test_seq_annotation.py
@@ -273,7 +273,7 @@ def test_annotation_db_lazy_evaluation():
     s = c3_moltype.DNA.make_seq(seq="AC", name="s1")
     assert isinstance(s._annotation_db, list)
     # now if we invoke the property we get an actual db instance created
-    assert isinstance(s.annotation_db, anndb_module.SupportsFeatures)
+    assert isinstance(s.annotation_db, anndb_module.AnnotationDbABC)
     close_dbs(s)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Align annotation handling around AnnotationDbABC, update related interfaces and deprecations, and remove obsolete tinydb conversion support.

New Features:
- Add get_records_matching to AnnotationDbABC for retrieving raw annotation records.
- Require AnnotationDbABC implementations to provide compatible() and close() methods for more consistent annotation DB behaviour.

Bug Fixes:
- Ensure sequence serialisation only calls annotation_db.to_rich_dict() when that method is available, preventing potential attribute errors.

Enhancements:
- Standardise annotation interfaces by using AnnotationDbABC instead of SupportsFeatures throughout core sequence, alignment, and annotation-related APIs.
- Adjust protocol and runtime checks to rely on AnnotationDbABC for type compatibility and capability validation.
- Treat deprecating __init_subclass__ as class deprecation in the warning utility to improve deprecation messaging.

Tests:
- Update tests to assert AnnotationDbABC usage and lazy initialisation instead of the SupportsFeatures protocol.

Chores:
- Remove the deprecated tinydb-to-sqlite datastore conversion helper.
- Retarget existing maths utility deprecations to version 2026.3.
- Deprecate SupportsFeatures.__init_subclass__ in favour of AnnotationDbABC and update public imports accordingly.