### PR TITLE
ENH: support non-stationary models for scaling branch lengths

### DIFF
--- a/src/cogent3/evolve/likelihood_function.py
+++ b/src/cogent3/evolve/likelihood_function.py
@@ -735,21 +735,29 @@ class LikelihoodFunction(ParameterController):
 
         bprobs = [1.0] if len(bin_names) == 1 else get_value_of("bprobs", **value_of_kw)
 
-        mprobs = [get_value_of("mprobs", bin=b, **value_of_kw) for b in bin_names]
+        mprobs = {}
+        for b in bin_names:
+            probs = self.get_motif_probs_by_node(edges=None, bin=b, locus=locus)
+            edge_names = probs.template.names[0]
+            for edge_name in edge_names:
+                mprobs[b, edge_name] = probs[edge_name].array
 
         scaled_lengths = {}
-        for edge in self._tree.get_edge_vector():
-            if edge.isroot():
-                continue
+        for edge in self._tree.preorder(include_self=False):
+            parent_name = edge.parent.name
             Qs = [
                 get_value_of("Qd", bin=b, edge=edge.name, **value_of_kw).Q
                 for b in bin_names
             ]
-            length = get_value_of("length", edge=edge.name, **value_of_kw)
+            length = 0.0
+            for i, bname in enumerate(bin_names):
+                tau = get_value_of("length", bin=bname, edge=edge.name, **value_of_kw)
+                mprob = mprobs[bname, parent_name]
+                length += bprobs[i] * expected_number_subs(mprob, Qs[i], tau)
             scaled_lengths[edge.name] = length * self._model.get_scale_from_Qs(
                 Qs,
                 bprobs,
-                mprobs,
+                [mprobs[b, parent_name] for b in bin_names],
                 predicate,
             )
         return scaled_lengths

--- a/tests/test_evolve/test_scale_rules.py
+++ b/tests/test_evolve/test_scale_rules.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 from cogent3 import make_tree
 from cogent3.evolve import ns_substitution_model, substitution_model
@@ -17,16 +18,17 @@ trans = MotifChange("A", "G") | MotifChange("T", "C")
 TREE = make_tree(tip_names="ab")
 
 
-class ScaleRuleTests(unittest.TestCase):
-    def _makeModel(self, predicates, scale_rules=None):
-        scale_rules = scale_rules or []
-        return substitution_model.TimeReversibleNucleotide(
-            equal_motif_probs=True,
-            model_gaps=False,
-            predicates=predicates,
-            scales=scale_rules,
-        )
+def _make_model_factory(predicates, scale_rules=None):
+    scale_rules = scale_rules or []
+    return substitution_model.TimeReversibleNucleotide(
+        equal_motif_probs=True,
+        model_gaps=False,
+        predicates=predicates,
+        scales=scale_rules,
+    )
 
+
+class ScaleRuleTests(unittest.TestCase):
     def _get_scaled_lengths(self, model, params):
         LF = model.make_likelihood_function(TREE)
         for param in params:
@@ -38,27 +40,16 @@ class ScaleRuleTests(unittest.TestCase):
 
     def test_scaled(self):
         """Scale rule requiring matrix entries to have all pars specified"""
-        model = self._makeModel({"k": trans}, {"ts": trans, "tv": ~trans})
+        model = _make_model_factory({"k": trans}, {"ts": trans, "tv": ~trans})
 
         assert self._get_scaled_lengths(model, {"k": 6.0, "length": 4.0}) == {
             "ts": 3.0,
             "tv": 1.0,
         }
 
-    def test_binned(self):
-        model = self._makeModel({"k": trans}, {"ts": trans, "tv": ~trans})
-
-        LF = model.make_likelihood_function(TREE, bins=2)
-        LF.set_param_rule("length", value=4.0, is_constant=True)
-        LF.set_param_rule("k", value=6.0, bin="bin0", is_constant=True)
-        LF.set_param_rule("k", value=1.0, bin="bin1", is_constant=True)
-
-        for bin, expected in [("bin0", 3.0), ("bin1", 4.0 / 3), (None, 13.0 / 6)]:
-            assert LF.get_scaled_lengths("ts", bin=bin)["a"] == expected
-
     def test_scaled_or(self):
         """Scale rule where matrix entries can have any of the pars specified"""
-        model = self._makeModel(
+        model = _make_model_factory(
             {"k": trans, "ac": a_c},
             {"or": (trans | a_c), "not": ~(trans | a_c)},
         )
@@ -178,3 +169,22 @@ def test_nstat_scaled():
     lengths = [lf.get_param_value("length", edge=n) for n in names]
     assert not numpy.allclose(lengths, sl)
     assert not numpy.allclose(lengths, n_sl)
+
+
+@pytest.mark.parametrize(
+    ("bin_name", "expected"),
+    [
+        ("bin0", 3.0),
+        ("bin1", 4 / 3),
+        (None, 13 / 6),
+    ],
+)
+def test_binned(bin_name, expected):
+    model = _make_model_factory({"k": trans}, {"ts": trans, "tv": ~trans})
+
+    lf = model.make_likelihood_function(TREE, bins=2)
+    lf.set_param_rule("length", value=4.0, is_constant=True)
+    lf.set_param_rule("k", value=6.0, bin="bin0", is_constant=True)
+    lf.set_param_rule("k", value=1.0, bin="bin1", is_constant=True)
+
+    assert numpy.allclose(lf.get_scaled_lengths("ts", bin=bin_name)["a"], expected)

--- a/tests/test_evolve/test_scale_rules.py
+++ b/tests/test_evolve/test_scale_rules.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
-
 import unittest
 
+import numpy
+
 from cogent3 import make_tree
-from cogent3.evolve import substitution_model
+from cogent3.evolve import ns_substitution_model, substitution_model
 from cogent3.evolve.predicate import MotifChange, replacement
 
 
@@ -154,5 +154,27 @@ class ScaleRuleTests(unittest.TestCase):
         assert f"{dS:.4f}" == "0.0514"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_nstat_scaled():
+    import cogent3 as c3
+
+    c2t = MotifChange("C", "T", forward_only=True)
+    sm = ns_substitution_model.NonReversibleNucleotide(
+        predicates=[c2t], scales={"CtoT": c2t, "not": ~c2t}
+    )
+
+    names = ["Human", "Mouse", "Wombat"]
+    aln = c3.get_dataset("brca1").take_seqs(names)
+    aln = aln.omit_gap_pos(allowed_gap_frac=0)
+    tree = c3.make_tree(tip_names=names)
+    lf = sm.make_likelihood_function(tree)
+    lf.set_param_rule("C>T", is_independent=True)
+    lf.set_alignment(aln)
+    lf.optimise(show_progress=False)
+    sl = lf.get_scaled_lengths("CtoT")
+    sl = [sl[n] for n in names]
+    n_sl = lf.get_scaled_lengths("not")
+    n_sl = [n_sl[n] for n in names]
+    assert not numpy.allclose(sl, n_sl)
+    lengths = [lf.get_param_value("length", edge=n) for n in names]
+    assert not numpy.allclose(lengths, sl)
+    assert not numpy.allclose(lengths, n_sl)


### PR DESCRIPTION
## Summary by Sourcery

Support branch-length scaling for non-stationary substitution models and validate behaviour with a dedicated test.

Enhancements:
- Update likelihood function branch-length scaling to use per-edge motif probabilities across bins, enabling non-stationary substitution models.

Tests:
- Add a regression test verifying scaled branch lengths differ between predicates and from raw lengths under a non-reversible nucleotide model with scaling rules.