### PR TITLE
ENH: Sequence classes get write method

### DIFF
--- a/doc/cookbook/DNA_and_RNA_sequences.rst
+++ b/doc/cookbook/DNA_and_RNA_sequences.rst
@@ -78,6 +78,23 @@ Convert a RNA sequence to FASTA format
     rnaseq = make_seq("ACGUACGUACGUACGU", moltype="rna")
     rnaseq
 
+Writing a sequence to file
+""""""""""""""""""""""""""
+
+.. jupyter-execute::
+
+    from cogent3 import make_seq
+
+    my_seq = make_seq("AGTACACTGGT", name="seq1", moltype="dna")
+    my_seq.write("my_seq.fasta")
+
+.. jupyter-execute::
+    :hide-code:
+
+    from cogent3.util.io import remove_files
+
+    remove_files(["my_seq.fasta"], error_on_missing=False)
+
 Creating a named sequence
 """""""""""""""""""""""""
 

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -30,6 +30,7 @@ import numba
 import numpy
 import numpy.typing as npt
 
+import cogent3._plugin as c3_plugin
 from cogent3._version import __version__
 from cogent3.core import alphabet as c3_alphabet
 from cogent3.core import moltype as c3_moltype
@@ -54,6 +55,7 @@ from cogent3.format.fasta import seqs_to_fasta
 from cogent3.maths.stats.number import CategoryCounter
 from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.dict_array import DictArray
+from cogent3.util.io import atomic_write, get_format_suffixes
 from cogent3.util.misc import (
     DistanceFromMatrix,
     get_object_provenance,
@@ -270,6 +272,12 @@ class Sequence(AnnotatableMixin):
                 result = self.moltype.complement(result)
         return result
 
+    def to_dict(
+        self, as_array: bool = False
+    ) -> dict[str | None, str | NumpyIntArrayType]:
+        seq = self.to_array() if as_array else str(self)
+        return {self.name: seq}
+
     def to_array(self, apply_transforms: bool = True) -> NumpyIntArrayType:
         """returns the numpy array
 
@@ -376,6 +384,41 @@ class Sequence(AnnotatableMixin):
     def to_json(self) -> str:
         """returns a json formatted string"""
         return json.dumps(self.to_rich_dict())
+
+    def write(
+        self, filename: str, format_name: str | None = None, **kwargs: Any
+    ) -> None:
+        """Write the sequence to a file.
+
+        Parameters
+        ----------
+        filename
+            name of the sequence file
+        format_name
+            format of the sequence file (e.g., 'fasta', 'json')
+        **kwargs
+            additional arguments passed to the format writer
+
+        Notes
+        -----
+        If format_name is None, will attempt to infer format from the filename
+        suffix. Uses the sequence format writer plugin system to support
+        multiple output formats.
+        """
+        suffix, _ = get_format_suffixes(filename)
+        if format_name is None and suffix:
+            format_name = suffix
+
+        if format_name == "json":
+            with atomic_write(filename, mode="wt") as f:
+                f.write(self.to_json())
+            return
+
+        writer = c3_plugin.get_seq_format_writer_plugin(
+            format_name=format_name,
+            file_suffix=suffix,
+        )
+        _ = writer.write(seqcoll=self, path=filename, **kwargs)
 
     def count(self, item: str) -> int:
         """count() delegates to self._seq."""

--- a/src/cogent3/format/sequence.py
+++ b/src/cogent3/format/sequence.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from cogent3.format import clustal, fasta, gde, paml, phylip
 from cogent3.parse.record import FileFormatError
 
-SeqsTypes = "CollectionBase[typing.Any]"
+SeqsTypes = "CollectionBase[typing.Any] | Sequence"
 
 FORMATTERS: dict[str, Callable[..., str]] = {
     "phylip": phylip.alignment_to_phylip,
@@ -50,7 +50,7 @@ class SequenceWriterBase(abc.ABC):
         Parameters
         ----------
         seqcoll
-            sequence collection to format, must have a to_dict() method
+            sequence, or a sequence collection, to format, must have a to_dict() method
         """
         formatter = FORMATTERS[self.name]
         return formatter(seqcoll.to_dict(), **kwargs)

--- a/src/cogent3/util/io.py
+++ b/src/cogent3/util/io.py
@@ -280,6 +280,9 @@ class atomic_write:
             else "".join(self._path.suffixes[:-1])
         )
         parent = self._in_zip.parent if self._in_zip else self._path.parent
+        if not parent.exists():
+            raise OSError(f"Parent dir '{parent}' of provided path does not exist")
+
         name = f"{uuid.uuid4()}{suffixes}"
         tmpdir = Path(mkdtemp(dir=parent)) if tmpdir is None else Path(tmpdir)
 

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -3157,3 +3157,34 @@ def test_count_kmers_seq_gt_k():
     got = seq.count_kmers(k=k)
     expect = numpy.zeros(4**k, dtype=int)
     assert (got == expect).all()
+
+
+@pytest.mark.parametrize("name", ["blah", None])
+@pytest.mark.parametrize("as_array", [False, True])
+def test_seq_to_dict(as_array, name):
+    seq = cogent3.make_seq("ACGTACGT", name=name, moltype="dna")
+    got = seq.to_dict(as_array=as_array)
+    assert name in got
+    expect_seq = seq.to_array() if as_array else str(seq)
+    correct = (got[name] == expect_seq).all() if as_array else (got[name] == expect_seq)
+    assert correct
+
+
+def test_sequence_write_fasta(tmp_path):
+    """Sequence.write() should write in correct FASTA format"""
+    seq = c3_moltype.DNA.make_seq(seq="TCAGAT", name="test_seq")
+    fn = tmp_path / "seq.fasta"
+    seq.write(fn)
+    result = cogent3.load_seq(fn, moltype="dna")
+    assert result.name == "test_seq"
+    assert str(result) == "TCAGAT"
+
+
+def test_sequence_write_json(tmp_path):
+    """Sequence.write() should write JSON format to file"""
+    seq = c3_moltype.DNA.make_seq(seq="AAGGCC", name="seq1")
+    path = tmp_path / "sample.json"
+    seq.write(path)
+    with open(path) as fn:
+        got = json.loads(fn.read())
+    assert got == seq.to_rich_dict()

--- a/tests/test_util/test_io.py
+++ b/tests/test_util/test_io.py
@@ -70,6 +70,11 @@ def test_writes_compressed_formats(DATA_DIR, tmp_dir, suffix):
     assert got == expect, f"write failed for {suffix}"
 
 
+def test_atomic_invalid_parent_dir():
+    with pytest.raises(OSError), atomic_write("invalid_dir/test.txt") as out:
+        out.write("will not work")
+
+
 def test_rename(tmp_dir):
     """Renames file as expected"""
     test_filepath = tmp_dir / "Atomic_write_test"


### PR DESCRIPTION
## Summary by Sourcery

Add direct file writing support for sequence objects and improve robustness of atomic file writes.

New Features:
- Expose a write() method and to_dict() helper on sequence objects to support writing individual sequences to various formats, including JSON.

Enhancements:
- Extend sequence formatting utilities to accept either a single sequence or a sequence collection.
- Make atomic file writing fail fast with a clear error when the target path's parent directory does not exist.

Tests:
- Add tests for Sequence.to_dict() output, FASTA and JSON writing via Sequence.write(), and for atomic_write failing on invalid parent directories.