### PR TITLE
ENH: implement repr for genbank location objects

### DIFF
--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -351,6 +351,10 @@ class Location:
         self.db = db
         self.strand = strand
 
+    def __repr__(self) -> str:
+        """Returns repr(self)."""
+        return f"{self.__class__.__name__}({self})"
+
     def __str__(self) -> str:
         """Returns self in string format.
 
@@ -363,6 +367,7 @@ class Location:
                 first, last = self._data
                 curr = f"{first}^{last}"
             except TypeError:  # only one base? must be this or the next
+                first = self._data
                 curr = f"{first}^{first + 1}"
         else:  # not self.is_between
             try:
@@ -413,6 +418,10 @@ class LocationList(list):
         """Returns strand of components: 1=forward, -1=reverse, 0=both"""
         curr = {i.strand: 1 for i in self}
         return 0 if len(curr) >= 2 else next(iter(curr.keys()))
+
+    def __repr__(self) -> str:
+        """Returns repr(self)."""
+        return f"{self.__class__.__name__}({self})"
 
     def __str__(self) -> str:
         """Returns (normalized) string representation of self."""

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -281,6 +281,7 @@ ORIGIN
         l = lsp("37")
         assert l._data == 37
         assert str(l) == "37"
+        assert repr(l) == "Location(37)"
         assert l.strand == 1
         l = lsp("40..50")
         first, second = l._data
@@ -404,6 +405,8 @@ class LocationTests(TestCase):
         assert str(l5) == "37^42..(37.42)"
         l5 = genbank.Location([l4, l3], strand=-1)
         assert str(l5) == "complement(37^42..(37.42))"
+        l6 = genbank.Location(6, is_between=True)
+        assert str(l6) == "6^7"
 
 
 def test_Location_start():
@@ -412,10 +415,6 @@ def test_Location_start():
     l = genbank.Location(37)
     assert l.start == 36
     assert l.stop == 36
-
-
-class LocationListTests(TestCase):
-    """Tests of the genbank.LocationList class."""
 
 
 def test_locationlist_extract():
@@ -544,6 +543,7 @@ def test_iter_genbank_records(gb_rec):
     assert seq.startswith("CAATACCCAC")
     assert seq.endswith("TGTGTACGTAA")
     assert features["locus"] == "AE017341"
+    assert "LocationList" in repr(features)
 
 
 @pytest.fixture(params=(pathlib.Path, str, io.FileIO))


### PR DESCRIPTION
[CHANGED] implement repr methods

[FIXED] fixed edge case in str method for Location class

## Summary by Sourcery

Add representation methods for GenBank location objects and fix an edge case in their string formatting.

New Features:
- Provide __repr__ implementations for Location and LocationList to give informative, class-based representations.

Bug Fixes:
- Correct Location.__str__ behaviour for between-locations with a single base to ensure proper start and end formatting.

Tests:
- Extend GenBank parser tests to cover Location.__repr__, the fixed between-location string edge case, and LocationList presence in feature representations.