### PR TITLE
ENH: modernise the cigar parser

### DIFF
--- a/src/cogent3/parse/cigar.py
+++ b/src/cogent3/parse/cigar.py
@@ -1,159 +1,151 @@
-"""Parsers for the cigar format
-
-Cigar stands for Compact Idiosyncratic gapped Alignment Report and defines the sequence
-of matches/mismatches and deletions (or gaps). Cigar line is used in Ensembl database
-for both multiple and pairwise genomic alignment.
-
-for example, this cigar line 2MD3M2D2M will mean that the alignment contains 2 matches/
-mismatches, 1 deletion (number 1 is omitted in order to save some spaces), 3 matches/
-mismatches, 2 deletion and 2 matches/mismatches.
-
-if the original sequence is: AACGCTT
-   the cigar line is: 2MD3M2D2M
-the aligned sequence will be:
-    M M D M M M D D M M
-    A A - C G C - - T T
-"""
-
 import re
+import typing
+
+import numpy
 
 import cogent3
-from cogent3.core.location import IndelMap, LostSpan, Span
+from cogent3.core.location import IndelMap
+from cogent3.util import warning as c3warn
 
-_pattern = re.compile("([0-9]*)([DM])")
+if typing.TYPE_CHECKING:
+    from cogent3.core.alignment import Alignment
+
+_pattern = re.compile("([0-9]*)([M=XI=DNSHP])")
 
 
-def map_to_cigar(map):
+def map_to_cigar(imap: IndelMap) -> str:
     """convert a IndelMap into a cigar string"""
-    cigar = ""
-    for span in map.spans:
-        if isinstance(span, Span):
-            num_chars = span.end - span.start
-            char = "M"
-        else:
-            num_chars = span.length
-            char = "D"
-        cigar += char if num_chars == 1 else str(num_chars) + char
-    return cigar
+    cigar = []
+    if imap.num_gaps == 0:
+        return f"{imap.parent_length}M"
+
+    last_cumsum = 0
+    last_seq_pos = 0
+    for seq_pos, cum_gaps in zip(imap.gap_pos, imap.cum_gap_lengths, strict=False):
+        gap_len = cum_gaps - last_cumsum
+        last_cumsum = cum_gaps
+        if seq_span := seq_pos - last_seq_pos:
+            num_chars = "" if seq_span == 1 else seq_span
+            cigar.append(f"{num_chars}M")
+
+        num_gap = "" if gap_len == 1 else gap_len
+        cigar.append(f"{num_gap}D")
+        last_seq_pos = seq_pos
+
+    if last_seq_pos < imap.parent_length:
+        num_chars = (
+            ""
+            if imap.parent_length - last_seq_pos == 1
+            else imap.parent_length - last_seq_pos
+        )
+        cigar.append(f"{num_chars}M")
+    return "".join(cigar)
 
 
-def cigar_to_map(cigar_text):
+def cigar_to_map(cigar_text: str) -> IndelMap:
     """convert cigar string into IndelMap"""
-    assert "I" not in cigar_text
-    spans, posn = [], 0
+    # TODO handle soft/hard clipping
+
+    gpos = []
+    glengths = []
+    seq_pos = 0
+
     for n, c in _pattern.findall(cigar_text):
         n = int(n) if n else 1
-        if c == "M":
-            spans.append(Span(posn, posn + n))
-            posn += n
+        if c in {"M", "I", "=", "X"}:
+            seq_pos += n
         else:
-            spans.append(LostSpan(n))
-    return IndelMap.from_spans(spans=spans, parent_length=posn)
+            gpos.append(seq_pos)
+            glengths.append(n)
+
+    gpos = numpy.array(gpos, dtype=numpy.int32)
+    glengths = numpy.array(glengths, dtype=numpy.int32)
+
+    return IndelMap(
+        gap_pos=gpos,
+        gap_lengths=glengths,
+        parent_length=seq_pos,
+    )
 
 
-def aligned_from_cigar(cigar_text, seq, moltype="dna"):
+@c3warn.deprecated_args(
+    version="2026.3", reason="return type now string", discontinued=["moltype"]
+)
+def aligned_from_cigar(cigar_text: str, seq: str) -> str:
     """returns an Aligned sequence from a cigar string, sequence and moltype"""
-    moltype = cogent3.get_moltype(moltype)
-    if isinstance(seq, str):
-        seq = moltype.make_seq(seq=seq)
-    map = cigar_to_map(cigar_text)
-    return seq.gapped_by_map(map)
+    seq = str(seq)
+    imap = cigar_to_map(cigar_text)
+    pos_length = imap.get_gap_coordinates()
+    if not pos_length:
+        return seq
+
+    new_seq: list[str] = []
+    last_pos = 0
+    for pos, length in pos_length:
+        new_seq.extend((seq[last_pos:pos], "-" * length))
+        last_pos = pos
+    new_seq.append(seq[last_pos : imap.parent_length])
+    return "".join(new_seq)
 
 
-def _slice_by_aln(map, left, right):
-    slicemap = map[left:right]
-    location = [
-        map.get_seq_index(left),
-        map.get_seq_index(right),
-    ]
-    return slicemap, location
-
-
-def _slice_by_seq(map, start, end):
-    # start, end are in sequence coords
-    aln_start = map.get_align_index(start)
-    aln_end = map.get_align_index(end, slice_stop=True)
-    return map[aln_start:aln_end], [aln_start, aln_end]
-
-
-def _remap(map):
-    start = map.start
-    if start == 0:
-        new_map = map
-        new_map.parent_length = map.end
-    else:
-        spans = []
-        length = None
-        for span in map.spans:
-            if not span.lost:
-                span.start = span.start - start
-                span.end = span.end - start
-                length = span.end
-            spans.append(span)
-        new_map = IndelMap(spans=spans, parent_length=length)
-    return new_map
-
-
-def slice_cigar(cigar_text, start, end, by_align=True):
+def slice_cigar(
+    cigar_text: str, start: int, end: int, by_align: bool = True
+) -> tuple[IndelMap, list[int]]:
     """slices a cigar string as an alignment"""
-    map = cigar_to_map(cigar_text)
+    imap = cigar_to_map(cigar_text)
     if by_align:
-        new_map, location = _slice_by_aln(map, start, end)
+        new_map = imap[start:end]
+        location = [
+            imap.get_seq_index(start),
+            imap.get_seq_index(end),
+        ]
     else:
-        new_map, location = _slice_by_seq(map, start, end)
-    if hasattr(new_map, "start"):
-        new_map = _remap(new_map)
+        location = [
+            imap.get_align_index(start),
+            imap.get_align_index(end, slice_stop=True),
+        ]
+        new_map = imap[location[0] : location[1]]
     return new_map, location
 
 
-def CigarParser(
-    seqs,
-    cigars,
-    sliced=False,
-    ref_seqname=None,
-    start=None,
-    end=None,
-    moltype="dna",
-):
+@c3warn.deprecated_args(
+    version="2026.3",
+    reason="no effect",
+    discontinued=["sliced", "start", "end", "ref_seqname"],
+)
+def cigar_to_alignment(
+    seqs: dict[str, str],
+    cigars: dict[str, str],
+    moltype: str = "dna",
+) -> "Alignment":
     """return an alignment from raw sequences and cigar strings
-    if sliced, will return an alignment correspondent to ref sequence start to end
 
     Parameters
     ----------
-        seqs - raw sequences as {seqname: seq}
-        cigars - corresponding cigar text as {seqname: cigar_text}
+    seqs
+        raw sequences as {seqname: seq}
+    cigars
+        corresponding cigar text as {seqname: cigar_text}
         cigars and seqs should have the same seqnames
-        moltype - optional default to 'dna'
-
+    moltype
+        default to 'dna'
     """
     moltype = cogent3.get_moltype(moltype)
     data = {}
-    if not sliced:
-        for seqname in list(seqs.keys()):
-            aligned_seq = aligned_from_cigar(
-                cigars[seqname],
-                seqs[seqname],
-                moltype=moltype,
-            )
-            data[seqname] = aligned_seq
-    else:
-        ref_aln_seq = aligned_from_cigar(
-            cigars[ref_seqname],
-            seqs[ref_seqname],
-            moltype=moltype,
+    for seqname in list(seqs.keys()):
+        aligned_seq = aligned_from_cigar(
+            cigars[seqname],
+            seqs[seqname],
         )
-        m, aln_loc = slice_cigar(cigars[ref_seqname], start, end, by_align=False)
-        data[ref_seqname] = ref_aln_seq[aln_loc[0] : aln_loc[1]]
-        for seqname in [
-            seqname for seqname in list(seqs.keys()) if seqname != ref_seqname
-        ]:
-            m, seq_loc = slice_cigar(cigars[seqname], aln_loc[0], aln_loc[1])
-            if seq_loc:
-                start, stop = seq_loc
-                seq = seqs[seqname][start:stop]
-                if isinstance(seq, str):
-                    seq = moltype.make_seq(seq=seq)
-                data[seqname] = seq.gapped_by_map(m)
-            else:
-                data[seqname] = moltype.make_seq("-" * (aln_loc[1] - aln_loc[0]))
+        data[seqname] = aligned_seq
     return cogent3.make_aligned_seqs(data, moltype=moltype)
+
+
+@c3warn.deprecated_callable(
+    version="2026.3",
+    reason="better name",
+    new="cigar_to_alignment",
+)
+def CigarParser(*args, **kwargs) -> "Alignment":  # pragma: no cover
+    """deprecated alias for cigar_to_alignment"""
+    return cigar_to_alignment(*args, **kwargs)

--- a/src/cogent3/parse/cigar.py
+++ b/src/cogent3/parse/cigar.py
@@ -10,7 +10,7 @@ from cogent3.util import warning as c3warn
 if typing.TYPE_CHECKING:
     from cogent3.core.alignment import Alignment
 
-_pattern = re.compile("([0-9]*)([M=XI=DNSHP])")
+_pattern = re.compile("([0-9]*)([M=XIDNSHP])")
 
 
 def map_to_cigar(imap: IndelMap) -> str:

--- a/tests/test_parse/test_cigar.py
+++ b/tests/test_parse/test_cigar.py
@@ -1,10 +1,9 @@
-import unittest
+import pytest
 
 import cogent3
-from cogent3.core.annotation_db import GffAnnotationDb
 from cogent3.parse.cigar import (
-    CigarParser,
     aligned_from_cigar,
+    cigar_to_alignment,
     cigar_to_map,
     map_to_cigar,
     slice_cigar,
@@ -13,81 +12,161 @@ from cogent3.parse.cigar import (
 DNA = cogent3.get_moltype("dna")
 
 
-class TestCigar(unittest.TestCase):
-    def setUp(self):
-        self.cigar_text = "3D2M3D6MDM2D3MD"
-        self.aln_seq = DNA.make_seq(seq="---AA---GCTTAG-A--CCT-")
-        self.aln_seq1 = DNA.make_seq(seq="CCAAAAAA---TAGT-GGC--G")
-        self.map, self.seq = self.aln_seq.parse_out_gaps()
-        self.map1, self.seq1 = self.aln_seq1.parse_out_gaps()
-        self.slices = [(1, 4), (0, 8), (7, 12), (0, 1), (3, 5)]
-        self.aln = cogent3.make_aligned_seqs(
-            {"FAKE01": self.aln_seq, "FAKE02": self.aln_seq1},
-            moltype="dna",
-        )
-        self.cigars = {"FAKE01": self.cigar_text, "FAKE02": map_to_cigar(self.map1)}
-        self.seqs = {"FAKE01": str(self.seq), "FAKE02": str(self.seq1)}
+@pytest.fixture
+def cigar_text():
+    return "3D2M3D6MDM2D3MD"
 
-    def test_map_to_cigar(self):
-        """convert a Map to cigar string"""
-        assert map_to_cigar(self.map) == self.cigar_text
 
-    def test_cigar_to_map(self):
-        """test generating a Map from cigar"""
-        map = cigar_to_map(self.cigar_text)
-        assert str(map) == str(self.map)
+@pytest.fixture
+def aln_seq():
+    return DNA.make_seq(seq="---AA---GCTTAG-A--CCT-")
 
-    def test_aligned_from_cigar(self):
-        """test generating aligned seq from cigar"""
-        aligned_seq = aligned_from_cigar(self.cigar_text, self.seq)
-        assert aligned_seq == self.aln_seq
 
-    def test_slice_cigar(self):
-        """test slicing cigars"""
-        for start, end in self.slices:
-            # test by_align = True
-            map1, loc1 = slice_cigar(self.cigar_text, start, end)
-            ori1 = self.aln_seq[start:end]
-            if loc1:
-                slicealn1 = self.seq[loc1[0] : loc1[1]].gapped_by_map(map1)
-                assert ori1 == slicealn1
-            else:
-                assert len(map1) == len(ori1)
+@pytest.fixture
+def aln_seq1():
+    return DNA.make_seq(seq="CCAAAAAA---TAGT-GGC--G")
 
-            # test by_align = False
-            map2, loc2 = slice_cigar(self.cigar_text, start, end, by_align=False)
-            slicealn2 = self.seq[start:end].gapped_by_map(map2)
-            ori2 = self.aln_seq[loc2[0] : loc2[1]]
-            assert slicealn2 == ori2
 
-    def test_CigarParser(self):
-        """test without slice"""
-        aln = CigarParser(self.seqs, self.cigars)
-        assert aln == self.aln
-        # test slice
-        db = GffAnnotationDb()
-        aln.annotation_db = db
-        i = 1
-        for start, end in self.slices:
-            db.add_feature(
-                seqid="FAKE01",
-                biotype=f"annot{i}",
-                name="annot",
-                spans=[(start, end)],
-            )
+@pytest.fixture
+def map_and_seq(aln_seq):
+    return aln_seq.parse_out_gaps()
 
-            annot = list(aln.get_features(biotype=f"annot{i}"))
-            annot = annot[0].union(annot[1:])
-            slice_aln = annot.as_one_span().get_slice()
-            i += 1
 
-            cmp_aln = CigarParser(
-                self.seqs,
-                self.cigars,
-                sliced=True,
-                ref_seqname="FAKE01",
-                start=start,
-                end=end,
-            )
-            assert cmp_aln.to_dict() == slice_aln.to_dict(), (start, end)
-        db.close()
+@pytest.fixture
+def map1_and_seq1(aln_seq1):
+    return aln_seq1.parse_out_gaps()
+
+
+@pytest.fixture(params=[(1, 4), (0, 8), (7, 12), (0, 1), (3, 5)])
+def start_end(request):
+    return request.param
+
+
+@pytest.fixture
+def aln(aln_seq, aln_seq1):
+    return cogent3.make_aligned_seqs(
+        {"FAKE01": aln_seq, "FAKE02": aln_seq1},
+        moltype="dna",
+    )
+
+
+@pytest.fixture
+def cigars(cigar_text, map1_and_seq1):
+    map1, _ = map1_and_seq1
+    return {"FAKE01": cigar_text, "FAKE02": map_to_cigar(map1)}
+
+
+@pytest.fixture
+def seqs(map_and_seq, map1_and_seq1):
+    _, seq = map_and_seq
+    _, seq1 = map1_and_seq1
+    return {"FAKE01": str(seq), "FAKE02": str(seq1)}
+
+
+def test_map_to_cigar(map_and_seq, cigar_text):
+    """convert a Map to cigar string"""
+    map_, _ = map_and_seq
+    assert map_to_cigar(map_) == cigar_text
+
+
+def test_cigar_to_map(cigar_text, map_and_seq):
+    """test generating a Map from cigar"""
+    map_, _ = map_and_seq
+    imap = cigar_to_map(cigar_text)
+    assert str(imap) == str(map_)
+
+
+def test_cigar_to_map_with_equals():
+    """= symbol should advance sequence position like M"""
+    imap = cigar_to_map("5=")
+    assert imap.parent_length == 5
+    assert imap.num_gaps == 0
+
+
+def test_cigar_to_map_with_mismatch():
+    """X symbol should advance sequence position like M"""
+    imap = cigar_to_map("3X2M")
+    assert imap.parent_length == 5
+    assert imap.num_gaps == 0
+
+
+def test_cigar_to_map_with_insertion():
+    """I symbol should advance sequence position"""
+    imap = cigar_to_map("3M2I3M")
+    assert imap.parent_length == 8
+    assert imap.num_gaps == 0
+
+
+def test_cigar_to_map_with_skipped():
+    """N symbol should create gaps like D"""
+    imap = cigar_to_map("3M2N3M")
+    assert imap.parent_length == 6
+    assert imap.num_gaps == 1
+
+
+def test_cigar_to_map_with_soft_clip():
+    """S symbol should create gaps"""
+    imap = cigar_to_map("2S4M2S")
+    assert imap.parent_length == 4
+    assert imap.num_gaps == 2
+
+
+def test_cigar_to_map_with_hard_clip():
+    """H symbol should create gaps"""
+    imap = cigar_to_map("2H4M2H")
+    assert imap.parent_length == 4
+    assert imap.num_gaps == 2
+
+
+def test_cigar_to_map_with_padding():
+    """P symbol should create gaps"""
+    imap = cigar_to_map("3M1P3M")
+    assert imap.parent_length == 6
+    assert imap.num_gaps == 1
+
+
+def test_cigar_to_map_mixed_symbols():
+    """Test CIGAR with multiple symbol types"""
+    imap = cigar_to_map("2=3X2M1D2I")
+    assert imap.parent_length == 9  # 2+3+2+2
+    assert imap.num_gaps == 1  # 1D
+
+
+def test_cigar_to_map_implicit_count():
+    """CIGAR ops without numbers default to count of 1"""
+    imap = cigar_to_map("MDMDM")
+    assert imap.parent_length == 3  # M + M + M
+    assert imap.num_gaps == 2  # D + D
+
+
+def test_aligned_from_cigar(cigar_text, map_and_seq, aln_seq):
+    """test generating aligned seq from cigar"""
+    _, seq = map_and_seq
+    aligned_seq = aligned_from_cigar(cigar_text, seq)
+    assert aligned_seq == aln_seq
+
+
+def test_slice_cigar(start_end, cigar_text, aln_seq, map_and_seq):
+    """test slicing cigars"""
+    _, seq = map_and_seq
+    start, end = start_end
+    # test by_align = True
+    map1, loc1 = slice_cigar(cigar_text, start, end)
+    ori1 = aln_seq[start:end]
+    if loc1:
+        slicealn1 = seq[loc1[0] : loc1[1]].gapped_by_map(map1)
+        assert ori1 == slicealn1
+    else:
+        assert len(map1) == len(ori1)
+
+    # test by_align = False
+    map2, loc2 = slice_cigar(cigar_text, start, end, by_align=False)
+    slicealn2 = seq[start:end].gapped_by_map(map2)
+    ori2 = aln_seq[loc2[0] : loc2[1]]
+    assert slicealn2 == ori2
+
+
+def test_cigar_parser(seqs, cigars, aln):
+    """test without slice"""
+    result = cigar_to_alignment(seqs, cigars)
+    assert result == aln


### PR DESCRIPTION
[NEW] fully handle all valid characters in cigar string

[CHANGED] no longer use old style Span/LostSpan objects

[CHANGED] aligned_from_cigar() AOI has changed, it now returns
     a string, not an Aligned instance.

[CHANGED] CigarParser has been deprecated and the API changed.
     Now called cigar_to_alignment() and we no longer allow
     slicing relative to a reference -- we no longer have a good
     use case for that functionality. We will revisit of requested.

## Summary by Sourcery

Modernise the CIGAR parsing utilities to support the full CIGAR specification, simplify return types, and deprecate the legacy parser API.

New Features:
- Support all standard CIGAR operation codes when converting between CIGAR strings and IndelMap objects.

Bug Fixes:
- Handle alignment position and sequence position updates correctly for insertions, deletions, matches, mismatches, clipping, padding, and implicit operation counts in CIGAR strings.

Enhancements:
- Replace Span/LostSpan-based CIGAR construction with direct use of IndelMap gap metadata.
- Change aligned_from_cigar() to return a plain gapped sequence string instead of an Aligned instance.
- Introduce cigar_to_alignment() as the primary API for building alignments from sequences and CIGAR strings, replacing the older CigarParser name while keeping a deprecated alias.
- Refactor CIGAR parsing tests to pytest style with fixtures and expand coverage for all supported CIGAR operations and edge cases.

Tests:
- Convert CIGAR parser unit tests from unittest.TestCase to pytest with fixtures and parameterisation, adding new tests for all supported CIGAR operators and mixed/implicit-count cases.