### PR TITLE
BUG: load_annotations now works if file path has compression suffix

### DIFF
--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -31,7 +31,7 @@ from cogent3._version import __version__
 from cogent3.core.location import Strand, deserialise_map_spans
 from cogent3.parse.gff import GffRecordABC, merged_gff_records
 from cogent3.util.deserialise import deserialise_object, register_deserialiser
-from cogent3.util.io import PathType, iter_line_blocks
+from cogent3.util.io import PathType, get_format_suffixes, iter_line_blocks
 from cogent3.util.misc import extend_docstring_from, get_object_provenance
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -1996,7 +1996,8 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
         if format_name:
             fmt = format_name.lower()
         else:
-            suffix = pathlib.Path(path).suffix.lower()
+            suffix, _ = get_format_suffixes(path)
+            suffix = (suffix if suffix.startswith(".") else f".{suffix}").lower()
             if suffix == ".json":
                 fmt = "json"
             elif suffix in {".gb", ".gbk", ".gbff"}:
@@ -2113,7 +2114,8 @@ def load_annotations(
         suffix = f".{format_name}" if not format_name.startswith(".") else format_name
     else:
         # Auto-detect from file suffix
-        suffix = path.suffix.lower() if path.suffix else None
+        suffix, _ = get_format_suffixes(path)
+        suffix = (suffix if suffix.startswith(".") else f".{suffix}").lower()
         if not suffix:
             msg = f"Cannot auto-detect format for {path!r}, use format_name parameter"
             raise ValueError(msg)

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -2111,7 +2111,7 @@ def load_annotations(
     # Determine file suffix for format detection
     if format_name:
         # Explicit format specified - map to suffix
-        suffix = f".{format_name}" if not format_name.startswith(".") else format_name
+        suffix = format_name if format_name.startswith(".") else f".{format_name}"
     else:
         # Auto-detect from file suffix
         suffix, _ = get_format_suffixes(path)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import pathlib
 
@@ -67,11 +68,8 @@ def seq():
     seq = cogent3.make_seq("ATTGTACGCCTTTTTTATTATT", name="test_seq", moltype="dna")
     yield seq
     if seq.has_annotation_db():
-        try:
+        with contextlib.suppress(AttributeError):
             seq.annotation_db.close()
-        except AttributeError:
-            # handles funky test condition
-            pass
 
 
 @pytest.fixture
@@ -335,6 +333,20 @@ def test_load_annotations_multi(DATA_DIR):
     got = load_annotations(path=DATA_DIR / "simple*.gff")
     assert len(got) == expect
     close_dbs(one, two, got)
+
+
+@pytest.fixture(params=["annotated_seq.gb", "simple2.gff"])
+def compressed_flat_file(DATA_DIR, tmp_path, request):
+    src = DATA_DIR / request.param
+    out_path = tmp_path / f"{request.param}.gz"
+    with cogent3.open_(out_path, mode="w") as out:
+        out.write(src.read_bytes())
+    return out_path
+
+
+def test_load_annotations_compressed(compressed_flat_file):
+    got = load_annotations(path=compressed_flat_file)
+    assert isinstance(got, AnnotationDbABC)
 
 
 def test_load_annotations_chunked(gff_db, DATA_DIR):


### PR DESCRIPTION
## Summary by Sourcery

Handle annotation loading paths with optional compression suffixes and add coverage for compressed files.

Bug Fixes:
- Recognize format correctly when annotation files include compression extensions so load_annotations no longer fails on gzipped paths.

Tests:
- Add fixtures and tests to confirm load_annotations accepts compressed flat files.