### PR TITLE
ENH: improve performance of annotation db

### DIFF
--- a/doc/cookbook/annotation_db.rst
+++ b/doc/cookbook/annotation_db.rst
@@ -316,7 +316,7 @@ If you want a subset of a db, use the same arguments as you would for ``db.get_r
     just_cds = gff_db.subset(biotype="CDS")
     just_cds.describe
 
-.. note:: The result is an in-memory database by default. To have this written to disk, assign a path to the source argument, e.g. ``gff_db.subset(source="som/path/subset.c3gffdb", biotype="CDS")``.
+.. note:: The result is an in-memory database by default. To have this written to disk, assign a path to the source argument, e.g. ``gff_db.subset(source="some/path/subset.c3gffdb", biotype="CDS")``.
 
 .. _assign_db_to_seq:
 

--- a/doc/cookbook/annotation_db.rst
+++ b/doc/cookbook/annotation_db.rst
@@ -27,8 +27,8 @@ Achieved by creating an ``BasicAnnotationDb`` instance. This is an empty databas
     anno_db = BasicAnnotationDb()
     anno_db
 
-How to load an standalone ``AnnotationDb`` from a data file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How to load a standalone ``AnnotationDb`` from a data file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Typically, we want to load a collection of features from a genomic annotation file, such as a GFF or Genbank file. For the following examples, we will use data from the bacterium *Mycoplasma genitalium*.
 
@@ -107,14 +107,14 @@ In the above examples, all databases indicate that ``source=":memory:"``, i.e. t
 .. code-block:: python
 
     # write to disk
-    gb_db.write("data/m-genitalium-database.gbdb")
+    gb_db.write("data/m-genitalium-database.c3gbdb")
 
     # do something
 
     # re-load from disk
-    quick_load_gb_db = GenbankAnnotationDb(source="data/m-genitalium-database.gbdb")
+    quick_load_gb_db = load_annotations(path="data/m-genitalium-database.c3gbdb")
 
-.. note:: The suffix of the outpath (".gbdb" in the above example) can be arbitrarily chosen, however, this behaviour may change in the future to only accept registered suffixes! 👀
+.. note:: The suffix of the outpath (``.c3gbdb`` in the above example) is required for a GenBank derived db file. For a GFF3 or GFF file, the suffix must be ``.c3gffdb``. For the basic annottaion db it is ``.c3andb`. 👀
 
 How to query an ``AnnotationDb``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -294,13 +294,13 @@ The ``update()`` method will update records of a given database with another and
 Initialise a ``AnnotationDb`` with another database
 """""""""""""""""""""""""""""""""""""""""""""""""""
 
-You can assign a compatible database to the ``db`` argument in the ``AnnotationDb`` constructor. If it's the same class, its db will be bound to self and directly modified.
+You can assign a compatible database to the ``db`` argument in the ``AnnotationDb`` constructor. If it's the same class, its db will be bound to self and directly modified with any new data you add.
 
 .. jupyter-execute::
 
     from cogent3.core.annotation_db import GenbankAnnotationDb
 
-    new_gb_db = GenbankAnnotationDb(source="m-genitalium-database.gbdb", db=anno_db)
+    new_gb_db = GenbankAnnotationDb(source="m-genitalium-database.c3gbdb", db=anno_db)
     new_gb_db
 
 How to get a subset of an ``AnnotationDb``
@@ -316,7 +316,7 @@ If you want a subset of a db, use the same arguments as you would for ``db.get_r
     just_cds = gff_db.subset(biotype="CDS")
     just_cds.describe
 
-.. note:: The result is an in-memory database by default. To have this written to disk, assign a path to the source argument, e.g. ``gff_db.subset(source="som/path/subset.gff3db", biotype="CDS")``.
+.. note:: The result is an in-memory database by default. To have this written to disk, assign a path to the source argument, e.g. ``gff_db.subset(source="som/path/subset.c3gffdb", biotype="CDS")``.
 
 .. _assign_db_to_seq:
 
@@ -391,5 +391,5 @@ In the above example, the sequence name in the fasta file does not match any rec
 
     # clean up files
 
-    path = pathlib.Path("m-genitalium-database.gbdb")
+    path = pathlib.Path("m-genitalium-database.c3gbdb")
     path.unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,3 +226,7 @@ phylip = "cogent3.format.sequence:PhylipWriter"
 
 [project.entry-points."cogent3.load.annotations"]
 c3anndb = "cogent3.core.annotation_db:SqliteAnnotationDbLoader"
+# basic, genbank and gff specific annotation db suffixes
+c3andb = "cogent3.core.annotation_db:SqliteAnnotationDbLoader"
+c3gbdb = "cogent3.core.annotation_db:SqliteAnnotationDbLoader"
+c3gffdb = "cogent3.core.annotation_db:SqliteAnnotationDbLoader"

--- a/ruff.toml
+++ b/ruff.toml
@@ -79,6 +79,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "N803",
     "S608" # sql injection unlikely
 ]
+"src/cogent3/core/annotation_db.py" = [
+    "S608" # table/column names are internal constants, values use parameterized queries
+]
 "noxfile.py" = [
     "S101", # asserts allowed in tests...
     "INP001", # __init__.py files are not required...

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -40,6 +40,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 NumpyIntArrayType = npt.NDArray[numpy.integer]
 
+ANNDB_SUFFIX_GENBANK = "c3gbdb"
+ANNDB_SUFFIX_GFF = "c3gffdb"
+ANNDB_SUFFIX_BASIC = "c3andb"
+
 
 # Define custom types for storage in sqlite
 # https://stackoverflow.com/questions/18621513/python-insert-numpy-array-into-sqlite3-database
@@ -87,6 +91,189 @@ sqlite3.register_adapter(numpy.ndarray, array_to_sqlite)
 sqlite3.register_converter("array", sqlite_to_array)
 sqlite3.register_adapter(dict, dict_to_sqlite_as_json)
 sqlite3.register_converter("json", sqlite_json_to_dict)
+
+# Schema version for tracking database format changes
+# Version 1: Original schema with numpy array serialization for all spans
+# Version 2: Revised schema with inline single-span, hierarchy table
+SCHEMA_VERSION = 3
+
+# SQL statements for creating schema tables
+_LOOKUP_TABLES_SQL = {
+    "seqids": """
+        CREATE TABLE IF NOT EXISTS seqids (
+            id INTEGER PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL
+        )
+    """,
+    "biotypes": """
+        CREATE TABLE IF NOT EXISTS biotypes (
+            id INTEGER PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL
+        )
+    """,
+    "sources": """
+        CREATE TABLE IF NOT EXISTS sources (
+            id INTEGER PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL
+        )
+    """,
+}
+
+_FEATURE_SPANS_SQL = """
+    CREATE TABLE IF NOT EXISTS feature_spans (
+        feature_id INTEGER NOT NULL,
+        table_name TEXT NOT NULL,
+        span_index INTEGER NOT NULL,
+        start INTEGER NOT NULL,
+        stop INTEGER NOT NULL,
+        PRIMARY KEY (feature_id, table_name, span_index)
+    )
+"""
+
+_FEATURE_HIERARCHY_SQL = """
+    CREATE TABLE IF NOT EXISTS feature_hierarchy (
+        child_id INTEGER NOT NULL,
+        parent_id INTEGER NOT NULL,
+        table_name TEXT NOT NULL,
+        PRIMARY KEY (child_id, parent_id, table_name)
+    )
+"""
+
+_SCHEMA_VERSION_SQL = """
+    CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+"""
+
+
+def _get_schema_version(db: sqlite3.Connection) -> int:
+    """Get the schema version from a database, or 1 if not present."""
+    try:
+        cursor = db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'"
+        )
+        if not cursor.fetchone():
+            return 1
+        cursor = db.execute(
+            "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
+        )
+        row = cursor.fetchone()
+        return row[0] if row else 1
+    except sqlite3.Error:
+        return 1
+
+
+def _set_schema_version(db: sqlite3.Connection, version: int) -> None:
+    """Set the schema version in the database."""
+    db.execute(_SCHEMA_VERSION_SQL)
+    db.execute("INSERT INTO schema_version (version) VALUES (?)", (version,))
+    db.commit()
+
+
+class LookupTableCache:
+    """Manages caching of lookup table IDs for seqid, biotype, source normalization."""
+
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+        self._seqid_cache: dict[str, int] = {}
+        self._biotype_cache: dict[str, int] = {}
+        self._source_cache: dict[str, int] = {}
+        self._seqid_reverse: dict[int, str] = {}
+        self._biotype_reverse: dict[int, str] = {}
+        self._source_reverse: dict[int, str] = {}
+
+    def _get_or_create_id(
+        self,
+        table: str,
+        name: str,
+        cache: dict[str, int],
+        reverse: dict[int, str],
+    ) -> int:
+        """Get ID for a name, creating it if necessary."""
+        if name in cache:
+            return cache[name]
+
+        cursor = self._db.execute(f"SELECT id FROM {table} WHERE name = ?", (name,))
+        row = cursor.fetchone()
+        if row:
+            cache[name] = row[0]
+            reverse[row[0]] = name
+            return row[0]
+
+        cursor = self._db.execute(f"INSERT INTO {table} (name) VALUES (?)", (name,))
+        self._db.commit()
+        new_id = cursor.lastrowid
+        assert new_id is not None
+        cache[name] = new_id
+        reverse[new_id] = name
+        return new_id
+
+    def _get_name_by_id(
+        self,
+        table: str,
+        id_val: int,
+        cache: dict[str, int],
+        reverse: dict[int, str],
+    ) -> str | None:
+        """Get name for an ID."""
+        if id_val in reverse:
+            return reverse[id_val]
+
+        cursor = self._db.execute(f"SELECT name FROM {table} WHERE id = ?", (id_val,))
+        row = cursor.fetchone()
+        if row:
+            name = row[0]
+            cache[name] = id_val
+            reverse[id_val] = name
+            return name
+        return None
+
+    def get_seqid_id(self, name: str) -> int:
+        return self._get_or_create_id(
+            "seqids", name, self._seqid_cache, self._seqid_reverse
+        )
+
+    def get_biotype_id(self, name: str) -> int:
+        return self._get_or_create_id(
+            "biotypes", name, self._biotype_cache, self._biotype_reverse
+        )
+
+    def get_source_id(self, name: str) -> int:
+        return self._get_or_create_id(
+            "sources", name, self._source_cache, self._source_reverse
+        )
+
+    def get_seqid_name(self, id_val: int) -> str | None:
+        return self._get_name_by_id(
+            "seqids", id_val, self._seqid_cache, self._seqid_reverse
+        )
+
+    def get_biotype_name(self, id_val: int) -> str | None:
+        return self._get_name_by_id(
+            "biotypes", id_val, self._biotype_cache, self._biotype_reverse
+        )
+
+    def get_source_name(self, id_val: int) -> str | None:
+        return self._get_name_by_id(
+            "sources", id_val, self._source_cache, self._source_reverse
+        )
+
+    def load_all(self) -> None:
+        """Pre-load all lookup tables into cache."""
+        for table, cache, reverse in [
+            ("seqids", self._seqid_cache, self._seqid_reverse),
+            ("biotypes", self._biotype_cache, self._biotype_reverse),
+            ("sources", self._source_cache, self._source_reverse),
+        ]:
+            try:
+                cursor = self._db.execute(f"SELECT id, name FROM {table}")
+                for row in cursor:
+                    cache[row[1]] = row[0]
+                    reverse[row[0]] = row[1]
+            except sqlite3.OperationalError:
+                # Table doesn't exist (old schema)
+                pass
 
 
 class FeatureDataType(  # When does this have a start and stop key? same with parent_id
@@ -602,6 +789,52 @@ def _count_records_sql(
     return sql, vals
 
 
+# Tables that are part of the schema and should be ignored in compatibility checks
+_SCHEMA_TABLES = frozenset(
+    {
+        "seqids",
+        "biotypes",
+        "sources",
+        "feature_spans",
+        "feature_hierarchy",
+        "schema_version",
+    }
+)
+
+
+def _make_db_connection(
+    source: PathType,
+    table_names: tuple[str, ...] | None = None,
+) -> sqlite3.Connection:
+    """Create a sqlite3 connection with standard settings.
+
+    Parameters
+    ----------
+    source
+        Path to database file or ":memory:" for in-memory database.
+    table_names
+        Optional tuple of table names to check for legacy 'end' column rename.
+        If provided, renames 'end' to 'stop' in these tables.
+
+    Returns
+    -------
+    sqlite3.Connection configured with PARSE_DECLTYPES and Row factory.
+    """
+    conn = sqlite3.connect(
+        source,
+        detect_types=sqlite3.PARSE_DECLTYPES,
+        check_same_thread=False,
+    )
+    conn.row_factory = sqlite3.Row
+
+    # Handle legacy databases with 'end' column instead of 'stop'
+    if table_names is not None:
+        for table_name in table_names:
+            _rename_column_if_exists(conn, table_name, "end", "stop")
+
+    return conn
+
+
 def _compatible_schema(
     db: sqlite3.Connection, schema: dict[str, set[tuple[str, str]]]
 ) -> bool:
@@ -610,6 +843,9 @@ def _compatible_schema(
         "SELECT name FROM sqlite_master WHERE type='table'",
     ).fetchall():
         table = table["name"]  # noqa: PLW2901
+        # Skip auxiliary tables
+        if table in _SCHEMA_TABLES:
+            continue
         if table not in schema:
             return False
 
@@ -664,8 +900,8 @@ class SqliteAnnotationDbMixin:
     _table_names: ClassVar[tuple[str, ...]]
 
     _user_schema: ClassVar = {
-        "biotype": "TEXT",
-        "seqid": "TEXT",
+        "biotype_id": "INTEGER",
+        "seqid_id": "INTEGER",
         "name": "TEXT",
         "parent_id": "TEXT",
         "start": "INTEGER",
@@ -691,9 +927,11 @@ class SqliteAnnotationDbMixin:
         obj._serialisable = init_vals  # noqa: SLF001
         return obj
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
         self._serialisable: dict[str, Any]
         self.source: PathType
+        self._schema_version: int = 1
+        self._lookup_cache: LookupTableCache | None = None
 
     def __repr__(self) -> str:
         name = self.__class__.__name__
@@ -759,6 +997,8 @@ class SqliteAnnotationDbMixin:
         """initialises the db, using the db passed to the constructor"""
         if isinstance(db, self.__class__):
             self._db: sqlite3.Connection | None = db.db
+            self._schema_version = db._schema_version
+            self._lookup_cache = db._lookup_cache
             return
 
         if isinstance(db, sqlite3.Connection):
@@ -793,6 +1033,43 @@ class SqliteAnnotationDbMixin:
             sql = _make_table_sql(table_name, attr)
             self._execute_sql(sql)
 
+        self._schema_version = _get_schema_version(self.db)
+
+        if self._schema_version >= SCHEMA_VERSION:
+            # Already at current version, just set up caches
+            self._setup_caches()
+            return
+
+        # Database needs upgrade - create the schema v2 tables
+        self._create_v2_tables()
+        _set_schema_version(self.db, SCHEMA_VERSION)
+        self._schema_version = SCHEMA_VERSION
+        self._setup_caches()
+
+    def _create_v2_tables(self) -> None:
+        # Create lookup tables
+        for sql in _LOOKUP_TABLES_SQL.values():
+            self._execute_sql(sql)
+
+        # Create feature_spans table for multi-span features
+        self._execute_sql(_FEATURE_SPANS_SQL)
+
+        # Create feature_hierarchy table
+        self._execute_sql(_FEATURE_HIERARCHY_SQL)
+
+    def _setup_caches(self) -> None:
+        """Set up caches for schema lookups."""
+        if self._schema_version >= SCHEMA_VERSION:
+            self._lookup_cache = LookupTableCache(self.db)
+            self._lookup_cache.load_all()
+        else:
+            self._lookup_cache = None
+
+    @property
+    def schema_version(self) -> int:
+        """Return the schema version of this database."""
+        return self._schema_version
+
     @property
     def db(self) -> sqlite3.Connection:
         if self._db is None:
@@ -801,15 +1078,11 @@ class SqliteAnnotationDbMixin:
             # when the db is empty (tests fail). This  appears unrelated to
             # our code, and does not affect pickling/unpickling on the same
             # thread
-            self._db = sqlite3.connect(
-                self.source,
-                detect_types=sqlite3.PARSE_DECLTYPES,
-                check_same_thread=False,
-            )
-            self._db.row_factory = sqlite3.Row
+            self._db = _make_db_connection(self.source, table_names=self.table_names)
 
-            for table_name in self.table_names:
-                _rename_column_if_exists(self._db, table_name, "end", "stop")
+            # Detect schema version for existing databases
+            self._schema_version = _get_schema_version(self._db)
+            self._setup_caches()
 
         return self._db
 
@@ -823,6 +1096,181 @@ class SqliteAnnotationDbMixin:
             cursor = self.db.cursor()
             cursor.execute(cmnd, values or [])
             return cursor
+
+    def _add_to_hierarchy(
+        self,
+        table_name: str,
+        child_id: int,
+        parent_id: str | None,
+    ) -> None:
+        """Add parent-child relationships to the hierarchy table."""
+        if not self._can_use_hierarchy() or parent_id is None:
+            return
+
+        parent_rowids = self._resolve_parent_rowids(table_name, parent_id)
+        for parent_rowid in parent_rowids:
+            self._insert_hierarchy_entry(child_id, parent_rowid, table_name)
+
+    def _can_use_hierarchy(self) -> bool:
+        """Check if hierarchy table operations are available."""
+        return self._schema_version >= SCHEMA_VERSION
+
+    def _get_lookup_ids(
+        self, seqid: str | None, biotype: str | None, source: str | None = None
+    ) -> tuple[int, int, int]:
+        """Get lookup table IDs for seqid, biotype, and source."""
+        if self._lookup_cache is None:
+            return 0, 0, 0
+        seqid_id = self._lookup_cache.get_seqid_id(seqid) if seqid else 0
+        biotype_id = self._lookup_cache.get_biotype_id(biotype) if biotype else 0
+        source_id = self._lookup_cache.get_source_id(source) if source else 0
+        return seqid_id, biotype_id, source_id
+
+    def _translate_record_to_ids(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Convert seqid/biotype/source strings to IDs for insertion."""
+        if self._lookup_cache is None:
+            return record
+
+        result = dict(record)
+        if "seqid" in result:
+            seqid = result.pop("seqid")
+            result["seqid_id"] = self._lookup_cache.get_seqid_id(seqid) if seqid else 0
+        if "biotype" in result:
+            biotype = result.pop("biotype")
+            result["biotype_id"] = (
+                self._lookup_cache.get_biotype_id(biotype) if biotype else 0
+            )
+        if "source" in result:
+            source = result.pop("source")
+            result["source_id"] = (
+                self._lookup_cache.get_source_id(source) if source else 0
+            )
+        return result
+
+    def _translate_record_from_ids(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Convert seqid_id/biotype_id/source_id to strings for query results."""
+        if self._lookup_cache is None:
+            return record
+
+        result = dict(record)
+        if "seqid_id" in result:
+            seqid_id = result.pop("seqid_id")
+            result["seqid"] = (
+                self._lookup_cache.get_seqid_name(seqid_id) if seqid_id else ""
+            )
+        if "biotype_id" in result:
+            biotype_id = result.pop("biotype_id")
+            result["biotype"] = (
+                self._lookup_cache.get_biotype_name(biotype_id) if biotype_id else ""
+            )
+        if "source_id" in result:
+            source_id = result.pop("source_id")
+            result["source"] = (
+                self._lookup_cache.get_source_name(source_id) if source_id else ""
+            )
+        return result
+
+    def _translate_query_conditions(self, conditions: dict[str, Any]) -> dict[str, Any]:
+        """Convert seqid/biotype/source strings to IDs for query conditions."""
+        if self._lookup_cache is None:
+            return conditions
+
+        result = dict(conditions)
+        if "seqid" in result:
+            seqid = result.pop("seqid")
+            if seqid is not None:
+                if isinstance(seqid, str):
+                    result["seqid_id"] = self._lookup_cache.get_seqid_id(seqid)
+                else:
+                    # Multiple seqids (tuple, list, set)
+                    result["seqid_id"] = tuple(
+                        self._lookup_cache.get_seqid_id(s) for s in seqid
+                    )
+        if "biotype" in result:
+            biotype = result.pop("biotype")
+            if biotype is not None:
+                if isinstance(biotype, str):
+                    result["biotype_id"] = self._lookup_cache.get_biotype_id(biotype)
+                else:
+                    # Multiple biotypes (tuple, list, set)
+                    result["biotype_id"] = tuple(
+                        self._lookup_cache.get_biotype_id(b) for b in biotype
+                    )
+        if "source" in result:
+            source = result.pop("source")
+            if source is not None:
+                result["source_id"] = self._lookup_cache.get_source_id(source)
+        return result
+
+    def _get_feature_rowid(
+        self,
+        table_name: str,
+        name: str,
+        biotype: str | None = None,
+    ) -> int | None:
+        """Get rowid for a feature by name (and optionally biotype)."""
+        if biotype and self._lookup_cache is not None:
+            biotype_id = self._lookup_cache.get_biotype_id(biotype)
+            sql = f"SELECT rowid FROM {table_name} WHERE name = ? AND biotype_id = ?"  # noqa: S608
+            cursor = self._execute_sql(sql, (name, biotype_id))
+        else:
+            sql = f"SELECT rowid FROM {table_name} WHERE name = ?"  # noqa: S608
+            cursor = self._execute_sql(sql, (name,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    def _get_feature_rowids_batch(
+        self,
+        table_name: str,
+        names: set[str],
+    ) -> dict[str, int]:
+        """Get rowids for multiple features by name in a single query."""
+        if not names:
+            return {}
+        # Use a single query with IN clause for efficiency
+        placeholders = ",".join("?" * len(names))
+        names_list = list(names)
+        sql = f"SELECT name, rowid FROM {table_name} WHERE name IN ({placeholders})"
+        cursor = self._execute_sql(sql, tuple(names_list))
+        return {row[0]: row[1] for row in cursor.fetchall()}
+
+    def _resolve_parent_rowids(
+        self,
+        table_name: str,
+        parent_id: str,
+        name_to_rowid: dict[str, int] | None = None,
+    ) -> list[int]:
+        """Parse parent_id string and resolve to list of rowids.
+
+        If name_to_rowid is provided, use it as a cache to avoid SQL queries.
+        """
+        parent_names = [
+            p.strip() for p in parent_id.replace(" ", "").split(",") if p.strip()
+        ]
+        rowids = []
+        for parent_name in parent_names:
+            if name_to_rowid is not None:
+                rowid = name_to_rowid.get(parent_name)
+            else:
+                rowid = self._get_feature_rowid(table_name, parent_name)
+            if rowid is not None:
+                rowids.append(rowid)
+        return rowids
+
+    def _insert_hierarchy_entry(
+        self,
+        child_id: int,
+        parent_id: int,
+        table_name: str,
+    ) -> None:
+        """Insert a single entry into the hierarchy table."""
+        try:
+            self._execute_sql(
+                "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
+                (child_id, parent_id, table_name),
+            )
+        except sqlite3.IntegrityError:
+            pass  # Already exists
 
     def add_feature(
         self,
@@ -866,8 +1314,24 @@ class SqliteAnnotationDbMixin:
         record = {k: v for k, v in local_vars.items() if k != "self" and v is not None}
         if "strand" in record:
             record["strand"] = Strand.from_value(strand).value
+        # Translate seqid/biotype to IDs
+        record = self._translate_record_to_ids(record)
         sql, values = _add_record_sql("user", record)
-        self._execute_sql(sql, values=values)
+        cursor = self._execute_sql(sql, values=values)
+        feature_id = cursor.lastrowid
+
+        # Add to hierarchy table if available
+        if feature_id is not None:
+            self._add_to_hierarchy("user", feature_id, parent_id)
+
+    def _translate_columns_to_ids(
+        self, columns: Iterable[str] | None
+    ) -> tuple[str, ...] | None:
+        """Translate column names from strings to ID columns for normalized schema."""
+        if columns is None:
+            return None
+        mapping = {"seqid": "seqid_id", "biotype": "biotype_id", "source": "source_id"}
+        return tuple(mapping.get(c, c) for c in columns)
 
     def _get_records_matching(
         self,
@@ -879,6 +1343,12 @@ class SqliteAnnotationDbMixin:
             kwargs["attributes"] = f"%{kwargs['attributes']}%"
         columns = kwargs.pop("columns", None)
         allow_partial = kwargs.pop("allow_partial", False)
+
+        # Translate query conditions and column names for normalized schema
+        if self._lookup_cache is not None:
+            kwargs = self._translate_query_conditions(kwargs)
+            columns = self._translate_columns_to_ids(columns)
+
         sql, vals = _select_records_sql(
             table_name=table_name,
             conditions=kwargs,
@@ -901,9 +1371,14 @@ class SqliteAnnotationDbMixin:
         **kwargs: Any,  # noqa: ARG002
     ) -> Iterator[FeatureDataType]:
         # we return the parent_id because `get_feature_parent()` requires it
+        # Translate conditions and columns for normalized schema
+        conditions: dict[str, Any] = {column: name, "biotype": biotype}
+        if self._lookup_cache is not None:
+            conditions = self._translate_query_conditions(conditions)
+            columns = self._translate_columns_to_ids(columns)
         sql, vals = _select_records_sql(
             table_name=table_name,
-            conditions={column: name, "biotype": biotype},
+            conditions=conditions,
             columns=columns,
             allow_partial=allow_partial,
         )
@@ -911,21 +1386,108 @@ class SqliteAnnotationDbMixin:
             result = cast(  # noqa: PLW2901
                 "FeatureDataType", dict(zip(result.keys(), result, strict=False))
             )
+            # Translate IDs back to strings
+            result = self._translate_record_from_ids(result)  # type: ignore[arg-type]
             result["on_alignment"] = result.get("on_alignment")
             result["spans"] = [
                 cast("tuple[int, int]", tuple(c)) for c in result["spans"]
             ]
             yield result
 
-    def get_feature_children(
+    def _has_hierarchy_table(self) -> bool:
+        """Check if the feature_hierarchy table exists and has data."""
+        try:
+            cursor = self.db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='feature_hierarchy'"
+            )
+            return cursor.fetchone() is not None
+        except sqlite3.Error:
+            return False
+
+    def _get_children_via_hierarchy(
+        self,
+        table_name: str,
+        parent_name: str,
+        columns: tuple[str, ...],
+        biotype: str | None = None,
+    ) -> Iterator[FeatureDataType]:
+        # First, find the parent's rowid
+        cursor = self._execute_sql(
+            f"SELECT rowid FROM {table_name} WHERE name = ?",  # noqa: S608
+            (parent_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return
+        parent_rowid = row[0]
+
+        # Translate column names to ID columns for normalized schema
+        translated_columns = self._translate_columns_to_ids(columns) or columns
+        columns_str = ", ".join(f"f.{c}" for c in translated_columns)
+        sql = f"""
+            SELECT {columns_str} FROM {table_name} f
+            INNER JOIN feature_hierarchy h ON f.rowid = h.child_id
+            WHERE h.parent_id = ? AND h.table_name = ?
+        """  # noqa: S608
+        vals: list[Any] = [parent_rowid, table_name]
+
+        if biotype is not None and self._lookup_cache is not None:
+            biotype_id = self._lookup_cache.get_biotype_id(biotype)
+            sql += " AND f.biotype_id = ?"
+            vals.append(biotype_id)
+
+        for result in self._execute_sql(sql, values=tuple(vals)):
+            res = dict(zip(result.keys(), result, strict=False))
+            # Translate IDs back to strings
+            res = self._translate_record_from_ids(res)  # type: ignore[arg-type]
+            res["on_alignment"] = res.get("on_alignment")
+            res["spans"] = [cast("tuple[int, int]", tuple(c)) for c in res["spans"]]
+            # Remove parent_id if present
+            res.pop("parent_id", None)  # type: ignore[typeddict-item]
+            yield cast("FeatureDataType", res)
+
+    def _get_parents_via_hierarchy(
+        self,
+        table_name: str,
+        child_name: str,
+        columns: tuple[str, ...],
+    ) -> Iterator[FeatureDataType]:
+        # First, find the child's rowid
+        cursor = self._execute_sql(
+            f"SELECT rowid FROM {table_name} WHERE name = ?",  # noqa: S608
+            (child_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return
+        child_rowid = row[0]
+
+        # Translate column names to ID columns for normalized schema
+        translated_columns = self._translate_columns_to_ids(columns) or columns
+        columns_str = ", ".join(f"f.{c}" for c in translated_columns)
+        sql = f"""
+            SELECT {columns_str} FROM {table_name} f
+            INNER JOIN feature_hierarchy h ON f.rowid = h.parent_id
+            WHERE h.child_id = ? AND h.table_name = ?
+        """  # noqa: S608
+        vals = child_rowid, table_name
+
+        for result in self._execute_sql(sql, values=vals):
+            res = dict(zip(result.keys(), result, strict=False))
+            # Translate IDs back to strings
+            res = self._translate_record_from_ids(res)  # type: ignore[arg-type]
+            res["on_alignment"] = res.get("on_alignment")
+            res["spans"] = [cast("tuple[int, int]", tuple(c)) for c in res["spans"]]
+            # Remove parent_id if present
+            res.pop("parent_id", None)  # type: ignore[typeddict-item]
+            yield cast("FeatureDataType", res)
+
+    def _old_get_feature_children(
         self,
         name: str,
         biotype: str | None = None,
         **kwargs: Any,
-    ) -> Iterator[FeatureDataType]:
-        """yields children of name"""
-        # kwargs is used because other classes need start / stop
-        # just uses search matching
+    ) -> Iterator[FeatureDataType]:  # pragma: no cover
         for table_name in self.table_names:
             columns: tuple[str, ...] = (
                 "seqid",
@@ -937,6 +1499,8 @@ class SqliteAnnotationDbMixin:
             )
             if table_name == "user":
                 columns += ("on_alignment",)
+
+            # Fall back to LIKE-based search
             for result in self._get_feature_by_id(
                 table_name=table_name,
                 columns=columns,
@@ -949,11 +1513,43 @@ class SqliteAnnotationDbMixin:
                 result.pop("parent_id")  # type: ignore[typeddict-item]
                 yield result
 
-    def get_feature_parent(
+    def get_feature_children(
+        self,
+        name: str,
+        biotype: str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[FeatureDataType]:
+        """yields children of name"""
+        if not self._can_use_hierarchy():
+            yield from self._old_get_feature_children(
+                name=name, biotype=biotype, **kwargs
+            )
+            return
+
+        for table_name in self.table_names:
+            columns: tuple[str, ...] = (
+                "seqid",
+                "biotype",
+                "spans",
+                "strand",
+                "name",
+                "parent_id",
+            )
+            if table_name == "user":
+                columns += ("on_alignment",)
+
+            yield from self._get_children_via_hierarchy(
+                table_name=table_name,
+                parent_name=name,
+                columns=columns,
+                biotype=biotype,
+            )
+
+    def _old_get_feature_parent(
         self,
         name: str,
         **kwargs: Any,  # noqa: ARG002
-    ) -> Iterator[FeatureDataType]:
+    ) -> Iterator[FeatureDataType]:  # pragma: no cover
         """yields parents of name"""
         for table_name in self.table_names:
             columns: tuple[str, ...] = (
@@ -966,6 +1562,8 @@ class SqliteAnnotationDbMixin:
             )
             if table_name == "user":
                 columns += ("on_alignment",)
+
+            # Older version uses LIKE based search
             for result in self._get_feature_by_id(
                 table_name=table_name,
                 columns=columns,
@@ -996,6 +1594,34 @@ class SqliteAnnotationDbMixin:
                         )  # remove invalid field for the FeatureDataType
                         yield par
 
+    def get_feature_parent(
+        self,
+        name: str,
+        **kwargs: Any,
+    ) -> Iterator[FeatureDataType]:
+        """yields parents of name"""
+        if not self._can_use_hierarchy():
+            yield from self._old_get_feature_parent(name=name, **kwargs)
+            return
+
+        for table_name in self.table_names:
+            columns: tuple[str, ...] = (
+                "seqid",
+                "biotype",
+                "spans",
+                "strand",
+                "name",
+                "parent_id",
+            )
+            if table_name == "user":
+                columns += ("on_alignment",)
+
+            yield from self._get_parents_via_hierarchy(
+                table_name=table_name,
+                child_name=name,
+                columns=columns,
+            )
+
     def get_records_matching(
         self,
         *,
@@ -1022,7 +1648,8 @@ class SqliteAnnotationDbMixin:
         table_names = ["user"] if on_alignment else self.table_names
         for table_name in table_names:
             for result in self._get_records_matching(table_name, **kwargs):
-                yield dict(zip(result.keys(), result, strict=False))
+                res = dict(zip(result.keys(), result, strict=False))
+                yield self._translate_record_from_ids(res)
 
     def get_features_matching(
         self,
@@ -1061,12 +1688,12 @@ class SqliteAnnotationDbMixin:
                 columns=columns,
                 **query_args,
             ):
-                res = cast(
-                    "FeatureDataType", dict(zip(result.keys(), result, strict=False))
-                )
+                res = dict(zip(result.keys(), result, strict=False))
+                # Translate IDs back to strings
+                res = self._translate_record_from_ids(res)  # type: ignore[arg-type]
                 res["on_alignment"] = res.get("on_alignment")
                 res["spans"] = [cast("tuple[int, int]", tuple(c)) for c in res["spans"]]
-                yield res
+                yield cast("FeatureDataType", res)
 
     def num_matches(
         self,
@@ -1083,6 +1710,9 @@ class SqliteAnnotationDbMixin:
         kwargs = {k: v for k, v in local_vars.items() if k != "self" and v is not None}
         if "strand" in kwargs:
             kwargs["strand"] = Strand.from_value(kwargs["strand"]).value
+        # Translate conditions for normalized schema
+        if self._lookup_cache is not None:
+            kwargs = self._translate_query_conditions(kwargs)
         num = 0
         for table_name in self.table_names:
             sql, values = _count_records_sql(table_name, conditions=kwargs)
@@ -1123,22 +1753,63 @@ class SqliteAnnotationDbMixin:
         if not columns:
             return None
 
-        if constraints := {k: v for k, v in locals().items() if isinstance(v, str)}:
-            where_clause, values = _matching_conditions(constraints)
-            where_clause = f"WHERE {where_clause}"
-        else:
-            where_clause = ""
-            values = ()
+        constraints = {k: v for k, v in locals().items() if isinstance(v, str)}
 
         header = list(columns)
-        placeholder = "{}"
-        sql_template = (
-            f"SELECT {', '.join(header)}, COUNT(*) as count FROM {placeholder}"
-            f" {where_clause} GROUP BY {', '.join(header)};"
-        )
         data: list[tuple[Any, ...]] = []
+
         for table in self.table_names:
-            sql = sql_template.format(table)
+            # Build SELECT and GROUP BY with proper joins for normalized columns
+            if self._lookup_cache is not None:
+                # Use joins for normalized columns
+                select_parts = []
+                group_by_parts = []
+                joins = []
+                for col in header:
+                    if col == "seqid":
+                        select_parts.append("s.name as seqid")
+                        group_by_parts.append("t.seqid_id")
+                        joins.append("LEFT JOIN seqids s ON t.seqid_id = s.id")
+                    elif col == "biotype":
+                        select_parts.append("b.name as biotype")
+                        group_by_parts.append("t.biotype_id")
+                        joins.append("LEFT JOIN biotypes b ON t.biotype_id = b.id")
+                    else:
+                        select_parts.append(f"t.{col}")
+                        group_by_parts.append(f"t.{col}")
+
+                if translated_constraints := self._translate_query_conditions(
+                    constraints
+                ):
+                    # Prefix with t. for table alias
+                    prefixed_constraints = {
+                        f"t.{k}": v for k, v in translated_constraints.items()
+                    }
+                    where_clause, values = _matching_conditions(prefixed_constraints)
+                    where_clause = f"WHERE {where_clause}"
+                else:
+                    where_clause = ""
+                    values = ()
+
+                join_clause = " ".join(dict.fromkeys(joins))  # Remove duplicates
+                sql = (
+                    f"SELECT {', '.join(select_parts)}, COUNT(*) as count "  # noqa: S608
+                    f"FROM {table} t {join_clause} {where_clause} "
+                    f"GROUP BY {', '.join(group_by_parts)};"
+                )
+            else:
+                # No lookup cache, use original column names
+                if constraints:
+                    where_clause, values = _matching_conditions(constraints)
+                    where_clause = f"WHERE {where_clause}"
+                else:
+                    where_clause = ""
+                    values = ()
+                sql = (
+                    f"SELECT {', '.join(header)}, COUNT(*) as count FROM {table}"  # noqa: S608
+                    f" {where_clause} GROUP BY {', '.join(header)};"
+                )
+
             if result := self._execute_sql(sql, values).fetchall():
                 data.extend(tuple(r) for r in result)
 
@@ -1153,11 +1824,17 @@ class SqliteAnnotationDbMixin:
         """top level description of the annotation db"""
         from cogent3.core.table import Table
 
-        sql_template = "SELECT {}, COUNT(*) FROM {} GROUP BY {};"
         data: dict[str, int] = {}
         for column in ("seqid", "biotype"):
             for table in self.table_names:
-                sql = sql_template.format(column, table, column)
+                if self._lookup_cache is not None:
+                    # Use joins for normalized columns
+                    if column == "seqid":
+                        sql = f"SELECT s.name, COUNT(*) FROM {table} t LEFT JOIN seqids s ON t.seqid_id = s.id GROUP BY t.seqid_id;"  # noqa: S608
+                    else:  # biotype
+                        sql = f"SELECT b.name, COUNT(*) FROM {table} t LEFT JOIN biotypes b ON t.biotype_id = b.id GROUP BY t.biotype_id;"  # noqa: S608
+                else:
+                    sql = f"SELECT {column}, COUNT(*) FROM {table} GROUP BY {column};"  # noqa: S608
                 if result := self._execute_sql(sql).fetchall():
                     counts = dict(tuple(r) for r in result)
                     for distinct, count in counts.items():
@@ -1167,7 +1844,7 @@ class SqliteAnnotationDbMixin:
         row_counts: list[int] = []
         for table in self.table_names:
             result = self._execute_sql(
-                f"SELECT COUNT(*) as count FROM {table}",
+                f"SELECT COUNT(*) as count FROM {table}",  # noqa: S608
             ).fetchone()
             row_counts.append(result["count"])
 
@@ -1181,10 +1858,12 @@ class SqliteAnnotationDbMixin:
 
     def biotype_counts(self) -> dict[str, int]:
         """return counts of biological types across all tables and seqids"""
-        sql_template = "SELECT biotype FROM {}"
         counts: dict[str, int] = collections.Counter()
         for table in self.table_names:
-            sql = sql_template.format(table)
+            if self._lookup_cache is not None:
+                sql = f"SELECT b.name as biotype FROM {table} t LEFT JOIN biotypes b ON t.biotype_id = b.id"  # noqa: S608
+            else:
+                sql = f"SELECT biotype FROM {table}"  # noqa: S608
             if result := self._execute_sql(sql).fetchall():
                 counts.update(v for r in result if (v := r["biotype"]))
         return counts
@@ -1206,6 +1885,8 @@ class SqliteAnnotationDbMixin:
                     for k, v in zip(record.keys(), record, strict=False)
                     if v is not None
                 }
+                # Translate IDs back to strings for serialization
+                store = self._translate_record_from_ids(store)
                 store["spans"] = store["spans"].tolist()
                 table_data.append(store)
             tables[table_name] = table_data
@@ -1309,9 +1990,11 @@ class SqliteAnnotationDbMixin:
         # TODO gah prevent duplication of existing records
         for table_name, records in data["tables"].items():
             for record in records:
-                if seqids and record["seqid"] not in seqids:
+                if seqids and record.get("seqid") not in seqids:
                     continue
                 record["spans"] = numpy.array(record["spans"], dtype=int)
+                # Translate string columns to IDs for normalized schema
+                record = self._translate_record_to_ids(record)
                 sql, vals = _add_record_sql(
                     table_name,
                     {k: v for k, v in record.items() if v is not None},
@@ -1330,7 +2013,10 @@ class SqliteAnnotationDbMixin:
             msg = f"cannot update from {type(other_db)}"
             raise TypeError(msg)
 
-        conditions = {"seqid": seqids} if seqids else {}
+        conditions: dict[str, Any] = {"seqid": seqids} if seqids else {}
+        # Translate conditions for other_db's schema
+        if other_db._lookup_cache is not None:
+            conditions = other_db._translate_query_conditions(conditions)
         table_names = other_db.table_names
 
         col_order = {
@@ -1343,22 +2029,74 @@ class SqliteAnnotationDbMixin:
 
         for tname in other_db.table_names:
             sql, vals = _select_records_sql(table_name=tname, conditions=conditions)
-            data = other_db._execute_sql(sql, vals)
+            data = list(other_db._execute_sql(sql, vals))
             val_placeholder = ", ".join("?" * len(col_order[tname]))
             sql = f"INSERT INTO {tname} ({', '.join(col_order[tname])}) VALUES ({val_placeholder})"
 
             self.db.executemany(sql, data)
+            self.db.commit()
 
     def to_json(self) -> str:
         return json.dumps(self.to_rich_dict())
 
     def write(self, path: PathType) -> None:
-        """writes db as bytes to path"""
+        """writes db as bytes to path
+
+        Parameters
+        ----------
+        path
+            Path to write the database. Must have suffix matching
+            the class's _suffix attribute.
+
+        Raises
+        ------
+        ValueError
+            If the file suffix doesn't match the expected suffix for this class.
+        """
         path = pathlib.Path(path).expanduser()
+        expected_suffix = f".{self._suffix}"
+        if not path.name.endswith(expected_suffix):
+            msg = f"Expected file suffix {expected_suffix!r}, got {path.suffix!r}"
+            raise ValueError(msg)
         backup = sqlite3.connect(path)
         with self.db:
             self.db.backup(backup)
         backup.close()
+
+    @classmethod
+    def from_file(cls, path: PathType) -> Self:
+        """Load an annotation database from a file.
+
+        Parameters
+        ----------
+        path
+            Path to the saved database file. Must have suffix matching
+            the class's _suffix attribute.
+
+        Returns
+        -------
+        An instance of the annotation database class with the loaded data.
+
+        Raises
+        ------
+        ValueError
+            If the file suffix doesn't match the expected suffix for this class.
+        OSError
+            If the file doesn't exist.
+        """
+        path = pathlib.Path(path).expanduser()
+
+        if not path.exists():
+            msg = f"File {path} does not exist."
+            raise OSError(msg)
+
+        expected_suffix = f".{cls._suffix}"
+        if not path.name.endswith(expected_suffix):
+            msg = f"Expected file suffix {expected_suffix!r}, got {path.suffix!r}"
+            raise ValueError(msg)
+
+        conn = _make_db_connection(path, table_names=cls._table_names)
+        return cls(source=path, db=conn)
 
     def subset(
         self,
@@ -1428,7 +2166,14 @@ class SqliteAnnotationDbMixin:
         for table_name in self.table_names:
             self._make_index(
                 table_name=table_name,
-                col_names=("biotype", "seqid", "name", "start", "stop", "parent_id"),
+                col_names=(
+                    "biotype_id",
+                    "seqid_id",
+                    "name",
+                    "start",
+                    "stop",
+                    "parent_id",
+                ),
             )
 
 
@@ -1442,12 +2187,13 @@ class BasicAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
     """
 
     _table_names: ClassVar = ("user",)
+    _suffix = ANNDB_SUFFIX_BASIC
 
     def __init__(
         self,
         *,
         data: Iterable[dict[str, Any]] | None = None,
-        db: SqliteAnnotationDbMixin | None = None,
+        db: SqliteAnnotationDbMixin | sqlite3.Connection | None = None,
         source: PathType = ":memory:",
     ) -> None:
         """
@@ -1459,13 +2205,28 @@ class BasicAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
             a compatible annotation db instance. If db is the same class, it's
             db will be bound to self and directly modified.
         source
-            location to store the db, defaults to in memory only
+            location to store the db, defaults to in memory only. Must not be
+            an existing file - use from_file() to load existing databases.
         """
+        # Reject existing files - users should use from_file() instead
+        # Only check when db is not provided (db=None means we're not binding to existing)
+        if db is None and source != ":memory:":
+            source_path = pathlib.Path(source).expanduser()
+            if source_path.exists():
+                msg = (
+                    f"File {source_path} already exists. "
+                    f"Use {self.__class__.__name__}.from_file() to load existing databases."
+                )
+                raise ValueError(msg)
+
         data = data or []
         # note that data is destroyed
         self._num_fakeids = 0
         self.source = source
         self._db = None
+        # Initialise schema attributes
+        self._schema_version = 1
+        self._lookup_cache = None
         self._setup_db(db)
 
         self.add_records(data)
@@ -1503,9 +2264,9 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
     _table_names: ClassVar = "gff", "user"
     # We are relying on an attribute name structured as _<table name>_schema
     _gff_schema: ClassVar = {
-        "seqid": "TEXT",
-        "source": "TEXT",
-        "biotype": "TEXT",  # type in GFF
+        "seqid_id": "INTEGER",
+        "source_id": "INTEGER",
+        "biotype_id": "INTEGER",  # type in GFF
         "start": "INTEGER",
         "stop": "INTEGER",
         "score": "TEXT",  # check defn
@@ -1517,15 +2278,27 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         "name": "TEXT",
         "parent_id": "TEXT",
     }
+    _suffix = ANNDB_SUFFIX_GFF
 
     @extend_docstring_from(BasicAnnotationDb.__init__)
     def __init__(
         self,
         *,
         data: list[GffRecordABC] | None = None,
-        db: SqliteAnnotationDbMixin | None = None,
+        db: SqliteAnnotationDbMixin | sqlite3.Connection | None = None,
         source: PathType = ":memory:",
     ) -> None:
+        # Reject existing files - users should use from_file() instead
+        # Only check when db is not provided (db=None means we're not binding to existing)
+        if db is None and source != ":memory:":
+            source_path = pathlib.Path(source).expanduser()
+            if source_path.exists():
+                msg = (
+                    f"File {source_path} already exists. "
+                    f"Use {self.__class__.__name__}.from_file() to load existing databases."
+                )
+                raise ValueError(msg)
+
         data = data or []
         # note that data is destroyed
         self._num_fakeids = 0
@@ -1534,6 +2307,9 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         # ensure serialisable state reflects this
         self._serialisable["source"] = self.source
         self._db = None
+        # Initialise schema attributes
+        self._schema_version = 1
+        self._lookup_cache = None
         self._setup_db(db)
         merged_data, self._num_fakeids = merged_gff_records(data, self._num_fakeids)
         self.add_records(merged_data)
@@ -1550,21 +2326,106 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         # across sources of gff?? I doubt it, so more robust regex likely
         # required
         rows: list[tuple[Any, ...]] = []
+        hierarchy_entries: list[tuple[str, str | None]] = []
+
         for record in reduced.values():
             # our Feature code assumes start always < stop,
             # we record direction using Strand
             spans = numpy.array(sorted(record["spans"]), dtype=int)  # sorts the rows
             spans.sort(axis=1)
-            record["start"] = int(spans.min())
-            record["stop"] = int(spans.max())
-            record["spans"] = spans
-            record["strand"] = Strand.from_value(record.get("strand")).value
-            rows.append(tuple(record.get(c) for c in col_order))
+            start = int(spans.min())
+            stop = int(spans.max())
+
+            # Build a row dict with translated IDs (since GffRecord objects are read-only)
+            row_data: dict[str, Any] = {
+                "start": start,
+                "stop": stop,
+                "spans": spans,
+                "strand": Strand.from_value(record.get("strand")).value,
+                "name": record.get("name"),
+                "parent_id": record.get("parent_id"),
+                "score": record.get("score"),
+                "phase": record.get("phase"),
+                "attributes": record.get("attributes"),
+                "comments": record.get("comments"),
+            }
+
+            # Translate seqid/biotype/source to IDs
+            if self._lookup_cache is not None:
+                row_data["seqid_id"] = (
+                    self._lookup_cache.get_seqid_id(record.get("seqid"))
+                    if record.get("seqid")
+                    else 0
+                )
+                row_data["biotype_id"] = (
+                    self._lookup_cache.get_biotype_id(record.get("biotype"))
+                    if record.get("biotype")
+                    else 0
+                )
+                row_data["source_id"] = (
+                    self._lookup_cache.get_source_id(record.get("source"))
+                    if record.get("source")
+                    else 0
+                )
+            else:
+                row_data["seqid_id"] = 0
+                row_data["biotype_id"] = 0
+                row_data["source_id"] = 0
+
+            rows.append(tuple(row_data.get(c) for c in col_order))
+
+            # Collect data for hierarchy
+            name = record.get("name") or ""
+            if parent_id := record.get("parent_id"):
+                hierarchy_entries.append((name, parent_id))
 
         self.db.executemany(sql, rows)
-
         self.db.commit()
+
+        # Populate hierarchy table
+        self._populate_hierarchy_batch("gff", hierarchy_entries)
+
         del reduced
+
+    def _populate_hierarchy_batch(
+        self,
+        table_name: str,
+        entries: list[tuple[str, str | None]],
+    ) -> None:
+        """Populate hierarchy table for a batch of records."""
+        if not self._can_use_hierarchy():
+            return
+
+        # Collect all names (children and parents) for a single batch lookup
+        all_names: set[str] = set()
+        for child_name, parent_id in entries:
+            all_names.add(child_name)
+            if parent_id:
+                for p in parent_id.replace(" ", "").split(","):
+                    if p := p.strip():
+                        all_names.add(p)
+
+        # Get all rowids in a single query
+        name_to_rowid = self._get_feature_rowids_batch(table_name, all_names)
+
+        # Build hierarchy entries with inlined parent resolution
+        hierarchy_rows = []
+        for child_name, parent_id in entries:
+            if child_name not in name_to_rowid or not parent_id:
+                continue
+            child_rowid = name_to_rowid[child_name]
+            # Inline parent_id parsing to avoid function call overhead
+            for p in parent_id.replace(" ", "").split(","):
+                p = p.strip()
+                if p and p in name_to_rowid:
+                    hierarchy_rows.append((child_rowid, name_to_rowid[p], table_name))
+
+        if hierarchy_rows:
+            self.db.executemany(
+                "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
+                hierarchy_rows,
+            )
+            self.db.commit()
 
     def update_record_spans(self, *, name: str, spans: list[tuple[int, int]]) -> None:
         """updates spans attribute of a gff table record if present
@@ -1613,9 +2474,9 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
     _table_names: ClassVar = "gb", "user"
     # We are relying on an attribute name structured as _<table name>_schema
     _gb_schema: ClassVar = {
-        "seqid": "TEXT",
-        "source": "TEXT",
-        "biotype": "TEXT",  # type in GFF
+        "seqid_id": "INTEGER",
+        "source_id": "INTEGER",
+        "biotype_id": "INTEGER",  # type in GFF
         "start": "INTEGER",
         "stop": "INTEGER",
         "strand": "INTEGER",
@@ -1626,6 +2487,7 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         "parent_id": "TEXT",
         "attributes": "json",
     }
+    _suffix = ANNDB_SUFFIX_GENBANK
 
     @extend_docstring_from(BasicAnnotationDb.__init__)
     def __init__(
@@ -1633,7 +2495,7 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         *,
         data: Iterable[dict[str, Any]] | None = None,
         seqid: str | None = None,
-        db: SqliteAnnotationDbMixin | None = None,
+        db: SqliteAnnotationDbMixin | sqlite3.Connection | None = None,
         source: PathType = ":memory:",
         namer: Callable[[dict[str, Any]], list[str] | None] | None = None,
     ) -> None:
@@ -1644,11 +2506,25 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
             callable that takes a record dict and returns a
             [name]
         """
+        # Reject existing files - users should use from_file() instead
+        # Only check when db is not provided (db=None means we're not binding to existing)
+        if db is None and source != ":memory:":
+            source_path = pathlib.Path(source).expanduser()
+            if source_path.exists():
+                msg = (
+                    f"File {source_path} already exists. "
+                    f"Use {self.__class__.__name__}.from_file() to load existing databases."
+                )
+                raise ValueError(msg)
+
         data = data or []
         # note that data is destroyed
         self._num_fakeids = 0
         self.source = source
         self._db = None
+        # Initialise schema attributes
+        self._schema_version = 1
+        self._lookup_cache = None
         self._setup_db(db)
         if db:
             # guessing there's multiple seqid's
@@ -1672,7 +2548,7 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         exclude = {"translation", "location", "type"}  # location is grabbed directly
         for record in records:
             # our Feature code assumes start always < stop,
-            store: dict[str, Any] = {"seqid": seqid}
+            store: dict[str, Any] = {}
             # we create the location data directly
             if location := record.get("location", None):
                 store["spans"] = numpy.array(location.get_coordinates(), dtype=int)
@@ -1682,16 +2558,30 @@ class GenbankAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
                 store["stop"] = int(store["spans"].max())
 
             attrs_keys = record.keys() - exclude
-            store["biotype"] = record["type"]
+            biotype = record["type"]
             name = self._namer(record)
             if name is None:
                 name = self._make_fake_id(record)
             store["attributes"] = {k: record[k] for k in attrs_keys}
             store["name"] = ",".join(name)
+
+            # Translate seqid/biotype to IDs
+            if self._lookup_cache is not None:
+                store["seqid_id"] = (
+                    self._lookup_cache.get_seqid_id(seqid) if seqid else 0
+                )
+                store["biotype_id"] = (
+                    self._lookup_cache.get_biotype_id(biotype) if biotype else 0
+                )
+            else:
+                store["seqid_id"] = 0
+                store["biotype_id"] = 0
+
             rows.append(tuple(store.get(c) for c in col_order))
 
         self.db.executemany(sql, rows)
         self.db.commit()
+
         del records
 
     def _default_namer(self, record: dict[str, Any]) -> list[str] | None:
@@ -1960,7 +2850,17 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
 
     @property
     def supported_suffixes(self) -> set[str]:
-        return {".gff", ".gff3", ".gb", ".gbk", ".gbff", ".json"}
+        return {
+            ".gff",
+            ".gff3",
+            ".gb",
+            ".gbk",
+            ".gbff",
+            ".json",
+            f".{ANNDB_SUFFIX_GENBANK}",
+            f".{ANNDB_SUFFIX_GFF}",
+            f".{ANNDB_SUFFIX_BASIC}",
+        }
 
     def load(
         self,
@@ -1992,6 +2892,15 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
             Additional arguments (e.g., ui for progress display,
             lines_per_block for GFF chunked loading)
         """
+        # was this an already saved db
+        path = pathlib.Path(path)
+        if path.name.endswith(ANNDB_SUFFIX_GENBANK):
+            return GenbankAnnotationDb.from_file(path)
+        if path.name.endswith(ANNDB_SUFFIX_GFF):
+            return GffAnnotationDb.from_file(path)
+        if path.name.endswith(ANNDB_SUFFIX_BASIC):
+            return BasicAnnotationDb.from_file(path)
+
         # Determine format from format_name parameter or file suffix
         if format_name:
             fmt = format_name.lower()
@@ -2243,6 +3152,152 @@ def update_file_format(
     conn.close()
 
 
+def upgrade_annotation_db(
+    source_path: PathType,
+    backup: bool = True,
+) -> None:
+    """Upgrade an existing annotation database to the schema.
+
+    This function migrates old-format annotation databases to use the new
+    schema, which includes:
+    - Lookup tables for seqid, biotype, source normalization
+    - Feature hierarchy table for fast parent/child lookups
+
+    Parameters
+    ----------
+    source_path
+        Path to the existing database file
+    backup
+        If True, creates backup at source_path.bak before migration
+
+    Notes
+    -----
+    - Detects schema version and skips if already upgraded
+    - Preserves all existing data
+    - Creates lookup tables and hierarchy table
+    - Running twice is safe
+
+    Raises
+    ------
+    OSError
+        If source_path does not exist
+    FileExistsError
+        If backup=True and backup file already exists
+
+    Examples
+    --------
+    >>> from cogent3.core.annotation_db import upgrade_annotation_db
+    >>> upgrade_annotation_db("my_annotations.gffdb")  # doctest: +SKIP
+    """
+    source_path = pathlib.Path(source_path).expanduser()
+
+    if not source_path.exists():
+        msg = f"File {source_path} does not exist."
+        raise OSError(msg)
+
+    # Open the database to check schema version
+    conn = sqlite3.connect(
+        source_path,
+        detect_types=sqlite3.PARSE_DECLTYPES,
+        check_same_thread=False,
+    )
+    conn.row_factory = sqlite3.Row
+
+    current_version = _get_schema_version(conn)
+    if current_version >= SCHEMA_VERSION:
+        conn.close()
+        return  # Already at current version
+
+    # Create backup if requested
+    if backup:
+        backup_path = source_path.parent / f"{source_path.name}.bak"
+        if backup_path.exists():
+            conn.close()
+            msg = (
+                f"Backup file already exists at {backup_path}. "
+                "Remove or rename it before upgrading."
+            )
+            raise FileExistsError(msg)
+
+        backup_conn = sqlite3.connect(backup_path)
+        conn.backup(backup_conn)
+        backup_conn.close()
+
+    # Detect which table type this is (gff, gb, or just user)
+    table_names: list[str] = []
+    for table in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall():
+        name = table["name"]
+        if name in ("gff", "gb", "user"):
+            table_names.append(name)
+
+    # Create schema tables
+    for sql in _LOOKUP_TABLES_SQL.values():
+        conn.execute(sql)
+    conn.execute(_FEATURE_SPANS_SQL)
+    conn.execute(_FEATURE_HIERARCHY_SQL)
+    conn.commit()
+
+    # Build lookup tables from existing data
+    lookup_cache = LookupTableCache(conn)
+
+    for table_name in table_names:
+        # Get all records from this table
+        cursor = conn.execute(f"SELECT rowid, * FROM {table_name}")  # noqa: S608
+        records = cursor.fetchall()
+
+        # Build hierarchy entries
+        hierarchy_entries = []
+
+        for row in records:
+            row_dict = dict(zip(row.keys(), row, strict=False))
+            rowid = row_dict.get("rowid")
+            seqid = row_dict.get("seqid") or ""
+            biotype = row_dict.get("biotype") or ""
+            name = row_dict.get("name") or ""
+            parent_id = row_dict.get("parent_id")
+
+            # Add to lookup tables (this populates the seqids/biotypes tables)
+            if seqid:
+                lookup_cache.get_seqid_id(seqid)
+            if biotype:
+                lookup_cache.get_biotype_id(biotype)
+
+            # Collect hierarchy entries
+            if parent_id and rowid is not None:
+                parent_names = [
+                    p.strip()
+                    for p in parent_id.replace(" ", "").split(",")
+                    if p.strip()
+                ]
+                hierarchy_entries.extend(
+                    (rowid, name, parent_name, table_name)
+                    for parent_name in parent_names
+                )
+        # Populate hierarchy table
+        if hierarchy_entries:
+            # Need to resolve parent names to rowids
+            for child_rowid, _, parent_name, tbl in hierarchy_entries:
+                cursor = conn.execute(
+                    f"SELECT rowid FROM {tbl} WHERE name = ?",  # noqa: S608
+                    (parent_name,),
+                )
+                if row := cursor.fetchone():
+                    parent_rowid = row[0]
+                    with contextlib.suppress(sqlite3.IntegrityError):
+                        conn.execute(
+                            "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
+                            (child_rowid, parent_rowid, tbl),
+                        )
+            conn.commit()
+
+    # Set schema version
+    _set_schema_version(conn, SCHEMA_VERSION)
+
+    conn.close()
+
+
 DEFAULT_ANNOTATION_DB = BasicAnnotationDb
 
 # This is a design note about the annotation_db property of SequenceCollection, Alignment,
@@ -2262,7 +3317,7 @@ DEFAULT_ANNOTATION_DB = BasicAnnotationDb
 class AnnotatableMixin:
     """class handling an annotation database for a collection, aligned or sequence"""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pragma: no cover
         self._annotation_db: list[AnnotationDbABC] = []
 
     def _init_annot_db_value(

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -835,6 +835,81 @@ def _make_db_connection(
     return conn
 
 
+def _get_name_to_rowid_batch(
+    conn: sqlite3.Connection,
+    table_name: str,
+    names: set[str],
+) -> dict[str, int]:
+    """Get rowids for multiple features by name in a single query.
+
+    Parameters
+    ----------
+    conn
+        Database connection
+    table_name
+        Name of table to query
+    names
+        Set of feature names to look up
+
+    Returns
+    -------
+    Dict mapping feature name to rowid
+    """
+    if not names:
+        return {}
+    placeholders = ",".join("?" * len(names))
+    names_list = list(names)
+    sql = f"SELECT name, rowid FROM {table_name} WHERE name IN ({placeholders})"  # noqa: S608
+    cursor = conn.execute(sql, tuple(names_list))
+    return {row[0]: row[1] for row in cursor.fetchall()}
+
+
+def _populate_hierarchy_table(
+    conn: sqlite3.Connection,
+    table_name: str,
+    entries: list[tuple[int, str]],
+) -> None:
+    """Populate the feature_hierarchy table from child-parent entries.
+
+    Parameters
+    ----------
+    conn
+        Database connection with feature_hierarchy table
+    table_name
+        Name of feature table (gff, gb, user)
+    entries
+        List of (child_rowid, parent_id_string) tuples where parent_id_string
+        may contain comma-separated parent names
+    """
+    if not entries:
+        return
+
+    # Collect all parent names for batch lookup
+    parent_names: set[str] = set()
+    for _, parent_id in entries:
+        for p in parent_id.replace(" ", "").split(","):
+            if p := p.strip():
+                parent_names.add(p)
+
+    # Batch lookup parent names to rowids
+    name_to_rowid = _get_name_to_rowid_batch(conn, table_name, parent_names)
+
+    # Build hierarchy rows
+    hierarchy_rows = []
+    for child_rowid, parent_id in entries:
+        for p in parent_id.replace(" ", "").split(","):
+            p = p.strip()
+            if p and p in name_to_rowid:
+                hierarchy_rows.append((child_rowid, name_to_rowid[p], table_name))
+
+    if hierarchy_rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
+            hierarchy_rows,
+        )
+        conn.commit()
+
+
 def _compatible_schema(
     db: sqlite3.Connection, schema: dict[str, set[tuple[str, str]]]
 ) -> bool:
@@ -2392,40 +2467,36 @@ class GffAnnotationDb(SqliteAnnotationDbMixin, AnnotationDbABC):
         table_name: str,
         entries: list[tuple[str, str | None]],
     ) -> None:
-        """Populate hierarchy table for a batch of records."""
+        """Populate hierarchy table for a batch of records.
+
+        Parameters
+        ----------
+        table_name
+            Name of feature table (gff, gb, user)
+        entries
+            List of (child_name, parent_id_string) tuples
+        """
         if not self._can_use_hierarchy():
             return
 
-        # Collect all names (children and parents) for a single batch lookup
-        all_names: set[str] = set()
-        for child_name, parent_id in entries:
-            all_names.add(child_name)
-            if parent_id:
-                for p in parent_id.replace(" ", "").split(","):
-                    if p := p.strip():
-                        all_names.add(p)
+        # Collect child names that have parent_id
+        child_names: set[str] = {
+            child_name for child_name, parent_id in entries if parent_id
+        }
+        if not child_names:
+            return
 
-        # Get all rowids in a single query
-        name_to_rowid = self._get_feature_rowids_batch(table_name, all_names)
+        # Batch lookup child names to rowids
+        name_to_rowid = self._get_feature_rowids_batch(table_name, child_names)
 
-        # Build hierarchy entries with inlined parent resolution
-        hierarchy_rows = []
-        for child_name, parent_id in entries:
-            if child_name not in name_to_rowid or not parent_id:
-                continue
-            child_rowid = name_to_rowid[child_name]
-            # Inline parent_id parsing to avoid function call overhead
-            for p in parent_id.replace(" ", "").split(","):
-                p = p.strip()
-                if p and p in name_to_rowid:
-                    hierarchy_rows.append((child_rowid, name_to_rowid[p], table_name))
+        # Convert to (child_rowid, parent_id) format for shared helper
+        rowid_entries = [
+            (name_to_rowid[child_name], parent_id)
+            for child_name, parent_id in entries
+            if parent_id and child_name in name_to_rowid
+        ]
 
-        if hierarchy_rows:
-            self.db.executemany(
-                "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
-                hierarchy_rows,
-            )
-            self.db.commit()
+        _populate_hierarchy_table(self.db, table_name, rowid_entries)
 
     def update_record_spans(self, *, name: str, spans: list[tuple[int, int]]) -> None:
         """updates spans attribute of a gff table record if present
@@ -3196,12 +3267,7 @@ def upgrade_annotation_db(
         raise OSError(msg)
 
     # Open the database to check schema version
-    conn = sqlite3.connect(
-        source_path,
-        detect_types=sqlite3.PARSE_DECLTYPES,
-        check_same_thread=False,
-    )
-    conn.row_factory = sqlite3.Row
+    conn = _make_db_connection(source_path)
 
     current_version = _get_schema_version(conn)
     if current_version >= SCHEMA_VERSION:
@@ -3247,15 +3313,14 @@ def upgrade_annotation_db(
         cursor = conn.execute(f"SELECT rowid, * FROM {table_name}")  # noqa: S608
         records = cursor.fetchall()
 
-        # Build hierarchy entries
-        hierarchy_entries = []
+        # Build hierarchy entries as (child_rowid, parent_id_string) tuples
+        hierarchy_entries: list[tuple[int, str]] = []
 
         for row in records:
             row_dict = dict(zip(row.keys(), row, strict=False))
             rowid = row_dict.get("rowid")
             seqid = row_dict.get("seqid") or ""
             biotype = row_dict.get("biotype") or ""
-            name = row_dict.get("name") or ""
             parent_id = row_dict.get("parent_id")
 
             # Add to lookup tables (this populates the seqids/biotypes tables)
@@ -3266,31 +3331,10 @@ def upgrade_annotation_db(
 
             # Collect hierarchy entries
             if parent_id and rowid is not None:
-                parent_names = [
-                    p.strip()
-                    for p in parent_id.replace(" ", "").split(",")
-                    if p.strip()
-                ]
-                hierarchy_entries.extend(
-                    (rowid, name, parent_name, table_name)
-                    for parent_name in parent_names
-                )
-        # Populate hierarchy table
-        if hierarchy_entries:
-            # Need to resolve parent names to rowids
-            for child_rowid, _, parent_name, tbl in hierarchy_entries:
-                cursor = conn.execute(
-                    f"SELECT rowid FROM {tbl} WHERE name = ?",  # noqa: S608
-                    (parent_name,),
-                )
-                if row := cursor.fetchone():
-                    parent_rowid = row[0]
-                    with contextlib.suppress(sqlite3.IntegrityError):
-                        conn.execute(
-                            "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
-                            (child_rowid, parent_rowid, tbl),
-                        )
-            conn.commit()
+                hierarchy_entries.append((rowid, parent_id))
+
+        # Populate hierarchy table using shared helper
+        _populate_hierarchy_table(conn, table_name, hierarchy_entries)
 
     # Set schema version
     _set_schema_version(conn, SCHEMA_VERSION)

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -859,7 +859,7 @@ def _get_name_to_rowid_batch(
         return {}
     placeholders = ",".join("?" * len(names))
     names_list = list(names)
-    sql = f"SELECT name, rowid FROM {table_name} WHERE name IN ({placeholders})"  # noqa: S608
+    sql = f"SELECT name, rowid FROM {table_name} WHERE name IN ({placeholders})"
     cursor = conn.execute(sql, tuple(names_list))
     return {row[0]: row[1] for row in cursor.fetchall()}
 
@@ -907,6 +907,118 @@ def _populate_hierarchy_table(
             "INSERT OR IGNORE INTO feature_hierarchy (child_id, parent_id, table_name) VALUES (?, ?, ?)",
             hierarchy_rows,
         )
+        conn.commit()
+
+
+def _migrate_to_normalized_schema(
+    conn: sqlite3.Connection,
+    table_names: list[str],
+    lookup_cache: LookupTableCache,
+) -> None:
+    """Migrate old TEXT columns (seqid, biotype, source) to new *_id INTEGER columns.
+
+    Parameters
+    ----------
+    conn
+        Database connection
+    table_names
+        List of table names to migrate (gff, gb, user)
+    lookup_cache
+        LookupTableCache instance for getting/creating ID mappings
+
+    Notes
+    -----
+    This function handles the schema migration from old-format databases that used
+    TEXT columns directly to the new normalized format using lookup tables.
+    """
+    # Mapping of old column names to new column names
+    column_mappings = [
+        ("seqid", "seqid_id", lookup_cache.get_seqid_id),
+        ("biotype", "biotype_id", lookup_cache.get_biotype_id),
+        ("source", "source_id", lookup_cache.get_source_id),
+    ]
+
+    for table_name in table_names:
+        # Get current table columns
+        table_info = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        existing_columns = {row["name"] for row in table_info}
+
+        # Check which old columns need to be migrated
+        columns_to_migrate = []
+        for old_col, new_col, get_id_func in column_mappings:
+            if old_col in existing_columns and new_col not in existing_columns:
+                columns_to_migrate.append((old_col, new_col, get_id_func))
+
+        if not columns_to_migrate:
+            continue
+
+        # Add new INTEGER columns
+        for old_col, new_col, _ in columns_to_migrate:
+            conn.execute(
+                f"ALTER TABLE {table_name} ADD COLUMN {new_col} INTEGER DEFAULT 0"
+            )
+        conn.commit()
+
+        # Get all unique values for each column to migrate and populate lookup tables
+        # Then update all rows with the new IDs
+        for old_col, new_col, get_id_func in columns_to_migrate:
+            # Get all distinct values from the old column
+            cursor = conn.execute(
+                f"SELECT DISTINCT {old_col} FROM {table_name} WHERE {old_col} IS NOT NULL AND {old_col} != ''"
+            )
+            distinct_values = [row[old_col] for row in cursor.fetchall()]
+
+            # Populate lookup table and get ID mappings
+            value_to_id = {}
+            for value in distinct_values:
+                if value:
+                    value_to_id[value] = get_id_func(value)
+
+            # Update rows with new IDs
+            for value, id_val in value_to_id.items():
+                conn.execute(
+                    f"UPDATE {table_name} SET {new_col} = ? WHERE {old_col} = ?",
+                    (id_val, value),
+                )
+
+        conn.commit()
+
+        # Now we need to drop the old columns
+        # SQLite doesn't support DROP COLUMN directly in older versions,
+        # so we need to recreate the table without those columns
+        # Get the full schema to recreate the table
+        table_info = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        old_column_names = {old_col for old_col, _, _ in columns_to_migrate}
+
+        # Build column list for new table (excluding old TEXT columns)
+        new_columns = []
+        column_defs = []
+        for col in table_info:
+            if col["name"] not in old_column_names:
+                new_columns.append(col["name"])
+                col_type = col["type"]
+                col_def = f'"{col["name"]}" {col_type}'
+                if col["notnull"]:
+                    col_def += " NOT NULL"
+                if col["dflt_value"] is not None:
+                    col_def += f" DEFAULT {col['dflt_value']}"
+                column_defs.append(col_def)
+
+        # Create temporary table with new schema
+        temp_table = f"{table_name}_migration_temp"
+        create_sql = f"CREATE TABLE {temp_table} ({', '.join(column_defs)})"
+        conn.execute(create_sql)
+
+        # Copy data to temporary table
+        columns_str = ", ".join(f'"{c}"' for c in new_columns)
+        conn.execute(
+            f"INSERT INTO {temp_table} ({columns_str}) SELECT {columns_str} FROM {table_name}"
+        )
+
+        # Drop old table and rename temporary table
+        conn.execute(f"DROP TABLE {table_name}")
+        conn.execute(f"ALTER TABLE {temp_table} RENAME TO {table_name}")
+
         conn.commit()
 
 
@@ -1286,10 +1398,10 @@ class SqliteAnnotationDbMixin:
         """Get rowid for a feature by name (and optionally biotype)."""
         if biotype and self._lookup_cache is not None:
             biotype_id = self._lookup_cache.get_biotype_id(biotype)
-            sql = f"SELECT rowid FROM {table_name} WHERE name = ? AND biotype_id = ?"  # noqa: S608
+            sql = f"SELECT rowid FROM {table_name} WHERE name = ? AND biotype_id = ?"
             cursor = self._execute_sql(sql, (name, biotype_id))
         else:
-            sql = f"SELECT rowid FROM {table_name} WHERE name = ?"  # noqa: S608
+            sql = f"SELECT rowid FROM {table_name} WHERE name = ?"
             cursor = self._execute_sql(sql, (name,))
         row = cursor.fetchone()
         return row[0] if row else None
@@ -1488,7 +1600,7 @@ class SqliteAnnotationDbMixin:
     ) -> Iterator[FeatureDataType]:
         # First, find the parent's rowid
         cursor = self._execute_sql(
-            f"SELECT rowid FROM {table_name} WHERE name = ?",  # noqa: S608
+            f"SELECT rowid FROM {table_name} WHERE name = ?",
             (parent_name,),
         )
         row = cursor.fetchone()
@@ -1503,7 +1615,7 @@ class SqliteAnnotationDbMixin:
             SELECT {columns_str} FROM {table_name} f
             INNER JOIN feature_hierarchy h ON f.rowid = h.child_id
             WHERE h.parent_id = ? AND h.table_name = ?
-        """  # noqa: S608
+        """
         vals: list[Any] = [parent_rowid, table_name]
 
         if biotype is not None and self._lookup_cache is not None:
@@ -1529,7 +1641,7 @@ class SqliteAnnotationDbMixin:
     ) -> Iterator[FeatureDataType]:
         # First, find the child's rowid
         cursor = self._execute_sql(
-            f"SELECT rowid FROM {table_name} WHERE name = ?",  # noqa: S608
+            f"SELECT rowid FROM {table_name} WHERE name = ?",
             (child_name,),
         )
         row = cursor.fetchone()
@@ -1544,7 +1656,7 @@ class SqliteAnnotationDbMixin:
             SELECT {columns_str} FROM {table_name} f
             INNER JOIN feature_hierarchy h ON f.rowid = h.parent_id
             WHERE h.child_id = ? AND h.table_name = ?
-        """  # noqa: S608
+        """
         vals = child_rowid, table_name
 
         for result in self._execute_sql(sql, values=vals):
@@ -1868,7 +1980,7 @@ class SqliteAnnotationDbMixin:
 
                 join_clause = " ".join(dict.fromkeys(joins))  # Remove duplicates
                 sql = (
-                    f"SELECT {', '.join(select_parts)}, COUNT(*) as count "  # noqa: S608
+                    f"SELECT {', '.join(select_parts)}, COUNT(*) as count "
                     f"FROM {table} t {join_clause} {where_clause} "
                     f"GROUP BY {', '.join(group_by_parts)};"
                 )
@@ -1881,7 +1993,7 @@ class SqliteAnnotationDbMixin:
                     where_clause = ""
                     values = ()
                 sql = (
-                    f"SELECT {', '.join(header)}, COUNT(*) as count FROM {table}"  # noqa: S608
+                    f"SELECT {', '.join(header)}, COUNT(*) as count FROM {table}"
                     f" {where_clause} GROUP BY {', '.join(header)};"
                 )
 
@@ -1905,11 +2017,11 @@ class SqliteAnnotationDbMixin:
                 if self._lookup_cache is not None:
                     # Use joins for normalized columns
                     if column == "seqid":
-                        sql = f"SELECT s.name, COUNT(*) FROM {table} t LEFT JOIN seqids s ON t.seqid_id = s.id GROUP BY t.seqid_id;"  # noqa: S608
+                        sql = f"SELECT s.name, COUNT(*) FROM {table} t LEFT JOIN seqids s ON t.seqid_id = s.id GROUP BY t.seqid_id;"
                     else:  # biotype
-                        sql = f"SELECT b.name, COUNT(*) FROM {table} t LEFT JOIN biotypes b ON t.biotype_id = b.id GROUP BY t.biotype_id;"  # noqa: S608
+                        sql = f"SELECT b.name, COUNT(*) FROM {table} t LEFT JOIN biotypes b ON t.biotype_id = b.id GROUP BY t.biotype_id;"
                 else:
-                    sql = f"SELECT {column}, COUNT(*) FROM {table} GROUP BY {column};"  # noqa: S608
+                    sql = f"SELECT {column}, COUNT(*) FROM {table} GROUP BY {column};"
                 if result := self._execute_sql(sql).fetchall():
                     counts = dict(tuple(r) for r in result)
                     for distinct, count in counts.items():
@@ -1919,7 +2031,7 @@ class SqliteAnnotationDbMixin:
         row_counts: list[int] = []
         for table in self.table_names:
             result = self._execute_sql(
-                f"SELECT COUNT(*) as count FROM {table}",  # noqa: S608
+                f"SELECT COUNT(*) as count FROM {table}",
             ).fetchone()
             row_counts.append(result["count"])
 
@@ -1936,9 +2048,9 @@ class SqliteAnnotationDbMixin:
         counts: dict[str, int] = collections.Counter()
         for table in self.table_names:
             if self._lookup_cache is not None:
-                sql = f"SELECT b.name as biotype FROM {table} t LEFT JOIN biotypes b ON t.biotype_id = b.id"  # noqa: S608
+                sql = f"SELECT b.name as biotype FROM {table} t LEFT JOIN biotypes b ON t.biotype_id = b.id"
             else:
-                sql = f"SELECT biotype FROM {table}"  # noqa: S608
+                sql = f"SELECT biotype FROM {table}"
             if result := self._execute_sql(sql).fetchall():
                 counts.update(v for r in result if (v := r["biotype"]))
         return counts
@@ -3308,9 +3420,12 @@ def upgrade_annotation_db(
     # Build lookup tables from existing data
     lookup_cache = LookupTableCache(conn)
 
+    # Migrate old TEXT columns to new *_id INTEGER columns
+    _migrate_to_normalized_schema(conn, table_names, lookup_cache)
+
     for table_name in table_names:
         # Get all records from this table
-        cursor = conn.execute(f"SELECT rowid, * FROM {table_name}")  # noqa: S608
+        cursor = conn.execute(f"SELECT rowid, * FROM {table_name}")
         records = cursor.fetchall()
 
         # Build hierarchy entries as (child_rowid, parent_id_string) tuples
@@ -3319,15 +3434,7 @@ def upgrade_annotation_db(
         for row in records:
             row_dict = dict(zip(row.keys(), row, strict=False))
             rowid = row_dict.get("rowid")
-            seqid = row_dict.get("seqid") or ""
-            biotype = row_dict.get("biotype") or ""
             parent_id = row_dict.get("parent_id")
-
-            # Add to lookup tables (this populates the seqids/biotypes tables)
-            if seqid:
-                lookup_cache.get_seqid_id(seqid)
-            if biotype:
-                lookup_cache.get_biotype_id(biotype)
 
             # Collect hierarchy entries
             if parent_id and rowid is not None:

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -2965,11 +2965,11 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
         """
         # was this an already saved db
         path = pathlib.Path(path)
-        if path.name.endswith(ANNDB_SUFFIX_GENBANK):
+        if path.name.endswith(f".{ANNDB_SUFFIX_GENBANK}"):
             return GenbankAnnotationDb.from_file(path)
-        if path.name.endswith(ANNDB_SUFFIX_GFF):
+        if path.name.endswith(f".{ANNDB_SUFFIX_GFF}"):
             return GffAnnotationDb.from_file(path)
-        if path.name.endswith(ANNDB_SUFFIX_BASIC):
+        if path.name.endswith(f".{ANNDB_SUFFIX_BASIC}"):
             return BasicAnnotationDb.from_file(path)
 
         # Determine format from format_name parameter or file suffix

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import io
 import pathlib
@@ -339,10 +340,8 @@ class Location:
     ) -> None:
         """Returns new LocalLocation object."""
 
-        try:
+        with contextlib.suppress(TypeError):
             data = int(data)
-        except TypeError:
-            pass  # assume was two Location objects.
         self._data = data
         self.ambiguity = ambiguity
         self.is_between = is_between

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -2137,8 +2137,6 @@ def test_upgrade_annotation_db_migrates_columns(tmp_path):
     """
     import sqlite3
 
-    import numpy
-
     db_path = tmp_path / "old_schema_test.c3gffdb"
 
     # Create database with OLD schema (TEXT columns, not *_id INTEGER columns)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -13,6 +13,7 @@ from cogent3.core.annotation_db import (
     GenbankAnnotationDb,
     GffAnnotationDb,
     LookupTableCache,
+    _make_db_connection,
     _matching_conditions,
     _rename_column_if_exists,
     load_annotations,
@@ -1819,10 +1820,7 @@ def test_load_annotations_roundtrip_gb(DATA_DIR, tmp_path):
 
 def test_lookup_cache_get_seqid_name_cache_hit():
     """Test get_seqid_name returns cached value when ID is in reverse cache."""
-    import sqlite3
-
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
+    conn = _make_db_connection(":memory:")
     conn.execute("CREATE TABLE seqids (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
     conn.execute("INSERT INTO seqids (name) VALUES ('chr1')")
     conn.commit()
@@ -1839,10 +1837,7 @@ def test_lookup_cache_get_seqid_name_cache_hit():
 
 def test_lookup_cache_get_seqid_name_db_lookup():
     """Test get_seqid_name performs DB lookup when ID not in cache."""
-    import sqlite3
-
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
+    conn = _make_db_connection(":memory:")
     conn.execute("CREATE TABLE seqids (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
     conn.execute("INSERT INTO seqids (name) VALUES ('chr1')")
     conn.commit()
@@ -1865,10 +1860,7 @@ def test_lookup_cache_get_seqid_name_db_lookup():
 
 def test_lookup_cache_get_seqid_name_not_found():
     """Test get_seqid_name returns None when ID doesn't exist."""
-    import sqlite3
-
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
+    conn = _make_db_connection(":memory:")
     conn.execute("CREATE TABLE seqids (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
     conn.commit()
 
@@ -1882,10 +1874,7 @@ def test_lookup_cache_get_seqid_name_not_found():
 
 def test_lookup_cache_get_biotype_name():
     """Test get_biotype_name works correctly."""
-    import sqlite3
-
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
+    conn = _make_db_connection(":memory:")
     conn.execute("CREATE TABLE biotypes (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
     conn.execute("INSERT INTO biotypes (name) VALUES ('gene')")
     conn.commit()
@@ -1905,10 +1894,7 @@ def test_lookup_cache_get_biotype_name():
 
 def test_lookup_cache_get_source_name():
     """Test get_source_name works correctly."""
-    import sqlite3
-
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
+    conn = _make_db_connection(":memory:")
     conn.execute("CREATE TABLE sources (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
     conn.execute("INSERT INTO sources (name) VALUES ('GFF3')")
     conn.commit()

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -7,13 +7,16 @@ import pytest
 
 import cogent3
 from cogent3.core.annotation_db import (
+    SCHEMA_VERSION,
     AnnotationDbABC,
     BasicAnnotationDb,
     GenbankAnnotationDb,
     GffAnnotationDb,
+    LookupTableCache,
     _matching_conditions,
     _rename_column_if_exists,
     load_annotations,
+    upgrade_annotation_db,
 )
 from cogent3.parse import genbank
 from cogent3.util import deserialise
@@ -210,6 +213,28 @@ def test_count_distinct_no_match(gb_db):
     assert got.shape == (0, 2)
 
 
+@pytest.mark.parametrize(
+    ("db_fixture", "db_class"),
+    [
+        ("gb_db", GenbankAnnotationDb),
+        ("gff_db", GffAnnotationDb),
+        ("anno_db", BasicAnnotationDb),
+    ],
+)
+def test_count_distinct_after_db_reuse(db_fixture, db_class, request):
+    """count_distinct works when db class reuses existing db connection.
+
+    Regression test: _setup_db was not copying _schema_version and
+    _lookup_cache when binding to an existing db of the same class,
+    causing "no such column: biotype" errors.
+    """
+    first_db = request.getfixturevalue(db_fixture)
+    second_db = db_class(db=first_db)
+    result = second_db.count_distinct(biotype=True)
+    assert result is not None
+    second_db.close()
+
+
 def test_gff_features_matching(gff_db):
     result = list(gff_db.get_features_matching(biotype="CDS"))
     assert result
@@ -347,6 +372,7 @@ def compressed_flat_file(DATA_DIR, tmp_path, request):
 def test_load_annotations_compressed(compressed_flat_file):
     got = load_annotations(path=compressed_flat_file)
     assert isinstance(got, AnnotationDbABC)
+    got.close()
 
 
 def test_load_annotations_chunked(gff_db, DATA_DIR):
@@ -1097,11 +1123,10 @@ def test_gb_namer(DATA_DIR):
     close_dbs(db)
 
 
-@pytest.fixture
 def test_write(gb_db, tmp_path):
-    outpath = tmp_path / "ondisk.gbkdb"
+    outpath = tmp_path / "ondisk.c3gbdb"
     gb_db.write(outpath)
-    got = GenbankAnnotationDb(source=outpath)
+    got = GenbankAnnotationDb.from_file(outpath)
     assert got.to_rich_dict()["tables"] == gb_db.to_rich_dict()["tables"]
     assert isinstance(got, GenbankAnnotationDb)
     close_dbs(got, gb_db)
@@ -1128,7 +1153,7 @@ def convert_spans_column(db, table_name):
 def test_read_old_format(db_name, cls, tmp_path, request):
     db = request.getfixturevalue(db_name)
 
-    path = tmp_path / f"old_format_{db_name}.db"
+    path = tmp_path / f"old_format_{db_name}.{cls._suffix}"
 
     old_tables = db.to_rich_dict()["tables"]
 
@@ -1137,7 +1162,7 @@ def test_read_old_format(db_name, cls, tmp_path, request):
 
     db.write(path)
 
-    new_db = cls(source=path)
+    new_db = cls.from_file(path)
     with pytest.warns(UserWarning):
         new_tables = new_db.to_rich_dict()["tables"]
     assert new_tables == old_tables
@@ -1151,10 +1176,10 @@ def tmp_dir(tmp_path_factory):
 
 def test_load_anns_with_write(DATA_DIR, tmp_dir):
     inpath = DATA_DIR / "simple.gff"
-    outpath = tmp_dir / "simple.gffdb"
+    outpath = tmp_dir / "simple.c3gffdb"
     orig = load_annotations(path=inpath, write_path=outpath)
     expect = load_annotations(path=inpath)
-    got = GffAnnotationDb(source=outpath)
+    got = GffAnnotationDb.from_file(outpath)
     assert len(got) == len(expect)
     got_data = got.to_rich_dict()
     expect_data = expect.to_rich_dict()
@@ -1177,7 +1202,7 @@ def test_load_anns_from_json(DATA_DIR, tmp_dir):
 
 
 def test_gff_end_renamed_to_stop(gff_db, tmp_path):
-    bad_col_path = tmp_path / "bad_col.gffdb"
+    bad_col_path = tmp_path / "bad_col.c3gffdb"
 
     correct_rich_dict = gff_db.to_rich_dict()
     del correct_rich_dict["init_args"]
@@ -1186,10 +1211,10 @@ def test_gff_end_renamed_to_stop(gff_db, tmp_path):
         # Convert in memory db stop column to the old end name
         _rename_column_if_exists(gff_db.db, table_name, "stop", "end")
 
-    gff_db.write(tmp_path / bad_col_path)
+    gff_db.write(bad_col_path)
 
     # Test that end column is renamed to stop on construction
-    loaded_gff_db = GffAnnotationDb(source=bad_col_path)
+    loaded_gff_db = GffAnnotationDb.from_file(bad_col_path)
 
     new_rich_dict = loaded_gff_db.to_rich_dict()
     del new_rich_dict["init_args"]
@@ -1199,7 +1224,7 @@ def test_gff_end_renamed_to_stop(gff_db, tmp_path):
 
 
 def test_gb_end_renamed_to_stop(gb_db, tmp_path):
-    bad_col_path = tmp_path / "bad_col.gbdb"
+    bad_col_path = tmp_path / "bad_col.c3gbdb"
 
     correct_rich_dict = gb_db.to_rich_dict()
     del correct_rich_dict["init_args"]
@@ -1208,10 +1233,10 @@ def test_gb_end_renamed_to_stop(gb_db, tmp_path):
         # Convert in memory db stop column to the old end name
         _rename_column_if_exists(gb_db.db, table_name, "stop", "end")
 
-    gb_db.write(tmp_path / bad_col_path)
+    gb_db.write(bad_col_path)
 
     # Test that end column is renamed to stop on construction
-    loaded_gb_db = GenbankAnnotationDb(source=bad_col_path)
+    loaded_gb_db = GenbankAnnotationDb.from_file(bad_col_path)
 
     new_rich_dict = loaded_gb_db.to_rich_dict()
     del new_rich_dict["init_args"]
@@ -1281,7 +1306,7 @@ def test_subset_gb_db(gb_db):
 
 
 def test_subset_gff3_db_source(gff_db, tmp_dir):
-    outpath = tmp_dir / "subset.gff3db"
+    outpath = tmp_dir / "subset.c3gffdb"
     subset = gff_db.subset(
         seqid="I",
         start=40,
@@ -1292,7 +1317,7 @@ def test_subset_gff3_db_source(gff_db, tmp_dir):
     subset.db.close()
 
     # reload
-    subset = type(gff_db)(source=outpath)
+    subset = type(gff_db).from_file(outpath)
     # manual inspection of the original GFF3 file indicates 7 records
     # BUT the CDS records get merged into a single row
     assert len(subset) == 6
@@ -1342,7 +1367,7 @@ def test_db_close(request, db):
 @pytest.mark.parametrize("db", ["gff_db", "gb_db"])
 @pytest.mark.parametrize(
     "col",
-    ["biotype", "seqid", "name", "start", "stop", "parent_id"],
+    ["biotype_id", "seqid_id", "name", "start", "stop", "parent_id"],
 )
 def test_db_make_index(request, db, col):
     ann_db = request.getfixturevalue(db)
@@ -1391,3 +1416,728 @@ def test_load_annotations_invalid_backend():
 def test_load_annotations_invalid_file_format():
     with pytest.raises(ValueError):
         load_annotations(path="somefile.txt", format_name="invalid_format")
+
+
+# Tests for optimized schema and upgrade_annotation_db function
+
+
+def test_schema_version_new_db():
+    """New databases should have the current schema version."""
+    db = BasicAnnotationDb()
+    assert db.schema_version == SCHEMA_VERSION
+    db.close()
+
+    db = GffAnnotationDb()
+    assert db.schema_version == SCHEMA_VERSION
+    db.close()
+
+    db = GenbankAnnotationDb()
+    assert db.schema_version == SCHEMA_VERSION
+    db.close()
+
+
+def test_lookup_tables_exist(DATA_DIR):
+    """Lookup tables should exist in the schema."""
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+
+    # Check that lookup tables exist (they may or may not have entries)
+    conn = db.db
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('seqids', 'biotypes')"
+    )
+    tables = [row[0] for row in cursor.fetchall()]
+    assert "seqids" in tables
+    assert "biotypes" in tables
+
+    db.close()
+
+
+def test_hierarchy_table_populated(DATA_DIR):
+    """Hierarchy table should be populated for features with parent_id."""
+    db = load_annotations(path=DATA_DIR / "c_elegans_WS199_shortened_gff.gff3")
+
+    # This GFF has parent-child relationships
+    conn = db.db
+    cursor = conn.execute("SELECT COUNT(*) FROM feature_hierarchy")
+    count = cursor.fetchone()[0]
+    # The shortened GFF should have some hierarchy entries
+    assert count >= 0  # May be 0 if no parent_id in data
+
+    db.close()
+
+
+def test_upgrade_annotation_db(DATA_DIR, tmp_path):
+    """Test upgrading an old-format database to the optimized schema."""
+    import sqlite3
+
+    # Create a database and write it to file
+    db_path = tmp_path / "test_upgrade.c3gffdb"
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    db.write(db_path)
+    db.close()
+
+    # Simulate an old-format database by removing schema_version table
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE IF EXISTS schema_version")
+    # Also drop optimized tables to simulate old format
+    conn.execute("DROP TABLE IF EXISTS seqids")
+    conn.execute("DROP TABLE IF EXISTS biotypes")
+    conn.execute("DROP TABLE IF EXISTS sources")
+    conn.execute("DROP TABLE IF EXISTS feature_spans")
+    conn.execute("DROP TABLE IF EXISTS feature_hierarchy")
+    conn.execute("DROP TABLE IF EXISTS feature_rtree")
+    conn.commit()
+    conn.close()
+
+    # Upgrade the database
+    upgrade_annotation_db(db_path, backup=True)
+
+    # Verify backup was created
+    backup_path = tmp_path / "test_upgrade.c3gffdb.bak"
+    assert backup_path.exists()
+
+    # Verify schema version is updated
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(
+        "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
+    )
+    version = cursor.fetchone()[0]
+    assert version == SCHEMA_VERSION
+
+    # Verify optimized tables exist
+    for table in ["seqids", "biotypes", "sources", "feature_hierarchy"]:
+        cursor = conn.execute(
+            f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table}'"
+        )
+        assert cursor.fetchone() is not None, f"Table {table} should exist"
+
+    conn.close()
+
+
+def test_upgrade_annotation_db_idempotent(DATA_DIR, tmp_path):
+    """Test that upgrading twice is safe (idempotent)."""
+    import sqlite3
+
+    # Create a database and write it to file
+    db_path = tmp_path / "test_idempotent.c3gffdb"
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    db.write(db_path)
+    db.close()
+
+    # Simulate old format
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE IF EXISTS schema_version")
+    conn.commit()
+    conn.close()
+
+    # Upgrade once
+    upgrade_annotation_db(db_path, backup=True)
+
+    # Upgrade again - should not fail and should not create another backup
+    upgrade_annotation_db(db_path, backup=False)
+
+    # Verify still at current version
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(
+        "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
+    )
+    version = cursor.fetchone()[0]
+    assert version == SCHEMA_VERSION
+    conn.close()
+
+
+def test_upgrade_annotation_db_file_not_exists(tmp_path):
+    """Test that upgrade fails gracefully when file doesn't exist."""
+    with pytest.raises(OSError):
+        upgrade_annotation_db(tmp_path / "nonexistent.gffdb")
+
+
+def test_upgrade_annotation_db_backup_exists(DATA_DIR, tmp_path):
+    """Test that upgrade fails when backup already exists."""
+    # Create database and backup file
+    db_path = tmp_path / "test_backup.c3gffdb"
+    backup_path = tmp_path / "test_backup.c3gffdb.bak"
+
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    db.write(db_path)
+    db.close()
+
+    # Create a fake backup file
+    backup_path.touch()
+
+    # Simulate old format
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE IF EXISTS schema_version")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(FileExistsError):
+        upgrade_annotation_db(db_path, backup=True)
+
+
+def test_upgrade_annotation_db_genbank(DATA_DIR, tmp_path):
+    """Test upgrading a GenBank annotation database."""
+    import sqlite3
+
+    # Create a GenBank database
+    db_path = tmp_path / "test_gb.c3gbdb"
+    db = load_annotations(path=DATA_DIR / "annotated_seq.gb")
+    db.write(db_path)
+    db.close()
+
+    # Simulate old format
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE IF EXISTS schema_version")
+    conn.commit()
+    conn.close()
+
+    # Upgrade
+    upgrade_annotation_db(db_path, backup=True)
+
+    # Verify schema version
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(
+        "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
+    )
+    version = cursor.fetchone()[0]
+    assert version == SCHEMA_VERSION
+    conn.close()
+
+
+def test_rtree_range_query_matches_original(DATA_DIR):
+    """R*Tree range queries should return same results as original queries."""
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+
+    # Get features with R*Tree
+    features_rtree = list(
+        db.get_features_matching(start=0, stop=10, allow_partial=True)
+    )
+
+    # Disable R*Tree and get features again
+    db._use_rtree = False
+    features_no_rtree = list(
+        db.get_features_matching(start=0, stop=10, allow_partial=True)
+    )
+
+    # Both should return the same results
+    assert len(features_rtree) == len(features_no_rtree)
+
+    # Compare feature names
+    rtree_names = {f["name"] for f in features_rtree}
+    no_rtree_names = {f["name"] for f in features_no_rtree}
+    assert rtree_names == no_rtree_names
+
+    db.close()
+
+
+def test_hierarchy_children_query_matches_original(DATA_DIR):
+    """Hierarchy-based children queries should return same results as LIKE-based."""
+    db = load_annotations(path=DATA_DIR / "c_elegans_WS199_shortened_gff.gff3")
+
+    # Get a gene name that has children
+    gene_name = "Gene:WBGene00000001"
+
+    # Get children with hierarchy table
+    children_hierarchy = list(db.get_feature_children(gene_name))
+
+    # Disable hierarchy and get children again
+    original_version = db._schema_version
+    db._schema_version = 1  # Force fallback to LIKE-based query
+    children_like = list(db.get_feature_children(gene_name))
+    db._schema_version = original_version
+
+    # Both should return the same results (or both empty if no children)
+    assert len(children_hierarchy) == len(children_like)
+
+    db.close()
+
+
+def test_data_integrity_after_upgrade(DATA_DIR, tmp_path):
+    """Data should be unchanged after upgrade."""
+    import sqlite3
+
+    # Create a database and write it to file
+    db_path = tmp_path / "test_integrity.c3gffdb"
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+
+    # Get feature count before
+    features_before = list(db.get_features_matching())
+    count_before = len(features_before)
+
+    db.write(db_path)
+    db.close()
+
+    # Simulate old format
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE IF EXISTS schema_version")
+    conn.commit()
+    conn.close()
+
+    # Upgrade
+    upgrade_annotation_db(db_path, backup=True)
+
+    # Load upgraded database and count features
+    db = GffAnnotationDb.from_file(path=db_path)
+    features_after = list(db.get_features_matching())
+    count_after = len(features_after)
+
+    assert count_before == count_after
+
+    # Check that specific features are preserved
+    names_before = {f["name"] for f in features_before}
+    names_after = {f["name"] for f in features_after}
+    assert names_before == names_after
+
+    db.close()
+
+
+@pytest.mark.parametrize(
+    ("db_name", "cls", "suffix"),
+    [
+        ("gff_db", GffAnnotationDb, "c3gffdb"),
+        ("gb_db", GenbankAnnotationDb, "c3gbdb"),
+        ("anno_db", BasicAnnotationDb, "c3andb"),
+    ],
+)
+def test_constructor_rejects_existing_db_file(db_name, cls, suffix, tmp_path, request):
+    """Constructing a db class with an existing file path should raise ValueError.
+
+    Users should use <ClassName>.from_file() to load existing databases,
+    not the constructor with source=path.
+    """
+    db = request.getfixturevalue(db_name)
+    outpath = tmp_path / f"existing_db.{suffix}"
+    db.write(outpath)
+
+    # This should raise ValueError - users should use from_file() instead
+    with pytest.raises(ValueError):
+        cls(source=outpath)
+
+
+# Tests for load_annotations plugin delegation with custom suffixes
+
+
+@pytest.mark.parametrize(
+    ("db_name", "cls", "suffix"),
+    [
+        ("gff_db", GffAnnotationDb, "c3gffdb"),
+        ("gb_db", GenbankAnnotationDb, "c3gbdb"),
+        ("anno_db", BasicAnnotationDb, "c3andb"),
+    ],
+)
+def test_load_annotations_saved_db_file(db_name, cls, suffix, tmp_path, request):
+    """load_annotations should correctly load saved database files by suffix."""
+    db = request.getfixturevalue(db_name)
+    outpath = tmp_path / f"saved_db.{suffix}"
+    db.write(outpath)
+
+    # load_annotations should delegate to the correct from_file method
+    loaded = load_annotations(path=outpath)
+    assert isinstance(loaded, cls)
+    assert loaded.num_matches() == db.num_matches()
+    close_dbs(loaded)
+
+
+@pytest.mark.parametrize(
+    ("db_name", "cls", "suffix"),
+    [
+        ("gff_db", GffAnnotationDb, "c3gffdb"),
+        ("gb_db", GenbankAnnotationDb, "c3gbdb"),
+        ("anno_db", BasicAnnotationDb, "c3andb"),
+    ],
+)
+def test_load_annotations_with_storage_backend(db_name, cls, suffix, tmp_path, request):
+    """load_annotations with storage_backend='c3anndb' should load saved db files."""
+    db = request.getfixturevalue(db_name)
+    outpath = tmp_path / f"saved_db.{suffix}"
+    db.write(outpath)
+
+    # Explicitly specify the storage backend
+    loaded = load_annotations(path=outpath, storage_backend="c3anndb")
+    assert isinstance(loaded, cls)
+    assert loaded.num_matches() == db.num_matches()
+    close_dbs(loaded)
+
+
+def test_load_annotations_gff_with_c3anndb_backend(DATA_DIR):
+    """load_annotations with storage_backend='c3anndb' should load GFF files."""
+    path = DATA_DIR / "simple.gff"
+    db = load_annotations(path=path, storage_backend="c3anndb")
+    assert isinstance(db, GffAnnotationDb)
+    assert db.num_matches() > 0
+    db.close()
+
+
+def test_load_annotations_gb_with_c3anndb_backend(DATA_DIR):
+    """load_annotations with storage_backend='c3anndb' should load GenBank files."""
+    path = DATA_DIR / "annotated_seq.gb"
+    db = load_annotations(path=path, storage_backend="c3anndb")
+    assert isinstance(db, GenbankAnnotationDb)
+    assert db.num_matches() > 0
+    db.close()
+
+
+def test_load_annotations_roundtrip_gff(DATA_DIR, tmp_path):
+    """Round-trip test: load GFF, save to c3gffdb, reload via load_annotations."""
+    # Load from GFF
+    orig = load_annotations(path=DATA_DIR / "simple.gff")
+    outpath = tmp_path / "roundtrip.c3gffdb"
+    orig.write(outpath)
+
+    # Reload via load_annotations (should auto-detect suffix)
+    reloaded = load_annotations(path=outpath)
+    assert isinstance(reloaded, GffAnnotationDb)
+    assert reloaded.num_matches() == orig.num_matches()
+
+    # Verify data integrity
+    orig_features = list(orig.get_features_matching())
+    reloaded_features = list(reloaded.get_features_matching())
+    assert len(orig_features) == len(reloaded_features)
+
+    close_dbs(orig, reloaded)
+
+
+def test_load_annotations_roundtrip_gb(DATA_DIR, tmp_path):
+    """Round-trip test: load GenBank, save to c3gbdb, reload via load_annotations."""
+    # Load from GenBank
+    orig = load_annotations(path=DATA_DIR / "annotated_seq.gb")
+    outpath = tmp_path / "roundtrip.c3gbdb"
+    orig.write(outpath)
+
+    # Reload via load_annotations (should auto-detect suffix)
+    reloaded = load_annotations(path=outpath)
+    assert isinstance(reloaded, GenbankAnnotationDb)
+    assert reloaded.num_matches() == orig.num_matches()
+
+    close_dbs(orig, reloaded)
+
+
+# Tests for LookupTableCache._get_name_by_id coverage
+
+
+def test_lookup_cache_get_seqid_name_cache_hit():
+    """Test get_seqid_name returns cached value when ID is in reverse cache."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE seqids (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
+    conn.execute("INSERT INTO seqids (name) VALUES ('chr1')")
+    conn.commit()
+
+    cache = LookupTableCache(conn)
+    # First call populates the cache
+    seqid_id = cache.get_seqid_id("chr1")
+    # Second call should hit the reverse cache
+    name = cache.get_seqid_name(seqid_id)
+    assert name == "chr1"
+
+    conn.close()
+
+
+def test_lookup_cache_get_seqid_name_db_lookup():
+    """Test get_seqid_name performs DB lookup when ID not in cache."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE seqids (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
+    conn.execute("INSERT INTO seqids (name) VALUES ('chr1')")
+    conn.commit()
+
+    # Create cache and manually insert ID without populating reverse cache
+    cache = LookupTableCache(conn)
+    # Directly query DB to get ID without populating cache
+    cursor = conn.execute("SELECT id FROM seqids WHERE name = 'chr1'")
+    seqid_id = cursor.fetchone()[0]
+
+    # get_seqid_name should look up from DB
+    name = cache.get_seqid_name(seqid_id)
+    assert name == "chr1"
+    # Verify it was cached
+    assert seqid_id in cache._seqid_reverse
+    assert "chr1" in cache._seqid_cache
+
+    conn.close()
+
+
+def test_lookup_cache_get_seqid_name_not_found():
+    """Test get_seqid_name returns None when ID doesn't exist."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE seqids (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
+    conn.commit()
+
+    cache = LookupTableCache(conn)
+    # Query for non-existent ID
+    name = cache.get_seqid_name(999)
+    assert name is None
+
+    conn.close()
+
+
+def test_lookup_cache_get_biotype_name():
+    """Test get_biotype_name works correctly."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE biotypes (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
+    conn.execute("INSERT INTO biotypes (name) VALUES ('gene')")
+    conn.commit()
+
+    cache = LookupTableCache(conn)
+    # First call populates the cache
+    biotype_id = cache.get_biotype_id("gene")
+    # Get name from ID
+    name = cache.get_biotype_name(biotype_id)
+    assert name == "gene"
+
+    # Test not found case
+    assert cache.get_biotype_name(999) is None
+
+    conn.close()
+
+
+def test_lookup_cache_get_source_name():
+    """Test get_source_name works correctly."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE sources (id INTEGER PRIMARY KEY, name TEXT UNIQUE)")
+    conn.execute("INSERT INTO sources (name) VALUES ('GFF3')")
+    conn.commit()
+
+    cache = LookupTableCache(conn)
+    # First call populates the cache
+    source_id = cache.get_source_id("GFF3")
+    # Get name from ID
+    name = cache.get_source_name(source_id)
+    assert name == "GFF3"
+
+    # Test not found case
+    assert cache.get_source_name(999) is None
+
+    conn.close()
+
+
+# Tests for SqliteAnnotationDbMixin._get_feature_rowid coverage
+
+
+def test_get_feature_rowid_by_name(gff_db):
+    """Test _get_feature_rowid finds feature by name."""
+    # Get a known feature name from the database
+    features = list(gff_db.get_features_matching(biotype="gene"))
+    if features:
+        feature_name = features[0]["name"]
+        rowid = gff_db._get_feature_rowid("gff", feature_name)
+        assert rowid is not None
+        assert isinstance(rowid, int)
+
+
+def test_get_feature_rowid_by_name_and_biotype(gff_db):
+    """Test _get_feature_rowid finds feature by name and biotype."""
+    # Get a known feature
+    features = list(gff_db.get_features_matching(biotype="gene"))
+    if features:
+        feature = features[0]
+        rowid = gff_db._get_feature_rowid(
+            "gff", feature["name"], biotype=feature["biotype"]
+        )
+        assert rowid is not None
+        assert isinstance(rowid, int)
+
+
+def test_get_feature_rowid_not_found(gff_db):
+    """Test _get_feature_rowid returns None when feature doesn't exist."""
+    rowid = gff_db._get_feature_rowid("gff", "nonexistent_feature_xyz")
+    assert rowid is None
+
+
+def test_get_feature_rowid_wrong_biotype(gff_db):
+    """Test _get_feature_rowid returns None when biotype doesn't match."""
+    # Get a gene feature
+    features = list(gff_db.get_features_matching(biotype="gene"))
+    if features:
+        feature_name = features[0]["name"]
+        # Search with wrong biotype
+        rowid = gff_db._get_feature_rowid(
+            "gff", feature_name, biotype="nonexistent_biotype"
+        )
+        assert rowid is None
+
+
+# Tests for upgrade_annotation_db hierarchy building coverage
+
+
+def test_upgrade_annotation_db_builds_hierarchy(tmp_path):
+    """Test that upgrade_annotation_db correctly builds feature hierarchy."""
+    import sqlite3
+
+    # Create a database with parent-child relationships
+    db_path = tmp_path / "hierarchy_test.c3gffdb"
+
+    # Create database manually with old schema (no hierarchy table)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    # Create gff table (simplified version of actual schema)
+    conn.execute("""
+        CREATE TABLE gff (
+            seqid TEXT,
+            source TEXT,
+            biotype TEXT,
+            start INTEGER,
+            stop INTEGER,
+            score TEXT,
+            strand TEXT,
+            phase TEXT,
+            name TEXT,
+            parent_id TEXT
+        )
+    """)
+
+    # Insert parent gene
+    conn.execute("""
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, parent_id)
+        VALUES ('chr1', 'test', 'gene', 100, 500, '+', 'gene1', NULL)
+    """)
+
+    # Insert child mRNA with parent_id pointing to gene1
+    conn.execute("""
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, parent_id)
+        VALUES ('chr1', 'test', 'mRNA', 100, 500, '+', 'mRNA1', 'gene1')
+    """)
+
+    # Insert exon with parent_id pointing to mRNA1
+    conn.execute("""
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, parent_id)
+        VALUES ('chr1', 'test', 'exon', 100, 200, '+', 'exon1', 'mRNA1')
+    """)
+
+    conn.commit()
+    conn.close()
+
+    # Upgrade the database
+    upgrade_annotation_db(db_path, backup=False)
+
+    # Verify hierarchy was built
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    # Check feature_hierarchy table exists and has entries
+    cursor = conn.execute("SELECT COUNT(*) FROM feature_hierarchy")
+    count = cursor.fetchone()[0]
+    assert count >= 2  # At least gene->mRNA and mRNA->exon relationships
+
+    # Check specific relationships
+    cursor = conn.execute("""
+        SELECT h.child_id, h.parent_id
+        FROM feature_hierarchy h
+        JOIN gff g_child ON g_child.rowid = h.child_id
+        JOIN gff g_parent ON g_parent.rowid = h.parent_id
+        WHERE g_child.name = 'mRNA1' AND g_parent.name = 'gene1'
+    """)
+    row = cursor.fetchone()
+    assert row is not None
+
+    conn.close()
+
+
+def test_upgrade_annotation_db_multiple_parents(tmp_path):
+    """Test upgrade handles features with comma-separated parent_ids."""
+    import sqlite3
+
+    db_path = tmp_path / "multi_parent_test.c3gffdb"
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    conn.execute("""
+        CREATE TABLE gff (
+            seqid TEXT,
+            source TEXT,
+            biotype TEXT,
+            start INTEGER,
+            stop INTEGER,
+            score TEXT,
+            strand TEXT,
+            phase TEXT,
+            name TEXT,
+            parent_id TEXT
+        )
+    """)
+
+    # Insert two parent genes
+    conn.execute("""
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, parent_id)
+        VALUES ('chr1', 'test', 'gene', 100, 500, '+', 'gene1', NULL)
+    """)
+    conn.execute("""
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, parent_id)
+        VALUES ('chr1', 'test', 'gene', 600, 1000, '+', 'gene2', NULL)
+    """)
+
+    # Insert exon with multiple parents (comma-separated)
+    conn.execute("""
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, parent_id)
+        VALUES ('chr1', 'test', 'exon', 100, 200, '+', 'shared_exon', 'gene1,gene2')
+    """)
+
+    conn.commit()
+    conn.close()
+
+    # Upgrade the database
+    upgrade_annotation_db(db_path, backup=False)
+
+    # Verify hierarchy has two entries for the shared exon
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    cursor = conn.execute("""
+        SELECT COUNT(*)
+        FROM feature_hierarchy h
+        JOIN gff g ON g.rowid = h.child_id
+        WHERE g.name = 'shared_exon'
+    """)
+    count = cursor.fetchone()[0]
+    assert count == 2  # Should have two parent relationships
+
+    conn.close()
+
+
+def test_upgrade_annotation_db_no_backup(DATA_DIR, tmp_path):
+    """Test upgrade_annotation_db with backup=False doesn't create backup file."""
+    import sqlite3
+
+    db_path = tmp_path / "no_backup_test.c3gffdb"
+    db = load_annotations(path=DATA_DIR / "simple.gff")
+    db.write(db_path)
+    db.close()
+
+    # Simulate old format
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE IF EXISTS schema_version")
+    conn.commit()
+    conn.close()
+
+    # Upgrade without backup
+    upgrade_annotation_db(db_path, backup=False)
+
+    # Verify no backup was created
+    backup_path = tmp_path / "no_backup_test.c3gffdb.bak"
+    assert not backup_path.exists()
+
+    # Verify schema was still upgraded
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(
+        "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
+    )
+    version = cursor.fetchone()[0]
+    assert version == SCHEMA_VERSION
+    conn.close()

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -1462,8 +1462,7 @@ def test_hierarchy_table_populated(DATA_DIR):
     cursor = conn.execute("SELECT COUNT(*) FROM feature_hierarchy")
     count = cursor.fetchone()[0]
     # The shortened GFF should have some hierarchy entries
-    assert count >= 0  # May be 0 if no parent_id in data
-
+    assert count > 0  # May be 0 if no parent_id in data
     db.close()
 
 

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -2126,3 +2126,91 @@ def test_upgrade_annotation_db_no_backup(DATA_DIR, tmp_path):
     version = cursor.fetchone()[0]
     assert version == SCHEMA_VERSION
     conn.close()
+
+
+def test_upgrade_annotation_db_migrates_columns(tmp_path):
+    """Test that upgrade_annotation_db migrates old TEXT columns to new *_id columns.
+
+    Old databases have seqid/biotype/source as TEXT columns.
+    New databases have seqid_id/biotype_id/source_id as INTEGER columns
+    referencing lookup tables. The upgrade function must migrate the schema.
+    """
+    import sqlite3
+
+    import numpy
+
+    db_path = tmp_path / "old_schema_test.c3gffdb"
+
+    # Create database with OLD schema (TEXT columns, not *_id INTEGER columns)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    # Old schema used seqid, biotype, source as TEXT columns (not *_id INTEGER)
+    conn.execute("""
+        CREATE TABLE gff (
+            seqid TEXT,
+            source TEXT,
+            biotype TEXT,
+            start INTEGER,
+            stop INTEGER,
+            score TEXT,
+            strand INTEGER,
+            phase TEXT,
+            attributes TEXT,
+            comments TEXT,
+            spans array,
+            name TEXT,
+            parent_id TEXT
+        )
+    """)
+
+    # Also need user table with old schema
+    conn.execute("""
+        CREATE TABLE user (
+            seqid TEXT,
+            biotype TEXT,
+            name TEXT,
+            parent_id TEXT,
+            start INTEGER,
+            stop INTEGER,
+            strand INTEGER,
+            spans array,
+            attributes TEXT,
+            on_alignment INT
+        )
+    """)
+
+    # Insert test data with the old schema
+    # Need to serialize spans as numpy array
+    from cogent3.core.annotation_db import array_to_sqlite
+
+    spans_data = array_to_sqlite(numpy.array([[100, 500]], dtype=int))
+    conn.execute(
+        """
+        INSERT INTO gff (seqid, source, biotype, start, stop, strand, name, spans)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("chr1", "test_source", "gene", 100, 500, 1, "gene1", spans_data),
+    )
+    conn.commit()
+    conn.close()
+
+    # Upgrade the database
+    upgrade_annotation_db(db_path, backup=False)
+
+    # Now try to load and use the database - this should work after proper upgrade
+    loaded_db = GffAnnotationDb.from_file(db_path)
+
+    # Query features - this will fail if columns weren't migrated properly
+    # because the code will try to query seqid_id but the table still has seqid
+    features = list(loaded_db.get_features_matching(seqid="chr1"))
+    assert len(features) == 1
+    assert features[0]["name"] == "gene1"
+    assert features[0]["biotype"] == "gene"
+    assert features[0]["seqid"] == "chr1"
+
+    # Also verify we can query by biotype
+    features = list(loaded_db.get_features_matching(biotype="gene"))
+    assert len(features) == 1
+
+    loaded_db.close()


### PR DESCRIPTION
[CHANGED] refactoerd the sqlite3 based annotation databases to a multiple
    table structure and improve lookup of related features. Now also includes
    a schema version.

[CHANGED] now specify distinct file name suffixes for cogent3
    annotation db's for genbank (.c3gbdb), gff (.c3gffdb) and
    the basic ann db (.c3andb). Writing these now enforces
    the correct suffix is used.

[CHANGED] added from_file() class method to simplify logic and
    validation of loading an exsiting db from file.

[NEW] added a `upgrade_annotation_db()` function for upgrading an
    existing db to the new schema.

[CHANGED] updated docs to new API and describe constraints on
    file sufixes for annotation db's

## Summary by Sourcery

Refactor SQLite-backed annotation databases to use a normalized, versioned schema with lookup and hierarchy tables, enforce new file suffix conventions and loading APIs, and add migration utilities and tests while updating loaders and documentation.

Bug Fixes:
- Fix reuse of existing annotation DB connections so that schema version and lookup cache state are correctly propagated, avoiding missing-column errors.
- Ensure legacy databases with an 'end' column are correctly upgraded by centralizing column-rename handling in a shared connection helper.
- Make LocalLocation construction robust to non-int-convertible inputs by suppressing TypeError during coordinate parsing.

Enhancements:
- Normalize annotation DB schemas to use lookup tables for seqid/biotype/source IDs and dedicated hierarchy tables for parent-child relationships, improving query performance and scalability.
- Introduce schema version tracking, standardized connection setup, and internal caching to support efficient lookups and backwards compatibility with legacy databases.
- Add strict file-suffix handling and class-level from_file constructors for Basic, GFF, and GenBank annotation databases, preventing accidental overwrites of existing DB files.
- Extend annotation loading and storage backends to recognize new .c3andb, .c3gffdb, and .c3gbdb suffixes and to reuse existing database connections safely.
- Optimize querying, counting, description, and index creation logic to work with the normalized schema while preserving existing public APIs.

Documentation:
- Update annotation DB cookbook and related documentation to describe the new schema, file suffix conventions, upgrade path, and usage of the new loading APIs.

Tests:
- Add extensive tests covering schema versioning, lookup caching behavior, hierarchy-based parent/child queries, database upgrade idempotency and integrity, and new file-suffix workflows for reading and writing annotation DBs.
- Extend existing tests to validate strict file-suffix enforcement, from_file constructors, backend selection via load_annotations, and index creation on normalized ID columns.