### PR TITLE
Minor enhancement

### DIFF
--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -57,7 +57,6 @@ _import_mapping = {
     "load_annotations": "core.annotation_db",
     "load_tree": "core.tree",
     "make_tree": "core.tree",
-    "PhyloNode": "core.tree",
     "TreeError": "core.tree",
     "load_table": "core.table",
     "make_table": "core.table",
@@ -78,6 +77,14 @@ _import_mapping = {
     "available_apps": "app",
     "get_app": "app",
     "open_data_store": "app.io",
+    # Core types returned by top-level functions
+    "Alignment": "core.alignment",
+    "SequenceCollection": "core.alignment",
+    "Sequence": "core.sequence",
+    "Table": "core.table",
+    "MolType": "core.moltype",
+    "GeneticCode": "core.genetic_code",
+    "PhyloNode": "core.tree",
 }
 
 

--- a/src/cogent3/align/pairwise.py
+++ b/src/cogent3/align/pairwise.py
@@ -194,7 +194,7 @@ class TrackBack:
         result = []
         for state, posn, (dx, dy) in self.tlist:
             pos = [[None, i - 1][d] for (i, d) in zip(posn, [dx, dy], strict=False)]
-            result.append((bin_map.get(int(state), None), pos))
+            result.append((bin_map.get(int(state)), pos))
         return result
 
 

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def _parse_license_name(classifier: str) -> str:
     """Extract just the license name from a trove classifier"""
-    match = re.search(r"(.+?)(?:\s+License)?$", classifier.split("::")[-1])
+    match = re.search(r"(.+?)(?:\s+License)?$", classifier.rsplit("::", maxsplit=1)[-1])
     return match[1].strip() if match else classifier
 
 

--- a/src/cogent3/core/profile.py
+++ b/src/cogent3/core/profile.py
@@ -590,7 +590,7 @@ def load_pssm(
     is_cisbp = path.endswith("cisbp")
     is_jaspar = path.endswith("jaspar")
     if not (is_cisbp or is_jaspar):
-        msg = f"Unknown format {path.split('.')[-1]}"
+        msg = f"Unknown format {path.rsplit('.', maxsplit=1)[-1]}"
         raise NotImplementedError(msg)
 
     if is_cisbp:

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -1055,7 +1055,7 @@ class Sequence(AnnotatableMixin):
         table.append("</table>")
         class_name = self.__class__.__name__
         if limit and limit < len(self):
-            summary = f"{class_name}, length={len(self):,} (truncated to {limit if limit else len(self)})"
+            summary = f"{class_name}, length={len(self):,} (truncated to {limit or len(self)})"
         else:
             summary = f"{class_name}, length={len(self):,}"
 
@@ -1615,7 +1615,7 @@ class Sequence(AnnotatableMixin):
 
     def __repr__(self) -> str:
         myclass = f"{self.__class__.__name__}"
-        myclass = myclass.split(".")[-1]
+        myclass = myclass.rsplit(".", maxsplit=1)[-1]
         seq = f"{str(self)[:7]}... {len(self):,}" if len(self) > 10 else str(self)
         return f"{myclass}({seq})"
 

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -1100,7 +1100,7 @@ class PhyloNode:
             # we pick an arbitrary child to root at
             child = result_root.children[0]
             child.name = (
-                child.name if child.name else "new-root"
+                child.name or "new-root"
             )  # this is a magic value, which is not good
             result_root = result_root.rooted(child.name)
         result_root.name = "root"
@@ -1164,7 +1164,7 @@ class PhyloNode:
             else:
                 child_info = [(scores[ch], rebuilt[ch]) for ch in node.children]
                 # Sort children by score, None is treated as +infinity
-                child_info.sort(key=lambda x: (infinity if x[0] is None else x[0]))
+                child_info.sort(key=lambda x: infinity if x[0] is None else x[0])
                 children = tuple(child for _, child in child_info)
                 tree = constructor(node, children, None)
                 non_null = [s for s, _ in child_info if s is not None]

--- a/src/cogent3/format/util.py
+++ b/src/cogent3/format/util.py
@@ -64,7 +64,7 @@ class _AlignmentFormatter:
 
         """
 
-        block_size = alt_block_size if alt_block_size else self.block_size
+        block_size = alt_block_size or self.block_size
 
         block_list = []
         seq_length = len(seq_string)

--- a/src/cogent3/parse/ncbi_taxonomy.py
+++ b/src/cogent3/parse/ncbi_taxonomy.py
@@ -97,7 +97,7 @@ class NcbiTaxon:
             line_pieces[-1] = last[:-1]
         self.__dict__ = dict(list(zip(self.Fields, line_pieces, strict=False)))
         self.Name = ""  # will get name field from names.dmp; fillNames
-        self.RankId = RanksToNumbers.get(self.Rank, None)
+        self.RankId = RanksToNumbers.get(self.Rank)
 
     def __str__(self) -> str:
         """Writes data out in format we got it."""

--- a/src/cogent3/util/dict_array.py
+++ b/src/cogent3/util/dict_array.py
@@ -257,7 +257,7 @@ def convert_series(
 
     if not header:
         header = None if ncols == 1 else ncols
-    row_order = row_order if row_order else nrows
+    row_order = row_order or nrows
 
     return data, row_order, header
 

--- a/tests/test_top_level_imports.py
+++ b/tests/test_top_level_imports.py
@@ -1,0 +1,35 @@
+import importlib
+
+import pytest
+
+import cogent3
+
+
+@pytest.mark.parametrize(
+    "name",
+    sorted(cogent3._import_mapping),
+)
+def test_lazy_import(name):
+    """all names in _import_mapping are accessible via cogent3.<name>"""
+    attr = getattr(cogent3, name)
+    module_path = cogent3._import_mapping[name]
+    module = importlib.import_module(f"cogent3.{module_path}")
+    assert attr is getattr(module, name)
+
+
+@pytest.mark.parametrize(
+    "name,expected_type",
+    [
+        ("Alignment", type),
+        ("SequenceCollection", type),
+        ("Sequence", type),
+        ("Table", type),
+        ("MolType", type),
+        ("GeneticCode", type),
+        ("PhyloNode", type),
+    ],
+)
+def test_toplevel_types(name, expected_type):
+    """core return types are accessible as cogent3.<Type>"""
+    attr = getattr(cogent3, name)
+    assert isinstance(attr, expected_type), f"cogent3.{name} is not a {expected_type}"


### PR DESCRIPTION
## Summary by Sourcery

Expose core return types at the cogent3 top level while tightening lazy-import coverage and applying minor code cleanups.

New Features:
- Expose core types such as Alignment, SequenceCollection, Sequence, Table, MolType, GeneticCode, and PhyloNode as top-level cogent3 attributes via lazy imports.

Enhancements:
- Simplify several conditional expressions and string-splitting operations for improved clarity and robustness across sequence, tree, profile, formatting, taxonomy parsing, and dict-array utilities.

Tests:
- Add tests to verify all lazy-imported names are accessible via top-level cogent3 attributes and that core types are available as classes from the top level.