### PR TITLE
ENH: new capabilities for drawing annotations

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -50,13 +50,13 @@ jobs:
           cov="--cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov cogent3 --cov-config=${dn}/.coveragerc"
           nox  -db uv --force-python python -s test -- $cov
 
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v2
-        with:
-          parallel: true
-          github-token: ${{ secrets.github_token }}
-          flag-name: run-${{matrix.python-version}}-${{matrix.os}}
-          file: "tests/lcov-${{matrix.os}}-${{matrix.python-version}}.lcov"
+      # - name: Coveralls Parallel
+      #   uses: coverallsapp/github-action@v2
+      #   with:
+      #     parallel: true
+      #     github-token: ${{ secrets.github_token }}
+      #     flag-name: run-${{matrix.python-version}}-${{matrix.os}}
+      #     file: "tests/lcov-${{matrix.os}}-${{matrix.python-version}}.lcov"
 
   type_check:
     name: Type Check
@@ -78,13 +78,13 @@ jobs:
           mypy src/cogent3/core/alignment.py src/cogent3/core/alphabet.py src/cogent3/core/annotation.py src/cogent3/core/genetic_code.py src/cogent3/core/location.py src/cogent3/core/moltype.py src/cogent3/core/seq_storage.py src/cogent3/core/sequence.py src/cogent3/core/seqview.py src/cogent3/core/slice_record.py src/cogent3/core/tree.py
 
 
-  finish:
-    name: "Finish Coveralls"
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true
+  # finish:
+  #   name: "Finish Coveralls"
+  #   needs: tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Coveralls Finished
+  #     uses: coverallsapp/github-action@v2
+  #     with:
+  #       github-token: ${{ secrets.github_token }}
+  #       parallel-finished: true

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -587,6 +587,17 @@ class AnnotationDbABC(abc.ABC):
         msg = f"{self.__class__.__name__!r} does not support union"
         raise NotImplementedError(msg)
 
+    def count_distinct(
+        self,
+        *,
+        seqid: str | bool = False,
+        biotype: str | bool = False,
+        name: str | bool = False,
+    ) -> Table | None:
+        # override in subclass
+        msg = f"{self.__class__.__name__!r} does not support count_distinct()"
+        raise NotImplementedError(msg)
+
     @abc.abstractmethod
     def close(self) -> None: ...
 

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -1103,6 +1103,7 @@ def _rename_column_if_exists(
 class SqliteAnnotationDbMixin:
     # table schema for user provided annotations
     _table_names: ClassVar[tuple[str, ...]]
+    _suffix: ClassVar[str]
 
     _user_schema: ClassVar = {
         "biotype_id": "INTEGER",
@@ -1597,7 +1598,7 @@ class SqliteAnnotationDbMixin:
             result["spans"] = [
                 cast("tuple[int, int]", tuple(c)) for c in result["spans"]
             ]
-            yield result
+            yield cast("FeatureDataType", result)
 
     def _has_hierarchy_table(self) -> bool:
         """Check if the feature_hierarchy table exists and has data."""
@@ -2159,10 +2160,11 @@ class SqliteAnnotationDbMixin:
         if not annot_db:
             return copy.deepcopy(self)
 
+        cls: type[Self]
         if self.compatible(annot_db, symmetric=False):
             cls = type(self)
         elif self.compatible(annot_db, symmetric=True):
-            cls = type(annot_db)
+            cls = type(annot_db)  # type: ignore[assignment]
         else:
             msg = f"cannot make a union between {type(self)} and {type(annot_db)}"
             raise TypeError(
@@ -2170,7 +2172,7 @@ class SqliteAnnotationDbMixin:
             )
 
         db = cls()
-        db.update(self)
+        db.update(self)  # type: ignore[arg-type]
         db.update(annot_db)
         return db
 
@@ -3089,6 +3091,9 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
             fmt = format_name.lower()
         else:
             suffix, _ = get_format_suffixes(path)
+            if suffix is None:
+                msg = f"Unknown annotation format for {path!r}"
+                raise ValueError(msg)
             suffix = (suffix if suffix.startswith(".") else f".{suffix}").lower()
             if suffix == ".json":
                 fmt = "json"
@@ -3113,6 +3118,7 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
             return deserialise_object(path)
 
         # Select parsing function and prepare kwargs before loop
+        parse_func: Callable[..., SqliteAnnotationDbMixin]
         if fmt == "genbank":
             parse_func = _db_from_genbank
             func_kwargs = {"write_path": write_path, **kwargs}
@@ -3139,13 +3145,16 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
         series = kwargs["ui"].series(paths) if "ui" in kwargs else paths
 
         # Process each file, passing db from one to the next
+        db_result: SqliteAnnotationDbMixin | None = cast(
+            "SqliteAnnotationDbMixin | None", db
+        )
         for file_path in series:
-            db = parse_func(path=file_path, db=db, **func_kwargs)
+            db_result = parse_func(path=file_path, db=db_result, **func_kwargs)
 
-        if db is None:
+        if db_result is None:
             msg = f"Failed to load annotations into database {str(path)!r}"
             raise RuntimeError(msg)
-        return db
+        return db_result
 
 
 def load_annotations(
@@ -3207,10 +3216,10 @@ def load_annotations(
     else:
         # Auto-detect from file suffix
         suffix, _ = get_format_suffixes(path)
-        suffix = (suffix if suffix.startswith(".") else f".{suffix}").lower()
-        if not suffix:
+        if suffix is None:
             msg = f"Cannot auto-detect format for {path!r}, use format_name parameter"
             raise ValueError(msg)
+        suffix = (suffix if suffix.startswith(".") else f".{suffix}").lower()
 
     # Get the loader plugin
     loader = get_annotation_loader_plugin(

--- a/src/cogent3/draw/annotation.py
+++ b/src/cogent3/draw/annotation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from cogent3.core.location import Strand
@@ -28,17 +29,22 @@ def _build_hover_text(feature: FeatureDataType) -> str:
     )
 
 
-def _infer_max_coord(
+def _infer_coord_range(
     features: list[FeatureDataType],
     padding_frac: float = 0.05,
-) -> int:
+) -> tuple[int, int]:
     """Determine x-axis range from feature spans with padding."""
+    min_val = float("inf")
     max_val = 0
     for feat in features:
         for span in feat["spans"]:
+            min_val = min(min_val, span[0], span[1])
             max_val = max(max_val, span[0], span[1])
-    padding = int(max_val * padding_frac)
-    return max_val + padding
+    if min_val == float("inf"):
+        return 0, 0
+    span_width = max_val - min_val
+    padding = int(span_width * padding_frac) if span_width > 0 else 0
+    return int(max(0, min_val - padding)), max_val + padding
 
 
 def _get_distinct_seqids(db: AnnotationDbABC) -> list[str]:
@@ -89,9 +95,14 @@ def _draw_single_seqid(
     Returns (traces, xaxis_config, yaxis_config, top_y).
     """
     if max_coord is None:
-        max_coord = _infer_max_coord(features)
+        min_coord, max_coord = _infer_coord_range(features)
+        axis_range = [min_coord, max_coord]
+        shape_max_coord = max_coord - min_coord
+    else:
+        axis_range = [0, max_coord]
+        shape_max_coord = max_coord
 
-    drawables = _annotations_to_shapes(features, max_coord)
+    drawables = _annotations_to_shapes(features, shape_max_coord)
     if not drawables:
         return [], {}, {}, 0.0
 
@@ -99,7 +110,7 @@ def _draw_single_seqid(
     all_traces = [t.as_trace() for t in annotes]
 
     xaxis: dict[str, Any] = {
-        "range": [0, max_coord],
+        "range": axis_range,
         "zeroline": False,
         "showline": True,
         "title": {"text": seqid},
@@ -170,7 +181,12 @@ def _make_single_seqid_drawable(
     if not traces:
         return None
 
-    effective_max = max_coord or _infer_max_coord(features)
+    if max_coord is None:
+        _, inferred_max = _infer_coord_range(features)
+        inferred_min, _ = _infer_coord_range(features)
+        effective_max = inferred_max - inferred_min
+    else:
+        effective_max = max_coord
     height = max((top / max(1, effective_max)) * width, 300)
     if show_controls:
         xaxis["rangeslider"] = {"visible": True}
@@ -245,6 +261,132 @@ def _make_multi_seqid_drawable(
     return drawer
 
 
+def _find_anchor_features(
+    db: AnnotationDbABC,
+    *,
+    name: str,
+    biotype: str | tuple[str, ...] | list[str] | set[str] | None = None,
+    seqid: str | None = None,
+    max_seqids: int | None = None,
+) -> dict[str, FeatureDataType]:
+    """Find the first feature matching ``name`` on each seqid.
+
+    Parameters
+    ----------
+    db
+        An annotation database instance.
+    name
+        Feature name to search for.
+    biotype
+        Optional biotype filter.
+    seqid
+        If provided, restrict search to this seqid only.
+    max_seqids
+        If provided, stop collecting after this many distinct seqids.
+
+    Returns
+    -------
+    dict mapping seqid to the first matching feature record.
+    """
+    kwargs: dict[str, Any] = {"name": name, "allow_partial": True}
+    if biotype is not None:
+        kwargs["biotype"] = biotype
+    if seqid is not None:
+        kwargs["seqid"] = seqid
+    anchors: dict[str, FeatureDataType] = {}
+    for feat in db.get_features_matching(**kwargs):
+        sid = feat["seqid"]
+        if sid not in anchors:
+            anchors[sid] = feat
+            if max_seqids is not None and len(anchors) >= max_seqids:
+                break
+    return anchors
+
+
+def _get_span_extent(feature: FeatureDataType) -> tuple[int, int]:
+    """Return (min_start, max_end) across all spans in a feature."""
+    spans = feature["spans"]
+    if hasattr(spans, "tolist"):
+        spans = spans.tolist()
+    all_starts = [s[0] for s in spans]
+    all_ends = [s[1] for s in spans]
+    return min(all_starts), max(all_ends)
+
+
+def _draw_centered(
+    db: AnnotationDbABC,
+    *,
+    center_on: str,
+    seqid: str | None,
+    biotype: str | tuple[str, ...] | list[str] | set[str] | None,
+    flank: int,
+    max_seqids: int | None,
+    max_features: int,
+    width: float,
+    title: str | None,
+    show_controls: bool,
+) -> Drawable | None:
+    """Build a drawable centered on a named feature across seqids."""
+    anchors = _find_anchor_features(
+        db,
+        name=center_on,
+        biotype=biotype,
+        seqid=seqid,
+        max_seqids=max_seqids,
+    )
+    if not anchors:
+        return None
+
+    selected_seqids = sorted(anchors)
+
+    # Compute uniform window width from the maximum anchor span
+    max_span = max(
+        _get_span_extent(anchors[sid])[1] - _get_span_extent(anchors[sid])[0]
+        for sid in selected_seqids
+    )
+    half = (max_span + 2 * flank) // 2
+
+    by_seqid: dict[str, list[FeatureDataType]] = {}
+    for sid in selected_seqids:
+        start, end = _get_span_extent(anchors[sid])
+        mid = (start + end) // 2
+        w_start = max(0, mid - half)
+        w_stop = mid + half
+        if feats := _query_features(
+            db,
+            seqid=sid,
+            biotype=biotype,
+            start=w_start,
+            stop=w_stop,
+        ):
+            by_seqid[sid] = feats
+
+    if not by_seqid:
+        return None
+
+    total = sum(len(v) for v in by_seqid.values())
+    _check_max_features(total, max_features)
+
+    default_title = title or f"Centered on: {center_on}"
+    seqids = sorted(by_seqid)
+    if len(seqids) == 1:
+        return _make_single_seqid_drawable(
+            by_seqid[seqids[0]],
+            seqid=seqids[0],
+            max_coord=None,
+            width=width,
+            title=default_title,
+            show_controls=show_controls,
+        )
+
+    return _make_multi_seqid_drawable(
+        by_seqid,
+        max_coord=None,
+        width=width,
+        title=default_title,
+    )
+
+
 def draw_annotations(
     db: AnnotationDbABC,
     *,
@@ -259,6 +401,9 @@ def draw_annotations(
     width: float = 600,
     title: str | None = None,
     show_controls: bool = True,
+    center_on: str | None = None,
+    flank: int = 5000,
+    max_seqids: int | None = None,
 ) -> Drawable | None:
     """Visualise annotations from an AnnotationDb
 
@@ -268,19 +413,21 @@ def draw_annotations(
         An annotation database instance.
     seqid
         Sequence identifier to display. If None, features for all seqids
-        are shown as stacked subplots.
+        are shown as stacked subplots. When used with ``center_on``,
+        restricts the anchor search to this seqid.
     biotype
         Feature type(s) to include. If None, all biotypes are shown.
     name
-        Feature name filter.
+        Feature name filter. Ignored when ``center_on`` is set.
     start
-        Start coordinate filter.
+        Start coordinate filter. Ignored when ``center_on`` is set.
     stop
-        Stop coordinate filter.
+        Stop coordinate filter. Ignored when ``center_on`` is set.
     strand
-        Strand filter.
+        Strand filter. Ignored when ``center_on`` is set.
     max_coord
         Maximum x-axis coordinate. Inferred from features if not provided.
+        Ignored when ``center_on`` is set.
     max_features
         Maximum number of features to render. Raise ValueError if exceeded.
     width
@@ -290,12 +437,49 @@ def draw_annotations(
     show_controls
         If True (default), display a range slider for navigating coordinates.
         Set to False for clean static image export.
+    center_on
+        Feature name to center on. When provided, finds features with this
+        name across all seqids and displays a window around each match.
+        Only seqids containing the feature are shown.
+    flank
+        Number of bases on each side of the anchor feature's midpoint.
+        Only used when ``center_on`` is set.
+    max_seqids
+        Maximum number of seqids to display. Applied after filtering to
+        those containing the anchor. Sorted alphabetically, first N taken.
 
     Returns
     -------
     Drawable or None
         A Drawable instance, or None if no features match.
     """
+    if center_on is not None:
+        if start is not None or stop is not None:
+            warnings.warn(
+                "start/stop are ignored when center_on is set",
+                UserWarning,
+                stacklevel=2,
+            )
+        if max_coord is not None:
+            warnings.warn(
+                "max_coord is ignored when center_on is set",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        return _draw_centered(
+            db,
+            center_on=center_on,
+            seqid=seqid,
+            biotype=biotype,
+            flank=flank,
+            max_seqids=max_seqids,
+            max_features=max_features,
+            width=width,
+            title=title,
+            show_controls=show_controls,
+        )
+
     features = _query_features(
         db,
         seqid=seqid,

--- a/src/cogent3/draw/annotation.py
+++ b/src/cogent3/draw/annotation.py
@@ -342,15 +342,13 @@ def _draw_centered(
     selected_seqids = sorted(anchors)
 
     # Compute uniform window width from the maximum anchor span
-    max_span = max(
-        _get_span_extent(anchors[sid])[1] - _get_span_extent(anchors[sid])[0]
-        for sid in selected_seqids
-    )
+    span_extents = {sid: _get_span_extent(anchors[sid]) for sid in selected_seqids}
+    max_span = max(end - start for (start, end) in span_extents.values())
     half = (max_span + 2 * flank) // 2
 
     by_seqid: dict[str, list[FeatureDataType]] = {}
     for sid in selected_seqids:
-        start, end = _get_span_extent(anchors[sid])
+        start, end = span_extents[sid]
         mid = (start + end) // 2
         w_start = max(0, mid - half)
         w_stop = mid + half

--- a/src/cogent3/draw/annotation.py
+++ b/src/cogent3/draw/annotation.py
@@ -182,8 +182,7 @@ def _make_single_seqid_drawable(
         return None
 
     if max_coord is None:
-        _, inferred_max = _infer_coord_range(features)
-        inferred_min, _ = _infer_coord_range(features)
+        inferred_min, inferred_max = _infer_coord_range(features)
         effective_max = inferred_max - inferred_min
     else:
         effective_max = max_coord
@@ -305,7 +304,10 @@ def _find_anchor_features(
 
 def _get_span_extent(feature: FeatureDataType) -> tuple[int, int]:
     """Return (min_start, max_end) across all spans in a feature."""
-    spans = feature["spans"]
+    if not (spans := feature.get("spans")):
+        msg = "feature['spans'] is empty, cannot compute span extent"
+        raise ValueError(msg)
+
     if hasattr(spans, "tolist"):
         spans = spans.tolist()
     all_starts = [s[0] for s in spans]
@@ -454,9 +456,15 @@ def draw_annotations(
         A Drawable instance, or None if no features match.
     """
     if center_on is not None:
-        if start is not None or stop is not None:
+        if name is not None:
             warnings.warn(
-                "start/stop are ignored when center_on is set",
+                "name is redundant when center_on is set and thus ignored",
+                UserWarning,
+                stacklevel=2,
+            )
+        if start is not None or stop is not None or strand is not None:
+            warnings.warn(
+                "start/stop/strand are ignored when center_on is set",
                 UserWarning,
                 stacklevel=2,
             )

--- a/tests/test_draw/test_annotations.py
+++ b/tests/test_draw/test_annotations.py
@@ -1,13 +1,16 @@
 """Tests for cogent3.draw.annotation module."""
 
+import warnings
+
 import pytest
 
 from cogent3.core.annotation_db import GffAnnotationDb
 from cogent3.draw.annotation import (
     _annotations_to_shapes,
     _build_hover_text,
+    _find_anchor_features,
     _get_distinct_seqids,
-    _infer_max_coord,
+    _infer_coord_range,
     draw_annotations,
 )
 
@@ -108,7 +111,7 @@ def test_build_hover_text_multi_span():
     assert "100-200, 300-400" in text
 
 
-def test_infer_max_coord_basic():
+def test_infer_coord_range_basic():
     features = [
         {
             "spans": [(0, 100)],
@@ -129,13 +132,34 @@ def test_infer_max_coord_basic():
             "xattr": {},
         },
     ]
-    result = _infer_max_coord(features)
-    assert result == 500 + int(500 * 0.05)
+    lo, hi = _infer_coord_range(features)
+    padding = int(500 * 0.05)
+    assert lo == 0
+    assert hi == 500 + padding
 
 
-def test_infer_max_coord_empty():
-    result = _infer_max_coord([])
-    assert result == 0
+def test_infer_coord_range_offset():
+    """Features far from origin should produce min > 0."""
+    features = [
+        {
+            "spans": [(1000, 2000)],
+            "biotype": "gene",
+            "name": "a",
+            "seqid": "s",
+            "strand": "+",
+            "on_alignment": False,
+            "xattr": {},
+        },
+    ]
+    lo, hi = _infer_coord_range(features)
+    padding = int(1000 * 0.05)
+    assert lo == 1000 - padding
+    assert hi == 2000 + padding
+
+
+def test_infer_coord_range_empty():
+    lo, hi = _infer_coord_range([])
+    assert (lo, hi) == (0, 0)
 
 
 def test_get_distinct_seqids_single(single_seqid_db):
@@ -219,6 +243,7 @@ def test_draw_annotations_strand_reverse_mapping(single_seqid_db):
 def test_draw_annotations_max_coord_sets_xaxis_range(single_seqid_db):
     result = draw_annotations(single_seqid_db, seqid="chr1", max_coord=2000)
     assert result is not None
+    assert result.layout.xaxis.range[0] == 0
     assert result.layout.xaxis.range[1] == 2000
 
 
@@ -328,3 +353,256 @@ def test_draw_annotations_via_cogent3_namespace():
 
     assert hasattr(cogent3, "draw_annotations")
     assert callable(cogent3.draw_annotations)
+
+
+# --- Fixtures and tests for center_on functionality ---
+
+
+@pytest.fixture
+def shared_feature_db():
+    """Create a DB with a shared feature across multiple seqids."""
+    db = GffAnnotationDb()
+    # Shared gene "dnaA" on three seqids at different positions
+    db.add_feature(
+        seqid="genome1",
+        biotype="gene",
+        name="dnaA",
+        spans=[(10000, 11000)],
+        strand="+",
+    )
+    db.add_feature(
+        seqid="genome1",
+        biotype="gene",
+        name="otherGene",
+        spans=[(12000, 13000)],
+        strand="+",
+    )
+    db.add_feature(
+        seqid="genome2",
+        biotype="gene",
+        name="dnaA",
+        spans=[(20000, 21200)],
+        strand="-",
+    )
+    db.add_feature(
+        seqid="genome2",
+        biotype="CDS",
+        name="someCDS",
+        spans=[(19000, 19500)],
+        strand="+",
+    )
+    db.add_feature(
+        seqid="genome3",
+        biotype="gene",
+        name="dnaA",
+        spans=[(5000, 5800)],
+        strand="+",
+    )
+    db.add_feature(
+        seqid="genome3",
+        biotype="exon",
+        name="exon1",
+        spans=[(5000, 5400)],
+        strand="+",
+    )
+    # genome4 does NOT have dnaA
+    db.add_feature(
+        seqid="genome4",
+        biotype="gene",
+        name="unrelated",
+        spans=[(1000, 2000)],
+        strand="+",
+    )
+    return db
+
+
+def test_find_anchor_features(shared_feature_db):
+    anchors = _find_anchor_features(shared_feature_db, name="dnaA")
+    assert set(anchors.keys()) == {"genome1", "genome2", "genome3"}
+    for sid, feat in anchors.items():
+        assert feat["name"] == "dnaA"
+        assert feat["seqid"] == sid
+
+
+def test_find_anchor_features_with_biotype(shared_feature_db):
+    anchors = _find_anchor_features(
+        shared_feature_db,
+        name="dnaA",
+        biotype="gene",
+    )
+    assert set(anchors.keys()) == {"genome1", "genome2", "genome3"}
+
+
+def test_find_anchor_features_no_match(shared_feature_db):
+    anchors = _find_anchor_features(shared_feature_db, name="nonexistent")
+    assert anchors == {}
+
+
+def test_center_on_produces_stacked_subplots(shared_feature_db):
+    result = draw_annotations(shared_feature_db, center_on="dnaA", biotype="gene")
+    assert result is not None
+    assert len(result.traces) > 0
+    # Should have multiple x-axes for multiple seqids
+    assert "xaxis2" in result.layout
+
+
+def test_center_on_only_includes_matching_seqids(shared_feature_db):
+    result = draw_annotations(shared_feature_db, center_on="dnaA", biotype="gene")
+    assert result is not None
+    # genome4 should not appear (no dnaA)
+    # Check x-axis titles contain only genome1, genome2, genome3
+    axis_titles = set()
+    for key in result.layout:
+        if key.startswith("xaxis"):
+            title_text = result.layout[key].get("title", {})
+            if isinstance(title_text, dict):
+                axis_titles.add(title_text.get("text", ""))
+            elif hasattr(title_text, "text"):
+                axis_titles.add(title_text.text)
+    assert "genome4" not in axis_titles
+
+
+def test_center_on_flank_controls_window(shared_feature_db):
+    result_small = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        flank=100,
+    )
+    result_large = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        flank=50000,
+    )
+    assert result_small is not None
+    assert result_large is not None
+    # Larger flank should produce wider x-axis range
+    small_range = result_small.layout.xaxis.range
+    large_range = result_large.layout.xaxis.range
+    small_width = small_range[1] - small_range[0]
+    large_width = large_range[1] - large_range[0]
+    assert large_width > small_width
+    # x-axis range should NOT start at 0 (features are far from origin)
+    assert small_range[0] > 0
+
+
+def test_center_on_xaxis_range_matches_window(shared_feature_db):
+    """x-axis range should be inferred from features in the window."""
+    flank = 2000
+    result = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        flank=flank,
+        max_seqids=1,
+    )
+    assert result is not None
+    xrange = result.layout.xaxis.range
+    # max_seqids=1 selects genome1 only; dnaA at (10000, 11000)
+    # Window queries [8000, 13000], finding dnaA (10000-11000) and
+    # otherGene (12000-13000). _infer_coord_range computes bounds from
+    # feature spans with padding.
+    # The range should NOT start at 0 (features are far from origin)
+    assert xrange[0] > 0
+    # The range should cover the anchor feature
+    assert xrange[0] <= 10000
+    assert xrange[1] >= 11000
+
+
+def test_center_on_max_seqids_limits_output(shared_feature_db):
+    result = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        max_seqids=2,
+    )
+    assert result is not None
+    # Count distinct x-axes
+    n_axes = sum(1 for k in result.layout if k.startswith("xaxis"))
+    assert n_axes == 2
+
+
+def test_center_on_max_seqids_one(shared_feature_db):
+    result = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        max_seqids=1,
+    )
+    assert result is not None
+    # Single seqid should produce single subplot with range slider
+    n_axes = sum(1 for k in result.layout if k.startswith("xaxis"))
+    assert n_axes == 1
+
+
+def test_center_on_returns_none_when_not_found(shared_feature_db):
+    result = draw_annotations(shared_feature_db, center_on="nonexistent")
+    assert result is None
+
+
+def test_center_on_biotype_filters_displayed_features(shared_feature_db):
+    result = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+    )
+    assert result is not None
+    # All traces should be gene biotype
+    for trace in result.traces:
+        assert trace.get("legendgroup") == "gene"
+
+
+def test_center_on_honors_seqid(shared_feature_db):
+    """When seqid is set with center_on, only that seqid is shown."""
+    result = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        seqid="genome1",
+    )
+    assert result is not None
+    # Single seqid should produce one subplot
+    n_axes = sum(1 for k in result.layout if k.startswith("xaxis"))
+    assert n_axes == 1
+    # The x-axis title should be genome1
+    assert result.layout.xaxis.title.text in ("genome1", "Range Slider")
+
+
+def test_center_on_warns_when_max_coord_set(shared_feature_db):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        draw_annotations(
+            shared_feature_db,
+            center_on="dnaA",
+            max_coord=50000,
+        )
+        assert any("max_coord is ignored" in str(warning.message) for warning in w)
+
+
+def test_center_on_warns_when_start_stop_set(shared_feature_db):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        draw_annotations(
+            shared_feature_db,
+            center_on="dnaA",
+            start=0,
+            stop=100,
+        )
+        assert any("start/stop are ignored" in str(warning.message) for warning in w)
+
+
+def test_center_on_default_title(shared_feature_db):
+    result = draw_annotations(shared_feature_db, center_on="dnaA", biotype="gene")
+    assert result is not None
+    assert "dnaA" in result.layout.title.text
+
+
+def test_center_on_custom_title(shared_feature_db):
+    result = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        title="Custom",
+    )
+    assert result is not None
+    assert result.layout.title.text == "Custom"

--- a/tests/test_draw/test_annotations.py
+++ b/tests/test_draw/test_annotations.py
@@ -589,7 +589,9 @@ def test_center_on_warns_when_start_stop_set(shared_feature_db):
             start=0,
             stop=100,
         )
-        assert any("start/stop are ignored" in str(warning.message) for warning in w)
+        assert any(
+            "start/stop/strand are ignored" in str(warning.message) for warning in w
+        )
 
 
 def test_center_on_default_title(shared_feature_db):

--- a/tests/test_draw/test_annotations.py
+++ b/tests/test_draw/test_annotations.py
@@ -10,6 +10,7 @@ from cogent3.draw.annotation import (
     _build_hover_text,
     _find_anchor_features,
     _get_distinct_seqids,
+    _get_span_extent,
     _infer_coord_range,
     draw_annotations,
 )
@@ -595,6 +596,14 @@ def test_center_on_default_title(shared_feature_db):
     result = draw_annotations(shared_feature_db, center_on="dnaA", biotype="gene")
     assert result is not None
     assert "dnaA" in result.layout.title.text
+
+
+@pytest.mark.parametrize("spans", [[], None], ids=["empty_list", "missing_key"])
+def test_get_span_extent_no_spans(spans):
+    """_get_span_extent raises ValueError when feature has no spans."""
+    feature = {"spans": spans} if spans is not None else {}
+    with pytest.raises(ValueError, match="empty"):
+        _get_span_extent(feature)
 
 
 def test_center_on_custom_title(shared_feature_db):


### PR DESCRIPTION
## Summary by Sourcery

Add centered-annotation drawing capabilities and improve coordinate range handling, while tightening annotation DB loading behaviour and disabling Coveralls in CI.

New Features:
- Allow draw_annotations() to center views on a named anchor feature across one or more seqids with configurable flank, seqid limits, and automatic windowing.

Enhancements:
- Infer full x-axis coordinate ranges from feature spans (including non-zero minima) when max_coord is not provided, updating single- and multi-seqid drawing behaviour accordingly.
- Extend the annotation DB abstraction with a count_distinct() API and refine type handling and error reporting for SQLite-backed annotation loading and unions.

CI:
- Comment out Coveralls upload and finish steps from the testing workflow.

Tests:
- Add comprehensive tests for coordinate range inference, axis range behaviour, and the new center_on drawing options, including flanking, seqid limiting, title handling, and warning conditions.