### PR TITLE
MAINT: enforce no wildcard support for DataStoreDirectory

### DIFF
--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -363,6 +363,17 @@ def summary_not_completeds(
     return Table(header=header, data=rows, title="not completed records")
 
 
+def _tidy_and_check_suffix(suffix: str | None) -> str:
+    """tidies suffix by removing leading wildcards and dots"""
+    suffix = suffix or ""
+    suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
+    if not suffix or suffix == "*":
+        msg = "suffix is required for DataStoreDirectory and cannot be just a wildcard"
+        raise ValueError(msg)
+
+    return suffix
+
+
 class DataStoreDirectory(DataStoreABC):
     def __init__(
         self,
@@ -370,16 +381,12 @@ class DataStoreDirectory(DataStoreABC):
         mode: Mode | str = READONLY,
         suffix: str | None = None,
         limit: int | None = None,
-        verbose=False,
+        verbose: bool = False,
     ) -> None:
         self._mode = Mode(mode)
-        if not suffix or suffix == "*":
-            msg = "suffix is required for DataStoreDirectory and cannot be just a wildcard"
-            raise ValueError(msg)
-        suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
         source = Path(source)
         self._source = source.expanduser()
-        self.suffix = suffix
+        self.suffix = _tidy_and_check_suffix(suffix)
         self._verbose = verbose
         self._source_check_create(mode)
         self._limit = limit
@@ -620,16 +627,13 @@ class ReadOnlyDataStoreZipped(DataStoreABC):
             msg = "this is a read only data store"
             raise ValueError(msg)
 
-        if not suffix or suffix == "*":
-            msg = "suffix is required for ReadOnlyDataStoreZipped and cannot be just a wildcard"
-            raise ValueError(msg)
-        suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
+        self.suffix = _tidy_and_check_suffix(suffix)
         source = Path(source)
         self._source = source.expanduser()
         if not self._source.exists():
             msg = f"{self._source!s} does not exit"
             raise OSError(msg)
-        self.suffix = suffix
+
         self._verbose = verbose
         self._limit = limit
 

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -373,9 +373,10 @@ class DataStoreDirectory(DataStoreABC):
         verbose=False,
     ) -> None:
         self._mode = Mode(mode)
-        suffix = suffix or ""
-        if suffix != "*":  # wild card search for all
-            suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
+        if not suffix or suffix == "*":
+            msg = "suffix is required for DataStoreDirectory and cannot be just a wildcard"
+            raise ValueError(msg)
+        suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
         source = Path(source)
         self._source = source.expanduser()
         self.suffix = suffix
@@ -461,7 +462,7 @@ class DataStoreDirectory(DataStoreABC):
     def completed(self) -> list[DataMember]:
         if not self._completed:
             self._completed = []
-            suffix = f"*.{self.suffix}" if self.suffix else "*"
+            suffix = f"*.{self.suffix}"
             for i, m in enumerate(self.source.glob(suffix)):
                 if self.limit and i == self.limit:
                     break
@@ -619,9 +620,10 @@ class ReadOnlyDataStoreZipped(DataStoreABC):
             msg = "this is a read only data store"
             raise ValueError(msg)
 
-        suffix = suffix or ""
-        if suffix != "*":  # wild card search for all
-            suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
+        if not suffix or suffix == "*":
+            msg = "suffix is required for ReadOnlyDataStoreZipped and cannot be just a wildcard"
+            raise ValueError(msg)
+        suffix = re.sub(r"^[\s.*]+", "", suffix)  # tidy the suffix
         source = Path(source)
         self._source = source.expanduser()
         if not self._source.exists():
@@ -663,7 +665,7 @@ class ReadOnlyDataStoreZipped(DataStoreABC):
     @property
     def completed(self) -> list[DataMember]:
         if not self._completed:
-            pattern = f"*.{self.suffix}" if self.suffix else "*"
+            pattern = f"*.{self.suffix}"
             self._completed = []
             num_matches = 0
             for name in self._iter_matches("", pattern):

--- a/tests/test_app/test_io.py
+++ b/tests/test_app/test_io.py
@@ -1,7 +1,6 @@
 import bz2
 import gzip
 import json
-import os
 import pathlib
 import pickle
 import shutil
@@ -40,7 +39,7 @@ def tmp_dir(tmp_path_factory):
 
 @pytest.fixture
 def w_dir_dstore(tmp_dir):
-    return DataStoreDirectory(tmp_dir, mode="w")
+    return DataStoreDirectory(tmp_dir, mode="w", suffix="tsv")
 
 
 @pytest.fixture(autouse=True)
@@ -549,9 +548,9 @@ def test_define_data_store(fasta_dir):
     found = list(open_data_store(fasta_dir, suffix=".fasta*"))
     assert len(found) > 2
 
-    # with a wild-card suffix
-    found = list(open_data_store(fasta_dir, suffix="*"))
-    assert len(os.listdir(fasta_dir)) == len(found)
+    # wildcard and missing suffix both raise
+    with pytest.raises(ValueError):
+        open_data_store(fasta_dir, suffix="*")
 
     # raises ValueError if suffix not provided or invalid
     with pytest.raises(ValueError):

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import pickle
+import warnings
 from collections import defaultdict
 from unittest import TestCase, skipIf
 
@@ -1596,9 +1597,9 @@ class TableTests(TestCase):
         r = cast_str_to_numeric(d)
         assert_equal(d, r)
 
-        with numpy.testing.suppress_warnings() as sup:
+        with warnings.catch_warnings():
             # we know that converting to real loses imaginary
-            sup.filter(ComplexWarning)
+            warnings.filterwarnings("ignore", category=ComplexWarning)
             for d_type in [numpy.int64, numpy.complex128, numpy.float64]:
                 d = d.astype(d_type)
                 r = cast_str_to_numeric(d)


### PR DESCRIPTION
[CHANGED] we already exclude this via open_data_store, a user cannot
    just provide a "*" suffix. Now also enforce this in the individual
    classes.

## Summary by Sourcery

Enforce explicit, non-wildcard suffix usage for directory- and zip-based data stores and update tests accordingly.

Bug Fixes:
- Prevent use of missing or pure-wildcard suffix values when initialising DataStoreDirectory and ReadOnlyDataStoreZipped, raising a ValueError instead.

Tests:
- Adjust existing fixtures to provide a concrete suffix and update open_data_store tests to expect errors for wildcard-only or missing suffix values.