### PR TITLE
MAINT: improve spacing between annotation tracks from draw_annotstions()

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 [![PyPI version](https://badge.fury.io/py/cogent3.svg)](https://badge.fury.io/py/cogent3)
-[![Conda Downloads](https://pepy.tech/badge/cogent3/month)](https://pepy.tech/project/cogent3)
+[![PyPI Downloads](https://pepy.tech/badge/cogent3/month)](https://pepy.tech/project/cogent3)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/cogent3/badges/downloads.svg)](https://anaconda.org/bioconda/cogent3)
 
 [![Build Status](https://github.com/cogent3/cogent3/workflows/CI/badge.svg?branch=develop)](https://github.com/cogent3/cogent3/actions?workflow=CI)

--- a/src/cogent3/draw/annotation.py
+++ b/src/cogent3/draw/annotation.py
@@ -211,7 +211,7 @@ def _make_multi_seqid_drawable(
     """Build a stacked subplot Drawable for multiple seqids."""
     seqids = sorted(by_seqid)
     n_seqids = len(seqids)
-    height_per_seqid = 200
+    height_per_seqid = 300
 
     all_traces: list[dict[str, Any]] = []
     layout_updates: dict[str, Any] = {}
@@ -230,7 +230,7 @@ def _make_multi_seqid_drawable(
             max_coord=max_coord,
         )
 
-        domain = get_domain(n_seqids, idx, is_y=True)
+        domain = get_domain(n_seqids, idx, is_y=True, space=0.12)
         yaxis_cfg["domain"] = list(domain)
         xaxis_cfg["anchor"] = yref
 

--- a/src/cogent3/draw/drawable.py
+++ b/src/cogent3/draw/drawable.py
@@ -44,7 +44,7 @@ def get_domain(total, element, is_y, space=0.01):
         raise ValueError(msg)
 
     per_element = 1 / total
-    space = min(space / 2, per_element / 10)
+    space = min(space / 5, per_element / 6)
     bounds = [per_element * i for i in range(total + 1)]
     domains = [
         (bounds[k] + space, bounds[k + 1] - space) for k in range(len(bounds) - 1)

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -96,14 +96,14 @@ class UtilDrawablesTests(unittest.TestCase):
         """space argument shifts boundaries"""
         sep = 0.1
         x = get_domain(2, 0, is_y=False, space=sep)
-        assert_allclose(x, [0 + sep / 2, 0.5 - sep / 2])
+        assert_allclose(x, [0 + sep / 5, 0.5 - sep / 5])
         x = get_domain(2, 1, is_y=False, space=sep)
-        assert_allclose(x, [0.5 + sep / 2, 1 - sep / 2])
+        assert_allclose(x, [0.5 + sep / 5, 1 - sep / 5])
         # if space too big relative to the span of each domain, it's reduced
-        # to 1/10th the domain span
+        # to 1/3rd the domain span
         sep = 0.6
         x = get_domain(2, 0, is_y=False, space=sep)
-        exp_sep = 0.5 / 10
+        exp_sep = 0.5 / 6
         assert_allclose(x, [0 + exp_sep, 0.5 - exp_sep])
 
     def test_domain_element_size(self):


### PR DESCRIPTION
## Summary by Sourcery

Adjust layout spacing and sizing for multi-sequence annotation plots and update related tests and documentation.

Enhancements:
- Increase vertical space allocated per sequence ID in multi-sequence annotation plots to improve readability.
- Adjust domain spacing calculation to provide more separation between stacked elements in plots.
- Specify a custom vertical spacing parameter when computing y-axis domains for multi-sequence annotation layouts.

Documentation:
- Rename the README download badge label from Conda Downloads to PyPI Downloads to match the linked statistics source.

Tests:
- Update domain spacing tests to reflect the revised spacing calculation and limits.