### PR TITLE
ENH: give credit to third-party developers, fixes #1792

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
     "charset_normalizer",
+    "citeable",
     "loky!=3.5.0",
     # prevent release candidate of numpy 2.4 
     # until numba modified to handle removal

--- a/src/cogent3/app/_citations.py
+++ b/src/cogent3/app/_citations.py
@@ -1,0 +1,24 @@
+from citeable import Software
+
+cite_cogent3 = Software(
+    key="cogent3",
+    author=[
+        "Huttley, Gavin",
+        "Caley, Katherine",
+        "Fotovat, Nabi",
+        "Ma, Stephen Ka-Wah",
+        "Koh, Moses",
+        "Morris, Richard",
+        "McArthur, Robert",
+        "McDonald, Daniel",
+        "Jaya, Fred",
+        "Maxwell, Peter",
+        "Martini, James",
+        "La, Thomas",
+        "Lang, Yapeng",
+    ],
+    title="{cogent3}: making sense of sequence",
+    year=2025,
+    doi="10.5281/zenodo.16519079",
+    url="https://cogent3.org",
+)

--- a/src/cogent3/app/align.py
+++ b/src/cogent3/app/align.py
@@ -23,6 +23,7 @@ from cogent3.evolve.fast_distance import get_distance_calculator
 from cogent3.evolve.models import get_model
 from cogent3.maths.util import safe_log
 
+from ._citations import cite_cogent3
 from .composable import NotCompleted, define_app
 from .tree import quick_tree, scale_branches
 from .typing import AlignedSeqsType, SerialisableType, UnalignedSeqsType
@@ -328,7 +329,7 @@ def pairwise_to_multiple(pwise, ref_seq, moltype, info=None):
     )
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class align_to_ref:
     """Aligns sequences to a nominated reference in the unaligned collection.
 
@@ -417,7 +418,7 @@ class align_to_ref:
         return self._func(seqs)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class progressive_align:
     """Progressive multiple sequence alignment via any cogent3 model."""
 
@@ -617,7 +618,7 @@ class progressive_align:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class smith_waterman:
     """Local alignment of two sequences using the Smith-Waterman algorithm
 
@@ -722,7 +723,7 @@ class smith_waterman:
         return aln.to_moltype(self.moltype)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class ic_score:
     """compute the Information Content alignment quality score
 
@@ -794,7 +795,7 @@ class ic_score:
         return i_seq.sum()
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 def cogent3_score(aln: AlignedSeqsType) -> float:
     """returns the cogent3 log-likelihood as an alignment quality score
 
@@ -870,7 +871,7 @@ def cogent3_score(aln: AlignedSeqsType) -> float:
     )
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class sp_score:
     """Compute a variant of Sum of Pairs alignment quality score
 

--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -936,6 +936,9 @@ def _apply_to(
         if cleanup:
             log_file_path.unlink(missing_ok=True)
 
+    # write citations
+    self.data_store.write_citations(data=self.citations)
+
     return self.data_store
 
 

--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -12,6 +12,7 @@ from enum import Enum
 from pathlib import Path
 from uuid import uuid4
 
+from citeable import Citation
 from scitrack import CachingLogger
 
 from cogent3._version import __version__
@@ -493,6 +494,7 @@ def define_app(
     *,
     app_type: AppType = GENERIC,
     skip_not_completed: bool = True,
+    cite: Citation | None = None,
 ) -> type:
     """decorator for building callable apps
 
@@ -506,6 +508,9 @@ def define_app(
     skip_not_completed
         if True (default), NotCompleted instances are returned without being
         passed to the app.
+    cite
+        a Citation instance describing the software or algorithm. If provided,
+        its ``.app`` attribute is set to the class name.
 
     Notes
     -----
@@ -675,6 +680,12 @@ def define_app(
         klass._return_types = return_hint
         klass.app_type = app_type
         klass._skip_not_completed = skip_not_completed
+
+        if cite is not None:
+            cite.app = klass.__name__
+        klass._cite = cite
+        klass.citations = property(_citations_property)
+        klass.bib = property(_bib)
 
         if app_type is not LOADER:
             klass.input = None
@@ -943,6 +954,35 @@ def _set_logger(self, logger=None) -> None:
     self.logger = logger
 
 
+def _get_citations(self) -> tuple[Citation, ...]:
+    """Return citations for this app and all composed input apps."""
+    seen: set[Citation] = set()
+    result: list[Citation] = []
+
+    if self._cite is not None:
+        seen.add(self._cite)
+        result.append(self._cite)
+
+    head = getattr(self, "input", None)
+    while head is not None:
+        if head._cite is not None and head._cite not in seen:
+            seen.add(head._cite)
+            result.append(head._cite)
+        head = getattr(head, "input", None)
+
+    return tuple(result)
+
+
+def _citations_property(self) -> tuple[Citation, ...]:
+    """Citations for this app and all composed input apps."""
+    return self._get_citations()
+
+
+def _bib(self) -> str:
+    """BibTeX formatted string of citations for this app and all composed input apps."""
+    return "\n\n".join(str(cite) for cite in self.citations)
+
+
 __mapping = {
     "__new__": _new,
     "__add__": _add,
@@ -953,6 +993,7 @@ __mapping = {
     "apply_to": _apply_to,
     "as_completed": _as_completed,
     "set_logger": _set_logger,
+    "_get_citations": _get_citations,
 }
 
 

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
     from os import PathLike
 
+    from citeable import CitationBase
+
     from cogent3.app.typing import TabularType
     from cogent3.core.table import Table
 
@@ -34,6 +36,8 @@ _MD5_TABLE = "md5"
 
 # used for log files, not-completed results
 _special_suffixes = re.compile(r"\.(log|json)$")
+
+_CITATIONS_FILE = "bibliography.citations"
 
 StrOrBytes = str | bytes
 NoneType = type(None)
@@ -289,6 +293,52 @@ class DataStoreABC(ABC):
         -------
         md5 checksum for the member, if available, None otherwise
         """
+
+    def write_citations(self, *, data: tuple[CitationBase, ...]) -> None:
+        """Write citations to the data store. Subclasses should override."""
+        if not data:
+            return
+        import warnings
+
+        warnings.warn(
+            f"{type(self).__name__} does not support saving citations",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    @property
+    def summary_citations(self) -> TabularType:
+        """Return a Table summarising stored citations."""
+        import warnings
+
+        warnings.warn(
+            f"{type(self).__name__} does not support saving citations",
+            UserWarning,
+            stacklevel=2,
+        )
+        from cogent3.core.table import Table
+
+        return Table(header=["app", "citation"], data=[], title="citations")
+
+    def write_bib(self, dest_path: str | Path) -> None:
+        """Write stored citations as a BibTeX .bib file."""
+        citations = self._load_citations()
+        if not citations:
+            import warnings
+
+            warnings.warn(
+                "No citations stored in this data store",
+                UserWarning,
+                stacklevel=2,
+            )
+            return
+        from citeable import write_bibtex
+
+        write_bibtex(citations, dest_path)
+
+    def _load_citations(self) -> list[CitationBase]:
+        """Load stored citations. Override in subclasses."""
+        return []
 
 
 class DataMember(DataMemberABC):
@@ -612,6 +662,30 @@ class DataStoreDirectory(DataStoreABC):
 
         return path.read_text() if path.exists() else None
 
+    def write_citations(self, *, data: tuple[CitationBase, ...]) -> None:
+        if not data:
+            return
+        from citeable import to_jsons
+
+        path = self.source / _CITATIONS_FILE
+        path.write_text(to_jsons(data))
+
+    def _load_citations(self) -> list[CitationBase]:
+        from citeable import from_jsons
+
+        path = self.source / _CITATIONS_FILE
+        if not path.exists():
+            return []
+        return from_jsons(path.read_text())
+
+    @property
+    def summary_citations(self) -> TabularType:
+        from cogent3.core.table import Table
+
+        citations = self._load_citations()
+        rows = [list(c.summary()) for c in citations]
+        return Table(header=["app", "citation"], data=rows, title="citations")
+
 
 class ReadOnlyDataStoreZipped(DataStoreABC):
     def __init__(
@@ -743,6 +817,29 @@ class ReadOnlyDataStoreZipped(DataStoreABC):
     def write_log(self, *, unique_id: str, data: StrOrBytes) -> None:
         msg = "zip data stores are read only"
         raise TypeError(msg)
+
+    def write_citations(self, *, data: tuple[CitationBase, ...]) -> None:
+        msg = "zip data stores are read only"
+        raise TypeError(msg)
+
+    def _load_citations(self) -> list[CitationBase]:
+        from citeable import from_jsons
+
+        target = str(pathlib.Path(self.source.stem, _CITATIONS_FILE)).replace("\\", "/")
+        try:
+            with zipfile.ZipFile(self.source) as archive:
+                data = archive.read(target).decode("latin-1")
+            return from_jsons(data)
+        except KeyError:
+            return []
+
+    @property
+    def summary_citations(self) -> TabularType:
+        from cogent3.core.table import Table
+
+        citations = self._load_citations()
+        rows = [list(c.summary()) for c in citations]
+        return Table(header=["app", "citation"], data=rows, title="citations")
 
 
 def get_unique_id(name: object) -> str | None:

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -828,7 +828,7 @@ class ReadOnlyDataStoreZipped(DataStoreABC):
         target = str(pathlib.Path(self.source.stem, _CITATIONS_FILE)).replace("\\", "/")
         try:
             with zipfile.ZipFile(self.source) as archive:
-                data = archive.read(target).decode("latin-1")
+                data = archive.read(target).decode("utf-8")
             return from_jsons(data)
         except KeyError:
             return []

--- a/src/cogent3/app/dist.py
+++ b/src/cogent3/app/dist.py
@@ -16,6 +16,7 @@ from cogent3.evolve.models import get_model
 from cogent3.maths.distance_transform import jaccard
 from cogent3.util.misc import get_true_spans
 
+from ._citations import cite_cogent3
 from .composable import NotCompleted, define_app
 from .data_store import get_data_source
 from .typing import (
@@ -47,7 +48,7 @@ JACCARD_PDIST_POLY_COEFFS = [
 ]
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class fast_slow_dist:
     """Pairwise distance calculation for aligned sequences.
 
@@ -190,7 +191,7 @@ def get_fast_slow_calc(distance, **kwargs):
     return fast_slow_dist(distance, **kwargs)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 def jaccard_dist(seq_coll: UnalignedSeqsType, k: int = 10) -> PairwiseDistanceType:
     """Calculates the pairwise Jaccard distance between the sets of kmers generated from
     sequences in the collection. A measure of distance for unaligned sequences.
@@ -244,7 +245,7 @@ def jaccard_dist(seq_coll: UnalignedSeqsType, k: int = 10) -> PairwiseDistanceTy
     return DistanceMatrix(dists, source=get_data_source(seq_coll))
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 def approx_pdist(jaccard_dists: PairwiseDistanceType) -> PairwiseDistanceType:
     """Calculates an approximation of the p-distance between sequences based
     on Jaccard distances (see Notes for details).
@@ -305,7 +306,7 @@ def approx_pdist(jaccard_dists: PairwiseDistanceType) -> PairwiseDistanceType:
     return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 def approx_jc69(
     pdists: PairwiseDistanceType,
     num_states: int = 4,
@@ -383,7 +384,7 @@ def get_approx_dist_calc(
     return dist_calc_app
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class gap_dist:
     """compute the pairwise difference in gaps using affine gap score"""
 

--- a/src/cogent3/app/evo.py
+++ b/src/cogent3/app/evo.py
@@ -10,6 +10,7 @@ from cogent3.evolve.models import get_model
 from cogent3.evolve.substitution_model import _SubstitutionModel
 from cogent3.util import parallel
 
+from ._citations import cite_cogent3
 from .composable import NotCompleted, define_app
 from .data_store import get_data_source
 from .result import (
@@ -54,7 +55,7 @@ def _config_rules(param_rules, lower, upper, overwrite=False):
     return param_rules
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class model:
     """Define a substitution model + tree for maximum likelihood evaluation."""
 
@@ -574,7 +575,7 @@ class _ModelCollectionBase:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class model_collection(_ModelCollectionBase):
     """Fits a collection of models."""
 
@@ -582,7 +583,7 @@ class model_collection(_ModelCollectionBase):
         return model_collection_result(source=get_data_source(aln))
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class hypothesis(_ModelCollectionBase):
     """Specify a hypothesis through defining two models."""
 
@@ -592,7 +593,7 @@ class hypothesis(_ModelCollectionBase):
         )
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class bootstrap:
     """Parametric bootstrap for a provided hypothesis."""
 
@@ -643,7 +644,7 @@ class bootstrap:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class ancestral_states:
     """Computes ancestral state probabilities from a model result."""
 
@@ -665,7 +666,7 @@ class ancestral_states:
         return tab
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class tabulate_stats:
     """Extracts all model statistics from model_result as Table."""
 
@@ -718,7 +719,7 @@ def is_codon_model(sm):
     return isinstance(sm, _Codon)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class natsel_neutral:
     """Test of selective neutrality by assessing whether omega equals 1.
     Under the alternate, there is one omega for all branches and all sites.
@@ -819,7 +820,7 @@ class natsel_neutral:
         return self._hyp(data)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class natsel_zhang:
     """The branch by site-class hypothesis test for natural selection of
     Zhang et al MBE 22: 2472-2479.
@@ -1031,7 +1032,7 @@ class natsel_zhang:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class natsel_sitehet:
     """Test for site-heterogeneity in omega. Under null, there are 2 site-classes,
     omega < 1 and omega = 1. Under the alternate, an additional site-class of
@@ -1189,7 +1190,7 @@ class natsel_sitehet:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class natsel_timehet:
     """The branch heterogeneity hypothesis test for natural selection.
     Tests for whether a single omega for all branches is sufficient against the

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -22,6 +22,7 @@ from cogent3.core.profile import (
 from cogent3.evolve.fast_distance import DistanceMatrix
 from cogent3.util.deserialise import deserialise_object
 
+from ._citations import cite_cogent3
 from .composable import LOADER, WRITER, NotCompleted, define_app
 from .data_store import (
     READONLY,
@@ -295,7 +296,7 @@ def _load_seqs(
     return coll_maker(data, moltype=moltype, source=unique_id)
 
 
-@define_app(app_type=LOADER)
+@define_app(app_type=LOADER, cite=cite_cogent3)
 class load_aligned:
     """Loads aligned sequences. Returns an Alignment object."""
 
@@ -330,7 +331,7 @@ class load_aligned:
         return _load_seqs(path, cogent3.make_aligned_seqs, self._parser, self.moltype)
 
 
-@define_app(app_type=LOADER)
+@define_app(app_type=LOADER, cite=cite_cogent3)
 class load_unaligned:
     """Loads unaligned sequences. Returns a SequenceCollection."""
 
@@ -367,7 +368,7 @@ class load_unaligned:
         return seqs.degap()
 
 
-@define_app(app_type=LOADER)
+@define_app(app_type=LOADER, cite=cite_cogent3)
 class load_tabular:
     """Loads delimited data. Returns a Table."""
 
@@ -472,7 +473,7 @@ class load_tabular:
         return func[self.as_type](data)
 
 
-@define_app(app_type=LOADER)
+@define_app(app_type=LOADER, cite=cite_cogent3)
 class load_json:
     """Loads json serialised cogent3 objects from a json file.
     Returns whatever object type was stored."""
@@ -504,7 +505,7 @@ class load_json:
 DEFAULT_DESERIALISER = unpickle_it() + from_primitive()
 
 
-@define_app(app_type=LOADER)
+@define_app(app_type=LOADER, cite=cite_cogent3)
 class load_db:
     """Loads serialised cogent3 objects from a db.
     Returns whatever object type was stored."""
@@ -532,7 +533,7 @@ class load_db:
         return result
 
 
-@define_app(app_type=WRITER)
+@define_app(app_type=WRITER, cite=cite_cogent3)
 class write_json:
     """Writes data in json format."""
 
@@ -587,7 +588,7 @@ class write_json:
         return self.data_store.write(unique_id=identifier, data=data)
 
 
-@define_app(app_type=WRITER)
+@define_app(app_type=WRITER, cite=cite_cogent3)
 class write_seqs:
     """Write sequences in standard formats."""
 
@@ -647,7 +648,7 @@ class write_seqs:
         return self.data_store.write(unique_id=identifier, data=data)
 
 
-@define_app(app_type=WRITER)
+@define_app(app_type=WRITER, cite=cite_cogent3)
 class write_tabular:
     """Writes tabular data in text format supported by the cogent3 Table object."""
 
@@ -706,7 +707,7 @@ class write_tabular:
 DEFAULT_SERIALISER = to_primitive() + pickle_it()
 
 
-@define_app(app_type=WRITER, skip_not_completed=False)
+@define_app(app_type=WRITER, skip_not_completed=False, cite=cite_cogent3)
 class write_db:
     """Write serialised objects to a database instance."""
 

--- a/src/cogent3/app/sample.py
+++ b/src/cogent3/app/sample.py
@@ -7,6 +7,7 @@ from numpy import random as np_random
 import cogent3
 from cogent3.core import moltype as c3_moltype
 
+from ._citations import cite_cogent3
 from .composable import NON_COMPOSABLE, NotCompleted, define_app
 from .translate import get_fourfold_degenerate_sets
 from .typing import AlignedSeqsType, SeqsCollectionType, SerialisableType
@@ -26,7 +27,7 @@ def union(groups: list[tuple[str, ...]]) -> set[str]:
     return union.union(*map(set, groups))
 
 
-@define_app(app_type=NON_COMPOSABLE)
+@define_app(app_type=NON_COMPOSABLE, cite=cite_cogent3)
 class concat:
     """Creates a concatenated alignment from a series."""
 
@@ -146,7 +147,7 @@ class concat:
         return NotCompleted("FAIL", self, message="result is empty")
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class omit_degenerates:
     """Excludes alignment columns with degenerate characters. Can accomodate
     reading frame."""
@@ -238,7 +239,7 @@ class omit_degenerates:
         )
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class omit_gap_pos:
     """Excludes gapped alignment columns meeting a threshold. Can accomodate
     reading frame."""
@@ -333,7 +334,7 @@ class omit_gap_pos:
         )
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class take_codon_positions:
     """Extracts the specified codon position(s) from an alignment."""
 
@@ -485,7 +486,7 @@ class take_codon_positions:
         return self._func(aln)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class take_named_seqs:
     """Selects named sequences from a collection."""
 
@@ -535,7 +536,7 @@ class take_named_seqs:
         return data.take_seqs(self._names, negate=self._negate)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class take_n_seqs:
     """Selects n sequences from a collection. Chooses first n sequences, or
     selects randomly if specified."""
@@ -654,7 +655,7 @@ class take_n_seqs:
         return data.take_seqs(self._names)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class min_length:
     """Filters sequence collections / alignments by length."""
 
@@ -754,7 +755,7 @@ class _GetStart:
         return self.func(length)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class fixed_length:
     """Sample an alignment to a fixed length."""
 
@@ -903,7 +904,7 @@ class fixed_length:
         return self._func(data)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class omit_bad_seqs:
     """Eliminates sequences from Alignment based on gap fraction, unique gaps."""
 
@@ -1007,7 +1008,7 @@ class omit_bad_seqs:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class omit_duplicated:
     """Removes redundant sequences, recording dropped sequences in
     seqs.info.dropped."""
@@ -1150,7 +1151,7 @@ class omit_duplicated:
         return self._func(seqs)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class trim_stop_codons:
     """Removes terminal stop codons."""
 

--- a/src/cogent3/app/sqlite_data_store.py
+++ b/src/cogent3/app/sqlite_data_store.py
@@ -26,6 +26,9 @@ from cogent3.app.data_store import (
 from cogent3.util.misc import extend_docstring_from
 
 if TYPE_CHECKING:  # pragma: no cover
+    from citeable import CitationBase
+
+    from cogent3.app.typing import TabularType
     from cogent3.core.table import Table
 
 _RESULT_TABLE = "results"
@@ -80,6 +83,7 @@ def open_sqlite_db_rw(path: str | Path):
         "state(state_id INTEGER PRIMARY KEY, record_type TEXT, lock_pid INTEGER)",
         f"{_LOG_TABLE}(log_id INTEGER PRIMARY KEY, log_name TEXT, date timestamp, data BLOB)",
         f"{_RESULT_TABLE}(record_id TEXT PRIMARY KEY, log_id INTEGER, md5 BLOB, is_completed INTEGER, data BLOB)",
+        "citations(citation_id INTEGER PRIMARY KEY, data TEXT)",
     ]
     for table in creates:
         db.execute(create_template.format(table))
@@ -108,7 +112,9 @@ def has_valid_schema(db):
     query = "SELECT name FROM sqlite_master WHERE type='table'"
     result = db.execute(query).fetchall()
     table_names = {r["name"] for r in result}
-    return table_names == {_RESULT_TABLE, _LOG_TABLE, "state"}
+    _required = {_RESULT_TABLE, _LOG_TABLE, "state"}
+    _optional = {"citations"}
+    return _required <= table_names <= (_required | _optional)
 
 
 class DataStoreSqlite(DataStoreABC):
@@ -436,6 +442,50 @@ class DataStoreSqlite(DataStoreABC):
         result = self.db.execute(cmnd, (unique_id,)).fetchone()
 
         return result["md5"] if result else None
+
+    def write_citations(self, *, data: tuple[CitationBase, ...]) -> None:
+        if not data:
+            return
+        if not self._has_citations_table():
+            self.db.execute(
+                "CREATE TABLE IF NOT EXISTS citations"
+                "(citation_id INTEGER PRIMARY KEY, data TEXT)",
+            )
+        from citeable import to_jsons
+
+        json_data = to_jsons(data)
+        existing = self.db.execute("SELECT citation_id FROM citations").fetchone()
+        if existing:
+            self.db.execute(
+                "UPDATE citations SET data=? WHERE citation_id=?",
+                (json_data, existing["citation_id"]),
+            )
+        else:
+            self.db.execute("INSERT INTO citations(data) VALUES (?)", (json_data,))
+
+    def _load_citations(self) -> list[CitationBase]:
+        from citeable import from_jsons
+
+        if not self._has_citations_table():
+            return []
+        result = self.db.execute("SELECT data FROM citations").fetchone()
+        if not result:
+            return []
+        return from_jsons(result["data"])
+
+    def _has_citations_table(self) -> bool:
+        result = self.db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='citations'",
+        ).fetchone()
+        return result is not None
+
+    @property
+    def summary_citations(self) -> TabularType:
+        from cogent3.core.table import Table
+
+        citations = self._load_citations()
+        rows = [list(c.summary()) for c in citations]
+        return Table(header=["app", "citation"], data=rows, title="citations")
 
     @property
     def describe(self) -> Table:

--- a/src/cogent3/app/translate.py
+++ b/src/cogent3/app/translate.py
@@ -5,6 +5,7 @@ import cogent3
 from cogent3.core import alphabet as c3_alphabet
 from cogent3.core import moltype as c3_moltype
 
+from ._citations import cite_cogent3
 from .composable import NotCompleted, define_app
 from .data_store import get_data_source
 from .typing import SeqsCollectionType, SeqType, SerialisableType
@@ -164,7 +165,7 @@ def get_fourfold_degenerate_sets(
     return four_fold
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class select_translatable:
     """Selects translatable sequences by identifying the most likely reading
     frame. Sequences are truncated to modulo 3. seqs.info has a
@@ -308,7 +309,7 @@ class select_translatable:
         return translatable
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class translate_seqs:
     """Translates nucleic acid sequences into protein sequences, assumes in
     correct reading frame."""

--- a/src/cogent3/app/tree.py
+++ b/src/cogent3/app/tree.py
@@ -7,6 +7,7 @@ from cogent3.phylo.nj import gnj
 from cogent3.util.io import path_exists
 from cogent3.util.misc import is_url
 
+from ._citations import cite_cogent3
 from .composable import define_app
 from .data_store import get_data_source
 from .typing import PairwiseDistanceType, SerialisableType, TreeType
@@ -14,7 +15,7 @@ from .typing import PairwiseDistanceType, SerialisableType, TreeType
 NoneType = type(None)
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class scale_branches:
     """Transforms tree branch lengths from nucleotide to codon, or the
     converse. Returns a new tree with lengths divided by scalar"""
@@ -67,7 +68,7 @@ class scale_branches:
         return tree
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class uniformize_tree:
     """Standardises the orientation of unrooted trees."""
 
@@ -101,7 +102,7 @@ class uniformize_tree:
         return result
 
 
-@define_app
+@define_app(cite=cite_cogent3)
 class quick_tree:
     """Computes a Neighbour Joining tree from pairwise distances."""
 

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -6,6 +6,7 @@ from pickle import dumps, loads
 from unittest.mock import Mock
 
 import pytest
+from citeable import Software
 from numpy import array, ndarray
 from scitrack import CachingLogger
 
@@ -1237,3 +1238,221 @@ def test_cogent3_serialisable_compatible_with_serialisabletype(tmp_path):
     result = app("(A:0.1,B:0.2);")  # pylint: disable=not-callable
     got = loader(result)
     assert isinstance(got, PhyloNode)
+
+
+def _make_cite(**kwargs):
+    defaults = dict(
+        author=["Doe, J"],
+        title="test",
+        year=2024,
+        url="https://example.com",
+        version="1.0",
+        license="MIT",
+        doi="10.0/test",
+        publisher="test",
+    )
+    defaults.update(kwargs)
+    return Software(**defaults)
+
+
+def test_single_app_with_citation():
+    cite = _make_cite()
+
+    @define_app(cite=cite)
+    class cited_app:
+        def main(self, val: int) -> int:
+            return val
+
+    app = cited_app()
+    assert app._cite is cite
+    assert app.citations == (cite,)
+
+
+def test_single_app_without_citation():
+    @define_app
+    class uncited_app:
+        def main(self, val: int) -> int:
+            return val
+
+    app = uncited_app()
+    assert app._cite is None
+    assert app.citations == ()
+
+
+def test_composed_apps_all_with_citations():
+    cite_a = _make_cite(title="A")
+    cite_b = _make_cite(title="B")
+
+    @define_app(cite=cite_a)
+    class app_a:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite_b)
+    class app_b:
+        def main(self, val: int) -> int:
+            return val
+
+    composed = app_a() + app_b()
+    assert composed.citations == (cite_b, cite_a)
+
+
+def test_composed_apps_some_with_citations():
+    cite_a = _make_cite(title="A")
+
+    @define_app(cite=cite_a)
+    class app_c:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app
+    class app_d:
+        def main(self, val: int) -> int:
+            return val
+
+    composed = app_c() + app_d()
+    assert composed.citations == (cite_a,)
+
+
+def test_composed_apps_none_with_citations():
+    @define_app
+    class app_e:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app
+    class app_f:
+        def main(self, val: int) -> int:
+            return val
+
+    composed = app_e() + app_f()
+    assert composed.citations == ()
+
+
+def test_composed_three_app_chain():
+    cite_l = _make_cite(title="L")
+    cite_g = _make_cite(title="G")
+    cite_w = _make_cite(title="W")
+
+    @define_app(cite=cite_l)
+    class chain_l:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite_g)
+    class chain_g:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite_w)
+    class chain_w:
+        def main(self, val: int) -> int:
+            return val
+
+    composed = chain_l() + chain_g() + chain_w()
+    assert composed.citations == (cite_w, cite_g, cite_l)
+
+
+def test_duplicate_citation_deduplication():
+    cite = _make_cite()
+
+    @define_app(cite=cite)
+    class dup_a:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite)
+    class dup_b:
+        def main(self, val: int) -> int:
+            return val
+
+    composed = dup_a() + dup_b()
+    assert composed.citations == (cite,)
+
+
+def test_non_composable_app_with_citation():
+    cite = _make_cite()
+
+    @define_app(app_type=NON_COMPOSABLE, cite=cite)
+    class nc_cited:
+        def main(self, val: int) -> int:
+            return val
+
+    app = nc_cited()
+    assert app.citations == (cite,)
+
+
+def test_citations_after_disconnect():
+    cite_a = _make_cite(title="A")
+    cite_b = _make_cite(title="B")
+
+    @define_app(cite=cite_a)
+    class disc_a:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite_b)
+    class disc_b:
+        def main(self, val: int) -> int:
+            return val
+
+    a = disc_a()
+    b = disc_b()
+    composed = a + b
+    assert len(composed.citations) == 2
+    composed.disconnect()
+    assert b.citations == (cite_b,)
+    assert a.citations == (cite_a,)
+
+
+def test_cite_sets_app_attribute():
+    cite = _make_cite()
+
+    @define_app(cite=cite)
+    class my_special_app:
+        def main(self, val: int) -> int:
+            return val
+
+    assert cite.app == "my_special_app"
+
+
+def test_bib_single_app_with_citation():
+    cite = _make_cite()
+
+    @define_app(cite=cite)
+    class bib_app:
+        def main(self, val: int) -> int:
+            return val
+
+    app = bib_app()
+    assert app.bib == str(cite)
+
+
+def test_bib_app_without_citation():
+    @define_app
+    class no_bib_app:
+        def main(self, val: int) -> int:
+            return val
+
+    app = no_bib_app()
+    assert app.bib == ""
+
+
+def test_bib_composed_apps():
+    cite_a = _make_cite(title="A")
+    cite_b = _make_cite(title="B")
+
+    @define_app(cite=cite_a)
+    class bib_a:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite_b)
+    class bib_b:
+        def main(self, val: int) -> int:
+            return val
+
+    composed = bib_a() + bib_b()
+    assert str(cite_b) in composed.bib
+    assert str(cite_a) in composed.bib
+    assert "\n\n" in composed.bib

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -1456,3 +1456,33 @@ def test_bib_composed_apps():
     assert str(cite_b) in composed.bib
     assert str(cite_a) in composed.bib
     assert "\n\n" in composed.bib
+
+
+@pytest.mark.parametrize("klass", [DataStoreDirectory, DataStoreSqlite])
+def test_apply_to_writes_citations(DATA_DIR, tmp_dir, klass):
+    """apply_to writes citations to the data store"""
+    cite = _make_cite(title="Test Citation")
+
+    dstore = open_data_store(DATA_DIR, suffix="fasta", limit=2)
+    reader = io_app.load_aligned(format_name="fasta", moltype="dna")
+
+    @define_app(cite=cite)
+    class cited_step:
+        def main(self, val: AlignedSeqsType) -> AlignedSeqsType:
+            return val
+
+    if klass == DataStoreDirectory:
+        outpath = tmp_dir / "cite_out"
+        out_dstore = klass(outpath, mode=OVERWRITE, suffix="fasta")
+        writer = io_app.write_seqs(out_dstore)
+    else:
+        outpath = tmp_dir / "cite_out.sqlitedb"
+        out_dstore = klass(outpath, mode=OVERWRITE)
+        writer = io_app.write_db(out_dstore)
+
+    process = reader + cited_step() + writer
+    result_dstore = process.apply_to(dstore, show_progress=False)
+    loaded = result_dstore._load_citations()
+    assert len(loaded) >= 1
+    titles = [c.title for c in loaded]
+    assert "Test Citation" in titles

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -12,6 +12,7 @@ from cogent3.app import io as io_app
 from cogent3.app import sample as sample_app
 from cogent3.app.composable import NotCompleted
 from cogent3.app.data_store import (
+    _CITATIONS_FILE,
     _MD5_TABLE,
     _NOT_COMPLETED_TABLE,
     APPEND,
@@ -703,3 +704,128 @@ def test_apply_to_not_completed(nc_dstore, tmp_path):
     app = loader + num_seqs + writer
     fini = app.apply_to(nc_dstore)
     assert 0 < len(fini.completed) <= len(nc_dstore.completed)
+
+
+@pytest.fixture
+def sample_citations():
+    from citeable import Software
+
+    c1 = Software(author=["A Author"], title="Tool One", year=2024)
+    c1.app = "app_one"
+    c2 = Software(author=["B Author"], title="Tool Two", year=2025)
+    c2.app = "app_two"
+    return (c1, c2)
+
+
+def test_write_citations_directory(write_dir, sample_citations):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    path = write_dir / _CITATIONS_FILE
+    assert path.exists()
+    loaded = dstore._load_citations()
+    assert len(loaded) == 2
+    assert loaded[0].title == "Tool One"
+    assert loaded[1].title == "Tool Two"
+
+
+def test_write_citations_empty_directory(write_dir):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=())
+    path = write_dir / _CITATIONS_FILE
+    assert not path.exists()
+
+
+def test_summary_citations_directory(write_dir, sample_citations):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    table = dstore.summary_citations
+    assert isinstance(table, Table)
+    assert table.shape[0] == 2
+    assert "app" in table.header
+    assert "citation" in table.header
+
+
+def test_write_bib_directory(write_dir, sample_citations):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    bib_path = write_dir / "refs.bib"
+    dstore.write_bib(bib_path)
+    assert bib_path.exists()
+    content = bib_path.read_text()
+    assert "Tool One" in content
+    assert "Tool Two" in content
+
+
+def test_write_bib_no_citations(write_dir):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    bib_path = write_dir / "refs.bib"
+    with pytest.warns(UserWarning, match="No citations stored"):
+        dstore.write_bib(bib_path)
+    assert not bib_path.exists()
+
+
+def test_load_citations_no_file(write_dir):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    assert dstore._load_citations() == []
+
+
+def test_load_citations_zipped(write_dir, sample_citations):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    source = pathlib.Path(dstore.source)
+    path = shutil.make_archive(
+        base_name=source.name,
+        format="zip",
+        base_dir=source.name,
+        root_dir=source.parent,
+    )
+    zipped = ReadOnlyDataStoreZipped(pathlib.Path(path), suffix="fasta")
+    loaded = zipped._load_citations()
+    assert len(loaded) == 2
+    assert loaded[0].title == "Tool One"
+
+
+def test_summary_citations_zipped(write_dir, sample_citations):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    source = pathlib.Path(dstore.source)
+    path = shutil.make_archive(
+        base_name=source.name,
+        format="zip",
+        base_dir=source.name,
+        root_dir=source.parent,
+    )
+    zipped = ReadOnlyDataStoreZipped(pathlib.Path(path), suffix="fasta")
+    table = zipped.summary_citations
+    assert isinstance(table, Table)
+    assert table.shape[0] == 2
+
+
+def test_write_citations_zipped_raises(zipped_basic):
+    zipped = ReadOnlyDataStoreZipped(zipped_basic, suffix="fasta")
+    with pytest.raises(TypeError, match="read only"):
+        zipped.write_citations(data=(None,))
+
+
+def test_old_directory_store_without_citations(fasta_dir):
+    """Opening a directory store created before citations were added works."""
+    # fasta_dir has .fasta files but no .citations file
+    dstore = DataStoreDirectory(fasta_dir, suffix="fasta", mode=READONLY)
+    assert dstore._load_citations() == []
+    table = dstore.summary_citations
+    assert isinstance(table, Table)
+    assert table.shape[0] == 0
+
+
+def test_citations_file_not_in_completed(write_dir, sample_citations):
+    """The bibliography.citations file must not appear in the completed members list."""
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    # write a data file and citations
+    dstore.write(unique_id="sample.fasta", data=">s1\nACGT\n")
+    dstore.write_citations(data=sample_citations)
+    assert (write_dir / _CITATIONS_FILE).exists()
+    # reset cached completed list
+    dstore._completed = []
+    member_ids = {m.unique_id for m in dstore.completed}
+    assert _CITATIONS_FILE not in member_ids
+    assert "sample.fasta" in member_ids

--- a/tests/test_app/test_sqlite_data_store.py
+++ b/tests/test_app/test_sqlite_data_store.py
@@ -133,12 +133,13 @@ def test_db_creation():
     db = DataStoreSqlite(":memory:", mode=OVERWRITE)
     db = db.db
     result = db.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-    assert len(result) == 3
+    assert len(result) == 4
     created_names = {r["name"] for r in result}
     assert created_names == {
         _LOG_TABLE,
         _RESULT_TABLE,
         "state",
+        "citations",
     }
     rows = db.execute(f"Select * from {_LOG_TABLE}").fetchall()
     assert len(rows) == 0
@@ -154,14 +155,15 @@ def test_db_init_log():
 
 def test_open_sqlite_db_rw():
     db = open_sqlite_db_rw(":memory:")
-    # should make tables for results, log and state
+    # should make tables for results, log, state and citations
     result = db.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-    assert len(result) == 3
+    assert len(result) == 4
     created_names = {r["name"] for r in result}
     assert created_names == {
         _LOG_TABLE,
         _RESULT_TABLE,
         "state",
+        "citations",
     }
     db.close()
 
@@ -580,3 +582,118 @@ def test_summary_not_completed(nc_objects):
     vals = summary.to_list(columns=["origin", "message", "num"])
     assert len(vals) == 1
     assert vals[0] == ["location", "'message'", 3]
+
+
+@pytest.fixture
+def sample_citations():
+    from citeable import Software
+
+    c1 = Software(author=["A Author"], title="Tool One", year=2024)
+    c1.app = "app_one"
+    c2 = Software(author=["B Author"], title="Tool Two", year=2025)
+    c2.app = "app_two"
+    return (c1, c2)
+
+
+def test_write_citations_sqlite(sample_citations):
+    dstore = DataStoreSqlite(":memory:", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    loaded = dstore._load_citations()
+    assert len(loaded) == 2
+    assert loaded[0].title == "Tool One"
+    assert loaded[1].title == "Tool Two"
+
+
+def test_write_citations_empty_sqlite():
+    dstore = DataStoreSqlite(":memory:", mode=OVERWRITE)
+    dstore.write_citations(data=())
+    loaded = dstore._load_citations()
+    assert loaded == []
+
+
+def test_write_citations_overwrites_sqlite(sample_citations):
+    from citeable import Software
+
+    dstore = DataStoreSqlite(":memory:", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    c3 = Software(author=["C Author"], title="Tool Three", year=2026)
+    c3.app = "app_three"
+    dstore.write_citations(data=(c3,))
+    loaded = dstore._load_citations()
+    assert len(loaded) == 1
+    assert loaded[0].title == "Tool Three"
+
+
+def test_summary_citations_sqlite(sample_citations):
+    dstore = DataStoreSqlite(":memory:", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    table = dstore.summary_citations
+    assert isinstance(table, Table)
+    assert table.shape[0] == 2
+    assert "app" in table.header
+    assert "citation" in table.header
+
+
+def test_write_bib_sqlite(sample_citations, tmp_dir):
+    dstore = DataStoreSqlite(":memory:", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    bib_path = Path(str(tmp_dir)) / "refs.bib"
+    dstore.write_bib(bib_path)
+    assert bib_path.exists()
+    content = bib_path.read_text()
+    assert "Tool One" in content
+    assert "Tool Two" in content
+
+
+def test_old_schema_without_citations_table(tmp_dir):
+    """Opening an old-style database without a citations table should not fail."""
+    import sqlite3
+
+    db_path = Path(str(tmp_dir)) / "old.sqlitedb"
+    # Create a database with the old schema (no citations table)
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        "CREATE TABLE state(state_id INTEGER PRIMARY KEY, record_type TEXT, lock_pid INTEGER)",
+    )
+    db.execute(
+        f"CREATE TABLE {_LOG_TABLE}(log_id INTEGER PRIMARY KEY, log_name TEXT, date timestamp, data BLOB)",
+    )
+    db.execute(
+        f"CREATE TABLE {_RESULT_TABLE}(record_id TEXT PRIMARY KEY, log_id INTEGER, md5 BLOB, is_completed INTEGER, data BLOB)",
+    )
+    db.close()
+
+    # Should open without error in read-only mode
+    dstore = DataStoreSqlite(db_path, mode=READONLY)
+    assert dstore._load_citations() == []
+
+    # summary_citations should return empty table
+    table = dstore.summary_citations
+    assert table.shape[0] == 0
+    dstore.close()
+
+
+def test_old_schema_write_citations_creates_table(tmp_dir, sample_citations):
+    """Writing citations to an old-style database should create the table."""
+    import sqlite3
+
+    db_path = Path(str(tmp_dir)) / "old_rw.sqlitedb"
+    # Create a database with the old schema (no citations table)
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        "CREATE TABLE state(state_id INTEGER PRIMARY KEY, record_type TEXT, lock_pid INTEGER)",
+    )
+    db.execute(
+        f"CREATE TABLE {_LOG_TABLE}(log_id INTEGER PRIMARY KEY, log_name TEXT, date timestamp, data BLOB)",
+    )
+    db.execute(
+        f"CREATE TABLE {_RESULT_TABLE}(record_id TEXT PRIMARY KEY, log_id INTEGER, md5 BLOB, is_completed INTEGER, data BLOB)",
+    )
+    db.close()
+
+    # Open in append mode and write citations
+    dstore = DataStoreSqlite(db_path, mode=APPEND)
+    dstore.write_citations(data=sample_citations)
+    loaded = dstore._load_citations()
+    assert len(loaded) == 2
+    dstore.close()


### PR DESCRIPTION
## Summary by Sourcery

Add citation support for composable apps and data stores, enabling collection, storage, and export of software citations throughout analysis pipelines.

New Features:
- Allow apps defined with define_app to carry citation metadata, propagate citations through composed pipelines, and expose them via citations and bib properties.
- Persist citations in directory, zipped, and SQLite data stores, including summary_citations views and BibTeX export via write_bib.
- Provide a project-level cogent3 Software citation and attach it to core built-in apps so they can be credited automatically.

Enhancements:
- Extend apply_to to write collected citations into the output data store and ensure citations are not treated as completed data members.
- Update SQLite schema handling to optionally include a citations table while remaining compatible with older databases.
- Ensure read-only and legacy data stores gracefully handle absence or immutability of citation data, emitting appropriate warnings or errors.

Build:
- Declare citeable as a new runtime dependency for citation handling.

Tests:
- Add comprehensive tests for citation propagation across single, composed, and non-composable apps, including deduplication and BibTeX formatting.
- Add tests for writing, loading, summarising, and exporting citations in directory, zipped, and SQLite data stores, including backwards-compatibility scenarios and read-only safeguards.