### PR TITLE
Updated docs and gha

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -50,13 +50,13 @@ jobs:
           cov="--cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov cogent3 --cov-config=${dn}/.coveragerc"
           nox  -db uv --force-python python -s test -- $cov
 
-      # - name: Coveralls Parallel
-      #   uses: coverallsapp/github-action@v2
-      #   with:
-      #     parallel: true
-      #     github-token: ${{ secrets.github_token }}
-      #     flag-name: run-${{matrix.python-version}}-${{matrix.os}}
-      #     file: "tests/lcov-${{matrix.os}}-${{matrix.python-version}}.lcov"
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{matrix.python-version}}-${{matrix.os}}
+          file: "tests/lcov-${{matrix.os}}-${{matrix.python-version}}.lcov"
 
   type_check:
     name: Type Check
@@ -78,13 +78,13 @@ jobs:
           mypy src/cogent3/core/alignment.py src/cogent3/core/alphabet.py src/cogent3/core/annotation.py src/cogent3/core/genetic_code.py src/cogent3/core/location.py src/cogent3/core/moltype.py src/cogent3/core/seq_storage.py src/cogent3/core/sequence.py src/cogent3/core/seqview.py src/cogent3/core/slice_record.py src/cogent3/core/tree.py
 
 
-  # finish:
-  #   name: "Finish Coveralls"
-  #   needs: tests
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Coveralls Finished
-  #     uses: coverallsapp/github-action@v2
-  #     with:
-  #       github-token: ${{ secrets.github_token }}
-  #       parallel-finished: true
+  finish:
+    name: "Finish Coveralls"
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/doc/app/user_function.rst
+++ b/doc/app/user_function.rst
@@ -210,8 +210,8 @@ If you will make your app available on the Python package index, we recommend pr
 
 .. _app_citations:
 
-Citing the tools your app uses
-------------------------------
+Add a citation to your app so users can acknowledge your work
+-------------------------------------------------------------
 
 Correctly attributing the authors of algorithms and software is a requirement of good scientific practice. cogent3 makes this easy by letting app authors declare citations that are automatically tracked through composed pipelines.
 
@@ -236,7 +236,7 @@ Use the ``cite`` parameter of ``define_app`` to attach a citation to your own ap
         """Remove sequences shorter than the alignment."""
         return val.omit_bad_seqs()
 
-The ``.app`` attribute on the citation is set automatically to the class name (but this can over-ridden internally if a citation is assigned to multiple apps).
+The ``.app`` attribute on the citation is set automatically to the class name (but this can be over-ridden internally if a citation is assigned to multiple apps).
 
 .. jupyter-execute::
 
@@ -257,7 +257,7 @@ You can get the BibTeX string directly via the ``.bib`` property.
 
 .. dropdown:: Citations in a composed pipeline
 
-    When apps are composed into a pipeline, ``.citations`` collects citations from all apps in the chain.
+    When apps are composed into a pipeline, ``.citations`` collects unique citations from all apps in the chain.
 
     .. jupyter-execute::
 


### PR DESCRIPTION
## Summary by Sourcery

Enable Coveralls integration in the testing workflow and finalize coverage reporting in CI.

CI:
- Activate the Coveralls parallel reporting step in the testing_develop GitHub Actions workflow.
- Add a dedicated job to signal Coveralls that all parallel CI runs have finished.