### PR TITLE
BUG: table sorted method works again on mixed numeric/string data

### DIFF
--- a/src/cogent3/core/table.py
+++ b/src/cogent3/core/table.py
@@ -1622,15 +1622,16 @@ class Table:
 
                 columns.append(c)
 
-        dtypes = [(c, self.columns[c].dtype) for c in columns]
-        data = numpy.array(self.columns[columns], dtype="O").T
-        for c in reverse:
-            index = columns.index(c)
-            func = _reverse_num if array_is_num_type(self.columns[c]) else _reverse_str
-            func = numpy.vectorize(func)
-            data[:, index] = func(data[:, index])
+        arrays = []
+        for c in columns:
+            col = self.columns[c].copy()
+            if c in reverse:
+                func = _reverse_num if array_is_num_type(col) else _reverse_str
+                col = numpy.vectorize(func)(col)
+            arrays.append(col)
 
-        data = numpy.rec.fromarrays(data.copy().T, dtype=dtypes)
+        dtypes = [(c, arr.dtype) for c, arr in zip(columns, arrays)]
+        data = numpy.rec.fromarrays(arrays, dtype=dtypes)
         indices = data.argsort()
 
         attr = self._get_persistent_attrs()

--- a/src/cogent3/core/table.py
+++ b/src/cogent3/core/table.py
@@ -1600,12 +1600,8 @@ class Table:
                 msg,
             )
 
-        reverse = reverse if reverse is not None else []
-        if reverse != [] and columns is None:
-            columns = reverse
-
-        if columns is None:
-            columns = list(self.columns)
+        reverse = reverse or []
+        columns = columns or reverse or list(self.columns)
 
         if isinstance(columns, str):
             columns = [columns]
@@ -1615,12 +1611,14 @@ class Table:
 
         columns = list(columns)
 
-        if reverse and not (set(columns) & set(reverse)):
-            for c in reverse:
-                if c in columns:
-                    continue
+        if reverse:
+            if invalid := set(reverse) - set(self.columns):
+                msg = f"reverse column(s) {invalid} not in table columns"
+                raise ValueError(msg)
 
-                columns.append(c)
+            for c in reverse:
+                if c not in columns:
+                    columns.append(c)
 
         arrays = []
         for c in columns:

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -2306,3 +2306,21 @@ def test_count_unique_uses_group_indices():
     co = table.count_unique("Variant_Classification")
     assert co["Intron"] == 3
     assert co["IGR"] == 1
+
+
+def test_sorted_reverse_mixed_columns():
+    """sorted with reverse on numeric col when table has string cols"""
+    # When a table has both string and numeric columns, sorting with
+    # reverse on a numeric column should not fail. The bug is that
+    # numpy.array(..., dtype='O').T converts floats to strings, then
+    # _reverse_num multiplies a string by -1, yielding '' (empty string),
+    # which then fails when fromarrays tries to cast back to float.
+    table = make_table(
+        data={
+            "Locus": ["NP_003077", "NP_004893", "NP_005079"],
+            "Region": ["Con", "Con", "NonCon"],
+            "Ratio": [2.5386, 121351.4264, 9516594.9789],
+        },
+    )
+    result = table.sorted(columns=["Region", "Ratio"], reverse="Ratio")
+    assert result.shape == table.shape


### PR DESCRIPTION
## Summary by Sourcery

Fix table sorting on mixed numeric and string columns when using reverse ordering and add a regression test covering this scenario.

Bug Fixes:
- Ensure table.sorted correctly handles reverse sorting on numeric columns in tables that also contain string columns without causing dtype casting errors.

Tests:
- Add a regression test verifying sorted(reverse=...) works on tables with both string and numeric columns.