### PR TITLE
ENH: allow user to control vertical spacing in draw_annotations

### DIFF
--- a/src/cogent3/draw/annotation.py
+++ b/src/cogent3/draw/annotation.py
@@ -207,6 +207,7 @@ def _make_multi_seqid_drawable(
     max_coord: int | None,
     width: float,
     title: str | None,
+    vertical_spacing: float = 0.12,
 ) -> Drawable | None:
     """Build a stacked subplot Drawable for multiple seqids."""
     seqids = sorted(by_seqid)
@@ -230,7 +231,7 @@ def _make_multi_seqid_drawable(
             max_coord=max_coord,
         )
 
-        domain = get_domain(n_seqids, idx, is_y=True, space=0.12)
+        domain = get_domain(n_seqids, idx, is_y=True, space=vertical_spacing)
         yaxis_cfg["domain"] = list(domain)
         xaxis_cfg["anchor"] = yref
 
@@ -327,6 +328,7 @@ def _draw_centered(
     width: float,
     title: str | None,
     show_controls: bool,
+    vertical_spacing: float = 0.12,
 ) -> Drawable | None:
     """Build a drawable centered on a named feature across seqids."""
     anchors = _find_anchor_features(
@@ -384,6 +386,7 @@ def _draw_centered(
         max_coord=None,
         width=width,
         title=default_title,
+        vertical_spacing=vertical_spacing,
     )
 
 
@@ -404,6 +407,7 @@ def draw_annotations(
     center_on: str | None = None,
     flank: int = 5000,
     max_seqids: int | None = None,
+    vertical_spacing: float = 0.12,
 ) -> Drawable | None:
     """Visualise annotations from an AnnotationDb
 
@@ -447,6 +451,9 @@ def draw_annotations(
     max_seqids
         Maximum number of seqids to display. Applied after filtering to
         those containing the anchor. Sorted alphabetically, first N taken.
+    vertical_spacing
+        Fractional vertical space between subplots when multiple seqids
+        are displayed. Only used for multi-seqid plots. Default is 0.12.
 
     Returns
     -------
@@ -484,6 +491,7 @@ def draw_annotations(
             width=width,
             title=title,
             show_controls=show_controls,
+            vertical_spacing=vertical_spacing,
         )
 
     features = _query_features(
@@ -532,4 +540,5 @@ def draw_annotations(
         max_coord=max_coord,
         width=width,
         title=title,
+        vertical_spacing=vertical_spacing,
     )

--- a/tests/test_draw/test_annotations.py
+++ b/tests/test_draw/test_annotations.py
@@ -617,3 +617,35 @@ def test_center_on_custom_title(shared_feature_db):
     )
     assert result is not None
     assert result.layout.title.text == "Custom"
+
+
+def test_vertical_spacing_changes_yaxis_domains(multi_seqid_db):
+    """Different vertical_spacing values produce different y-axis domains."""
+    result_default = draw_annotations(multi_seqid_db)
+    result_wide = draw_annotations(multi_seqid_db, vertical_spacing=0.3)
+    assert result_default is not None
+    assert result_wide is not None
+    # Compare the yaxis domain of the first subplot
+    domain_default = list(result_default.layout.yaxis.domain)
+    domain_wide = list(result_wide.layout.yaxis.domain)
+    assert domain_default != domain_wide
+
+
+def test_vertical_spacing_center_on(shared_feature_db):
+    """vertical_spacing is accepted via the center_on path."""
+    result_default = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+    )
+    result_wide = draw_annotations(
+        shared_feature_db,
+        center_on="dnaA",
+        biotype="gene",
+        vertical_spacing=0.3,
+    )
+    assert result_default is not None
+    assert result_wide is not None
+    domain_default = list(result_default.layout.yaxis.domain)
+    domain_wide = list(result_wide.layout.yaxis.domain)
+    assert domain_default != domain_wide


### PR DESCRIPTION
[NEW] when doing centered_on, vertical_spacing controls the
     gap between different subplots

## Summary by Sourcery

Allow configuration of vertical spacing between subplots in multi-sequence annotation plots and ensure it works through the centered_on path.

Enhancements:
- Add a vertical_spacing parameter to multi-seqid and centered draw_annotation paths to control fractional space between stacked subplots.

Tests:
- Add tests verifying that different vertical_spacing values change y-axis domains and are honored when using center_on.