### PR TITLE
Fixes to cites and bib writing

### DIFF
--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -681,8 +681,6 @@ def define_app(
         klass.app_type = app_type
         klass._skip_not_completed = skip_not_completed
 
-        if cite is not None:
-            cite.app = klass.__name__
         klass._cite = cite
         klass.citations = property(_citations_property)
         klass.bib = property(_bib)
@@ -963,12 +961,14 @@ def _get_citations(self) -> tuple[Citation, ...]:
     result: list[Citation] = []
 
     if self._cite is not None:
+        self._cite.app = self.__class__.__name__
         seen.add(self._cite)
         result.append(self._cite)
 
     head = getattr(self, "input", None)
     while head is not None:
         if head._cite is not None and head._cite not in seen:
+            head._cite.app = head.__class__.__name__
             seen.add(head._cite)
             result.append(head._cite)
         head = getattr(head, "input", None)

--- a/src/cogent3/app/data_store.py
+++ b/src/cogent3/app/data_store.py
@@ -334,6 +334,7 @@ class DataStoreABC(ABC):
             return
         from citeable import write_bibtex
 
+        dest_path = Path(dest_path).expanduser().absolute()
         write_bibtex(citations, dest_path)
 
     def _load_citations(self) -> list[CitationBase]:

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -1413,7 +1413,27 @@ def test_cite_sets_app_attribute():
         def main(self, val: int) -> int:
             return val
 
-    assert cite.app == "my_special_app"
+    app = my_special_app()
+    assert app.citations[0].app == "my_special_app"
+
+
+def test_cite_shared_across_apps():
+    cite = _make_cite()
+
+    @define_app(cite=cite)
+    class app_one:
+        def main(self, val: int) -> int:
+            return val
+
+    @define_app(cite=cite)
+    class app_two:
+        def main(self, val: int) -> int:
+            return val
+
+    a = app_one()
+    b = app_two()
+    assert a.citations[0].app == "app_one"
+    assert b.citations[0].app == "app_two"
 
 
 def test_bib_single_app_with_citation():

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -756,6 +756,18 @@ def test_write_bib_directory(write_dir, sample_citations):
     assert "Tool Two" in content
 
 
+def test_write_bib_tilde_path(write_dir, sample_citations, HOME_TMP_DIR):
+    dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
+    dstore.write_citations(data=sample_citations)
+    bib_path = f"~/{HOME_TMP_DIR.name}/refs.bib"
+    dstore.write_bib(bib_path)
+    expected = pathlib.Path(bib_path).expanduser()
+    assert expected.exists()
+    content = expected.read_text()
+    assert "Tool One" in content
+    assert "Tool Two" in content
+
+
 def test_write_bib_no_citations(write_dir):
     dstore = DataStoreDirectory(write_dir, suffix="fasta", mode=OVERWRITE)
     bib_path = write_dir / "refs.bib"


### PR DESCRIPTION
## Summary by Sourcery

Adjust citation handling for composable apps and improve bibliography file writing behavior.

Bug Fixes:
- Ensure citations correctly record the app class name at citation collection time rather than at app definition, preventing shared citation objects from leaking app names across apps.
- Handle tilde-prefixed destination paths when writing bibliography files so refs.bib is created at the expanded user path.

Tests:
- Update composable app citation tests to validate per-instance app names and add coverage for shared citations across multiple apps.
- Add a data store test to verify writing bibliography files to tilde-based paths expands to the correct filesystem location.