### PR TITLE
ENH: migrate app type checking from string-based to typeguard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "scitrack",
     "stevedore",
     "tqdm",
+    "typeguard>=4.0,<5",
     "typing_extensions",
 ]
 # remember to update version in requires-python and classifiers
@@ -155,7 +156,7 @@ new_fragment_template = "file: changelog.d/templates/new.md.j2"
 entry_title_template = "file: changelog.d/templates/title.md.j2"
 
 [[tool.mypy.overrides]]
-module = ["numba", "loky", "mpi4py", "stevedore"]
+module = ["numba", "loky", "mpi4py", "stevedore", "typeguard"]
 ignore_missing_imports = true
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -104,6 +104,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "src/cogent3/parse/cogent3_json.py" = [
     "ANN401" # Allow use of Any
 ]
+"src/cogent3/app/io.py" = [
+    "ANN401" # Allow use of Any for generic serialisation apps
+]
 
 [format]
 # Like Black, use double quotes for strings.

--- a/src/cogent3/app/__init__.py
+++ b/src/cogent3/app/__init__.py
@@ -12,7 +12,17 @@ import cogent3
 from cogent3._plugin import get_app_manager
 
 from .composable import is_app, is_app_composable
-from .io import open_data_store  # noqa
+
+
+def __getattr__(name):
+    if name == "open_data_store":
+        from .io import open_data_store
+
+        globals()["open_data_store"] = open_data_store
+        return open_data_store
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from stevedore.extension import Extension
@@ -74,11 +84,15 @@ def _get_extension_attr(extension: Extension) -> list[str]:
 
 def _make_types(app: type) -> dict:
     """returns type hints for the input and output"""
+    from cogent3.app.typing import get_type_display_names
+
     _types = {"_data_types": [], "_return_types": []}
-    for tys in _types:
-        types = getattr(app, tys, None) or []
-        types = [types] if isinstance(types, str) else types
-        _types[tys] = [{None: ""}.get(e, e) for e in types]
+    input_type = getattr(app, "_input_type", None)
+    return_type = getattr(app, "_return_type", None)
+    if input_type is not None:
+        _types["_data_types"] = sorted(get_type_display_names(input_type))
+    if return_type is not None:
+        _types["_return_types"] = sorted(get_type_display_names(return_type))
     return _types
 
 

--- a/src/cogent3/app/composable.py
+++ b/src/cogent3/app/composable.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import re
+import sys
 import textwrap
 import time
 import traceback
@@ -14,9 +15,15 @@ from uuid import uuid4
 
 from citeable import Citation
 from scitrack import CachingLogger
+from typeguard import TypeCheckError, check_type
 
 from cogent3._version import __version__
 from cogent3.app import typing as c3_typing
+from cogent3.app.typing import (
+    check_type_compatibility,
+    get_type_display_names,
+    resolve_type_hint,
+)
 from cogent3.util import parallel as PAR
 from cogent3.util import progress_display as UI
 from cogent3.util.deserialise import register_deserialiser
@@ -151,20 +158,6 @@ def _get_raw_hints(main_func, min_params):
         msg = "NoneType invalid type for return value"
         raise TypeError(msg)
 
-    # we disallow type hints with too many levels of testing,
-    # e.g set[int] is ok but tuple[set[int]] is not
-    msg = (
-        "{} type {} nesting level exceeds 2 for {}"
-        "we suggest using a custom type, e.g. a dataclass"
-    )
-    depth, _ = c3_typing.type_tree(first_param_type)
-    if depth > 2:
-        raise TypeError(msg.format("first_param", first_param_type, depth))
-
-    depth, _ = c3_typing.type_tree(return_type)
-    if depth > 2:
-        raise TypeError(msg.format("return_type", return_type, depth))
-
     if isinstance(first_param_type, str):
         msg = (
             "Apps do not yet support string type hints "
@@ -183,11 +176,12 @@ def _get_raw_hints(main_func, min_params):
     return first_param_type, return_type
 
 
-def _get_main_hints(klass: type) -> tuple[frozenset, frozenset]:
-    """return type hints for main method
+def _get_main_hints(klass: type) -> tuple:
+    """return raw type hints for main method
+
     Returns
     -------
-    {arg1hints}, {return type hint}
+    (first_param_type_hint, return_type_hint)
     """
     # Check klass.main exists and is type method
     main_func = getattr(klass, "main", None)
@@ -200,10 +194,7 @@ def _get_main_hints(klass: type) -> tuple[frozenset, frozenset]:
         raise ValueError(msg)
 
     first_param_type, return_type = _get_raw_hints(main_func, 2)
-    first_param_type = c3_typing.get_constraint_names(first_param_type)
-    return_type = c3_typing.get_constraint_names(return_type)
-
-    return frozenset(first_param_type), frozenset(return_type)
+    return first_param_type, return_type
 
 
 def _set_hints(main_meth, first_param_type, return_type):
@@ -248,26 +239,15 @@ def _add(self, other):
         msg = "Right hand side of add operator must not be of type loader"
         raise TypeError(msg)
 
-    if self._return_types & {"SerialisableType", "IdentifierType"}:
-        pass
-    # validate that self._return_types ia a non-empty set.
-    elif not self._return_types:
-        msg = f"return type not defined for {self.__class__.__name__!r}"
-        raise TypeError(msg)
-    # validate that other._data_types a non-empty set.
-    elif not other._data_types:
-        msg = f"input type not defined for {other.__class__.__name__!r}"
-        raise TypeError(msg)
-    # Check if self._return_types & other._data_types is incompatible.
-    elif not (self._return_types & other._data_types):
+    if not check_type_compatibility(self._return_type, other._input_type):
+        self_names = get_type_display_names(self._return_type)
+        other_names = get_type_display_names(other._input_type)
         msg = (
-            f"{self.__class__.__name__!r} return_type {self._return_types} "
+            f"{self.__class__.__name__!r} return_type {self_names} "
             f"incompatible with {other.__class__.__name__!r} input "
-            f"type {other._data_types}"
+            f"type {other_names}"
         )
-        raise TypeError(
-            msg,
-        )
+        raise TypeError(msg)
     other.input = self
     return other
 
@@ -415,32 +395,27 @@ def _call(self, val, *args, **kwargs):
 
 
 def _validate_data_type(self, data):
-    """checks data class name matches defined compatible types"""
-    # TODO when move to python 3.8 define protocol checks for the two singular types
-    if isinstance(data, NotCompleted) and self._skip_not_completed:
-        return data
-
-    if not self._data_types or self._data_types & {
-        "SerialisableType",
-        "IdentifierType",
-    }:
+    """checks data type matches defined compatible types using typeguard"""
+    if isinstance(data, NotCompleted):
+        if self._skip_not_completed:
+            return data
+        # skip_not_completed=False means the app handles NotCompleted itself
         return True
 
     if isinstance(data, source_proxy):
         data = data.obj
 
-    if isinstance(data, _builtin_seqs):
-        if len(data):
-            data = next(iter(data))
-        else:
-            return NotCompleted("ERROR", self, message="empty data", source=data)
+    if isinstance(data, _builtin_seqs) and len(data) == 0:
+        return NotCompleted("ERROR", self, message="empty data", source=data)
 
-    class_name = data.__class__.__name__
-    valid = class_name in self._data_types
-    if not valid:
-        msg = f"invalid data type, '{class_name}' not in {', '.join(list(self._data_types))}"
-        valid = NotCompleted("ERROR", self, message=msg, source=data)
-    return valid
+    try:
+        check_type(data, self._input_type)
+        return True
+    except TypeCheckError:
+        class_name = data.__class__.__name__
+        expected = get_type_display_names(self._input_type)
+        msg = f"invalid data type, '{class_name}' not in {', '.join(sorted(expected))}"
+        return NotCompleted("ERROR", self, message=msg, source=data)
 
 
 def _class_from_func(func):
@@ -674,10 +649,12 @@ def define_app(
             func.__name__ = meth
             setattr(klass, meth, func)
 
-        # Get type hints of main function in klass
-        arg_hints, return_hint = _get_main_hints(klass)
-        klass._data_types = arg_hints
-        klass._return_types = return_hint
+        # Resolve type hints at decoration time
+        raw_input, raw_return = _get_main_hints(klass)
+        mod = sys.modules.get(klass.__module__) if klass.__module__ else None
+        module_globals = vars(mod) if mod else {}
+        klass._input_type = resolve_type_hint(raw_input, module_globals)
+        klass._return_type = resolve_type_hint(raw_return, module_globals)
         klass.app_type = app_type
         klass._skip_not_completed = skip_not_completed
 

--- a/src/cogent3/app/io.py
+++ b/src/cogent3/app/io.py
@@ -162,13 +162,13 @@ def open_data_store(
 
 
 @define_app(skip_not_completed=False)
-def pickle_it(data: SerialisableType) -> bytes:
+def pickle_it(data: typing.Any) -> bytes:
     """Serialises data using pickle."""
     return pickle.dumps(data)
 
 
 @define_app(skip_not_completed=False)
-def unpickle_it(data: bytes) -> SerialisableType:
+def unpickle_it(data: bytes) -> typing.Any:
     "Deserialises pickle data."
     return pickle.loads(data)
 
@@ -222,7 +222,7 @@ class to_primitive:
     def __init__(self, convertor: callable = as_dict) -> None:
         self.convertor = convertor
 
-    def main(self, data: SerialisableType) -> SerialisableType:
+    def main(self, data: typing.Any) -> typing.Any:
         """returns dict from a cogent3 object"""
         return self.convertor(data)
 
@@ -234,19 +234,19 @@ class from_primitive:
     def __init__(self, deserialiser: callable = deserialise_object) -> None:
         self.deserialiser = deserialiser
 
-    def main(self, data: SerialisableType) -> SerialisableType:
+    def main(self, data: typing.Any) -> typing.Any:
         """either json or a dict from a cogent3 object"""
         return self.deserialiser(data)
 
 
 @define_app
-def to_json(data: SerialisableType) -> str:
+def to_json(data: dict) -> str:
     """Convert primitive python types to json string."""
     return json.dumps(data)
 
 
 @define_app
-def from_json(data: str) -> SerialisableType:
+def from_json(data: str) -> dict:
     """Convert json string to primitive python types."""
     return json.loads(data)
 

--- a/src/cogent3/app/typing.py
+++ b/src/cogent3/app/typing.py
@@ -280,10 +280,10 @@ def resolve_type_hint(hint, module_globals=None):
         to resolve forward references from user code
     """
     # Protocol classes (like SerialisableType) — return as-is
-    if isinstance(hint, type) and issubclass(hint, Protocol) and hint is not Protocol:
+    if getattr(hint, "_is_protocol", False) and hint is not Protocol:
         return hint
 
-    # TypeVar with __bound__ → resolve bound class
+    # TypeVar with __bound__ -> resolve bound class
     if isinstance(hint, TypeVar):
         if hint.__bound__:
             bound = hint.__bound__
@@ -300,7 +300,7 @@ def resolve_type_hint(hint, module_globals=None):
         msg = f"unconstrained TypeVar {hint!r} cannot be resolved"
         raise TypeError(msg)
 
-    # Union / UnionType → recurse
+    # Union / UnionType -> recurse
     origin = get_origin(hint)
     if origin is Union or isinstance(hint, UnionType):
         args = tuple(resolve_type_hint(a, module_globals) for a in get_args(hint))
@@ -316,11 +316,7 @@ def resolve_type_hint(hint, module_globals=None):
         return _resolve_name(hint.__forward_arg__, module_globals)
 
     # plain str
-    if isinstance(hint, str):
-        return _resolve_name(hint, module_globals)
-
-    # concrete class or type alias — return as-is
-    return hint
+    return _resolve_name(hint, module_globals) if isinstance(hint, str) else hint
 
 
 def get_type_display_names(hint) -> frozenset[str]:
@@ -362,7 +358,7 @@ def _get_concrete_classes(hint) -> set[type]:
 
 def _is_protocol(hint) -> bool:
     """checks if a type hint is or contains a runtime-checkable Protocol"""
-    if isinstance(hint, type) and issubclass(hint, Protocol) and hint is not Protocol:
+    if getattr(hint, "_is_protocol", False) and hint is not Protocol:
         return True
 
     origin = get_origin(hint)

--- a/src/cogent3/app/typing.py
+++ b/src/cogent3/app/typing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import inspect
 import re
+from pathlib import Path
 from types import UnionType
 from typing import (
     TYPE_CHECKING,
@@ -17,6 +18,9 @@ from typing import (
     get_origin,
     runtime_checkable,
 )
+
+from cogent3.app.data_store import DataMemberABC
+from cogent3.util.warning import deprecated_callable
 
 if TYPE_CHECKING:  # pragma: no cover
     from cogent3.app.result import (
@@ -88,11 +92,14 @@ ResultType = Union[
     ModelResultType,
     TabularResultType,
 ]
-SerialisableType = TypeVar(
-    "SerialisableType", SeqsCollectionType, TreeType, TabularType, ResultType, SeqType
-)
 
-IdentifierType = TypeVar("IdentifierType")
+
+@runtime_checkable
+class SerialisableType(Protocol):
+    def to_rich_dict(self) -> dict: ...
+
+
+IdentifierType = Union[str, Path, DataMemberABC]
 
 
 def _is_type(text):
@@ -107,24 +114,32 @@ def _is_type(text):
 _all_types = {n: t for n, t in locals().items() if _is_type(n)}
 
 
-def get_constraint_names(*hints) -> set[str | type]:
+@deprecated_callable(
+    version="2026.6",
+    reason="use get_type_display_names(resolve_type_hint(hint)) instead",
+    new="get_type_display_names",
+)
+def get_constraint_names(*hints) -> set[str | type]:  # pragma: no cover
     """returns the set of named constraints of a type hint"""
+    return _get_constraint_names(*hints)
+
+
+def _get_constraint_names(*hints) -> set[str | type]:  # pragma: no cover
+    """returns the set of named constraints of a type hint (internal, no warning)"""
     all_hints = set()
     for hint in hints:
-        if hint == IdentifierType or (
-            inspect.isclass(hint) and get_origin(hint) not in (list, tuple, set)
-        ):
-            all_hints.add(hint.__name__)
+        # SerialisableType is now a Protocol class
+        if hint is SerialisableType:
+            all_hints.add("SerialisableType")
             continue
 
-        if hint == SerialisableType or (
-            inspect.isclass(hint) and get_origin(hint) not in (list, tuple, set)
-        ):
+        # IdentifierType is now a Union
+        if hint is IdentifierType:
+            all_hints.add("IdentifierType")
+            continue
+
+        if inspect.isclass(hint) and get_origin(hint) not in (list, tuple, set):
             all_hints.add(hint.__name__)
-            # we expand the nominated cogent3 compatible types
-            for hnt in getattr(hint, "__constraints__", []):
-                typ = get_constraint_names(hnt) | get_constraint_names(*get_args(hnt))
-                all_hints |= typ
             continue
 
         if getattr(hint, "__bound__", None):
@@ -136,7 +151,7 @@ def get_constraint_names(*hints) -> set[str | type]:
             continue
 
         if get_origin(hint) in NESTED_HINTS:
-            all_hints.update(get_constraint_names(*get_args(hint)))
+            all_hints.update(_get_constraint_names(*get_args(hint)))
 
         if type(hint) == type:
             all_hints.add(hint.__name__)
@@ -148,8 +163,18 @@ def get_constraint_names(*hints) -> set[str | type]:
     return {h.__forward_arg__ if type(h) == ForwardRef else h for h in all_hints}
 
 
-def type_tree(hint, depth=0) -> tuple:
+@deprecated_callable(
+    version="2026.6",
+    reason="use typeguard.check_type() instead",
+    new="typeguard.check_type",
+)
+def type_tree(hint, depth=0) -> tuple:  # pragma: no cover
     """compute the order of types"""
+    return _type_tree(hint, depth=depth)
+
+
+def _type_tree(hint, depth=0) -> tuple:  # pragma: no cover
+    """compute the order of types (internal, no warning)"""
     level_type = get_origin(hint)
     if not level_type:
         return depth + 1, hint
@@ -157,7 +182,7 @@ def type_tree(hint, depth=0) -> tuple:
     levels = []
     depths = []
     for arg in get_args(hint):
-        d, t = type_tree(arg, depth=depth)
+        d, t = _type_tree(arg, depth=depth)
         levels.append(t)
         depths.append(d)
     depth = max(depths) + 1
@@ -173,6 +198,220 @@ def type_tree(hint, depth=0) -> tuple:
     return depth, (level_type, levels)
 
 
+_resolution_ns: dict | None = None
+
+
+def _get_resolution_namespace() -> dict[str, type]:
+    """lazily imports and caches all cogent3 types for forward-ref resolution"""
+    global _resolution_ns
+    if _resolution_ns is not None:
+        return _resolution_ns
+
+    from cogent3.app.result import (
+        bootstrap_result,
+        generic_result,
+        hypothesis_result,
+        model_collection_result,
+        model_result,
+        tabular_result,
+    )
+    from cogent3.core.alignment import Alignment, SequenceCollection
+    from cogent3.core.sequence import (
+        ByteSequence,
+        DnaSequence,
+        ProteinSequence,
+        ProteinWithStopSequence,
+        RnaSequence,
+        Sequence,
+    )
+    from cogent3.core.table import Table
+    from cogent3.core.tree import PhyloNode
+    from cogent3.evolve.fast_distance import DistanceMatrix
+    from cogent3.util.dict_array import DictArray
+
+    _resolution_ns = {
+        "Alignment": Alignment,
+        "SequenceCollection": SequenceCollection,
+        "Sequence": Sequence,
+        "DnaSequence": DnaSequence,
+        "RnaSequence": RnaSequence,
+        "ByteSequence": ByteSequence,
+        "ProteinSequence": ProteinSequence,
+        "ProteinWithStopSequence": ProteinWithStopSequence,
+        "Table": Table,
+        "PhyloNode": PhyloNode,
+        "DistanceMatrix": DistanceMatrix,
+        "DictArray": DictArray,
+        "bootstrap_result": bootstrap_result,
+        "generic_result": generic_result,
+        "hypothesis_result": hypothesis_result,
+        "model_collection_result": model_collection_result,
+        "model_result": model_result,
+        "tabular_result": tabular_result,
+    }
+    return _resolution_ns
+
+
+def _resolve_name(name: str, module_globals: dict | None = None) -> type:
+    """resolves a string name to a type, checking module_globals first,
+    then the cogent3 resolution namespace"""
+    if module_globals and name in module_globals:
+        result = module_globals[name]
+        if isinstance(result, type):
+            return result
+
+    ns = _get_resolution_namespace()
+    if name in ns:
+        return ns[name]
+
+    msg = f"cannot resolve type name {name!r}"
+    raise TypeError(msg)
+
+
+def resolve_type_hint(hint, module_globals=None):
+    """walks a type hint tree and resolves all forward references to classes
+
+    Parameters
+    ----------
+    hint
+        a type hint (TypeVar, Union, ForwardRef, str, or concrete class)
+    module_globals
+        optional dict of the module where the hint was defined, used
+        to resolve forward references from user code
+    """
+    # Protocol classes (like SerialisableType) — return as-is
+    if isinstance(hint, type) and issubclass(hint, Protocol) and hint is not Protocol:
+        return hint
+
+    # TypeVar with __bound__ → resolve bound class
+    if isinstance(hint, TypeVar):
+        if hint.__bound__:
+            bound = hint.__bound__
+            if isinstance(bound, str):
+                bound = _resolve_name(bound, module_globals)
+            elif isinstance(bound, ForwardRef):
+                bound = _resolve_name(bound.__forward_arg__, module_globals)
+            return bound
+        if hint.__constraints__:
+            resolved = tuple(
+                resolve_type_hint(c, module_globals) for c in hint.__constraints__
+            )
+            return Union[resolved]  # type: ignore
+        msg = f"unconstrained TypeVar {hint!r} cannot be resolved"
+        raise TypeError(msg)
+
+    # Union / UnionType → recurse
+    origin = get_origin(hint)
+    if origin is Union or isinstance(hint, UnionType):
+        args = tuple(resolve_type_hint(a, module_globals) for a in get_args(hint))
+        return Union[args]  # type: ignore
+
+    # Container types (list[X], tuple[X,Y], set[X])
+    if origin in (list, tuple, set):
+        args = tuple(resolve_type_hint(a, module_globals) for a in get_args(hint))
+        return origin[args] if args else hint
+
+    # ForwardRef
+    if isinstance(hint, ForwardRef):
+        return _resolve_name(hint.__forward_arg__, module_globals)
+
+    # plain str
+    if isinstance(hint, str):
+        return _resolve_name(hint, module_globals)
+
+    # concrete class or type alias — return as-is
+    return hint
+
+
+def get_type_display_names(hint) -> frozenset[str]:
+    """extracts human-readable class names from a resolved type hint
+
+    Parameters
+    ----------
+    hint
+        a resolved type hint (one that has been through resolve_type_hint)
+    """
+    names = set()
+    origin = get_origin(hint)
+
+    if origin is Union or isinstance(hint, UnionType) or origin in (list, tuple, set):
+        for arg in get_args(hint):
+            names |= get_type_display_names(arg)
+    elif isinstance(hint, type):
+        names.add(hint.__name__)
+    elif isinstance(hint, TypeVar):
+        # fallback for unresolved TypeVars — shouldn't normally happen
+        names.add(hint.__name__)
+
+    return frozenset(names)
+
+
+def _get_concrete_classes(hint) -> set[type]:
+    """extracts concrete classes from a resolved type hint, walking Unions"""
+    classes = set()
+    origin = get_origin(hint)
+
+    if origin is Union or isinstance(hint, UnionType):
+        for arg in get_args(hint):
+            classes |= _get_concrete_classes(arg)
+    elif isinstance(hint, type):
+        classes.add(hint)
+
+    return classes
+
+
+def _is_protocol(hint) -> bool:
+    """checks if a type hint is or contains a runtime-checkable Protocol"""
+    if isinstance(hint, type) and issubclass(hint, Protocol) and hint is not Protocol:
+        return True
+
+    origin = get_origin(hint)
+    if origin is Union or isinstance(hint, UnionType):
+        return any(_is_protocol(a) for a in get_args(hint))
+
+    return False
+
+
+def check_type_compatibility(return_hint, input_hint) -> bool:
+    """composition-time check: is the return type compatible with the input type?
+
+    Parameters
+    ----------
+    return_hint
+        resolved return type of the upstream app
+    input_hint
+        resolved input type of the downstream app
+
+    Returns
+    -------
+    True if the types are compatible, False otherwise
+    """
+    # typing.Any is compatible with everything
+    if return_hint is Any or input_hint is Any:
+        return True
+
+    # If either side is or contains a Protocol, be lenient — runtime check_type
+    # provides the real safety net
+    if _is_protocol(return_hint) or _is_protocol(input_hint):
+        return True
+
+    return_classes = _get_concrete_classes(return_hint)
+    input_classes = _get_concrete_classes(input_hint)
+
+    # Check if any return class is a subclass of any input class (or vice versa)
+    for ret_cls in return_classes:
+        for inp_cls in input_classes:
+            try:
+                if issubclass(ret_cls, inp_cls) or issubclass(inp_cls, ret_cls):
+                    return True
+            except TypeError:
+                # issubclass can fail for some types
+                if ret_cls is inp_cls:
+                    return True
+
+    return False
+
+
 def defined_types():
     """returns a table of the type hints and the cogent3 classes they represent
 
@@ -183,7 +422,15 @@ def defined_types():
     """
     from cogent3.core.table import Table
 
-    rows = [[n, ", ".join(get_constraint_names(t))] for n, t in _all_types.items()]
+    rows = []
+    for n, t in _all_types.items():
+        try:
+            resolved = resolve_type_hint(t)
+            names = get_type_display_names(resolved)
+            rows.append([n, ", ".join(sorted(names))])
+        except TypeError:
+            rows.append([n, n])
+
     title = "To use a type hint, from cogent3.app import typing"
     legend = (
         "An app which uses one of these hints is compatible with the indicated types."

--- a/tests/test_app/test_composable.py
+++ b/tests/test_app/test_composable.py
@@ -1111,24 +1111,20 @@ def test_validate_data_type_not_completed_pass_through():
     [(tuple[set[str]], int), (int, tuple[set[str]])],
 )
 def test_complex_type(first, ret):
-    # disallow >2-deep nesting of types for first arg and return type
-    with pytest.raises(TypeError):
-
-        @define_app
-        class x:
-            def main(self, data: first) -> ret:
-                return data
+    # deep nesting now allowed (typeguard handles arbitrary nesting)
+    @define_app
+    class x:
+        def main(self, data: first) -> ret:
+            return data
 
 
 @pytest.mark.parametrize("hint", [tuple[set[str]], tuple[tuple[set[str]]]])
 def test_complex_type_depths(hint):
-    # disallow >2-deep nesting of types for first arg and return type
-    with pytest.raises(TypeError):
-
-        @define_app
-        class x:
-            def main(self, data: hint) -> bool:
-                return True
+    # deep nesting now allowed (typeguard handles arbitrary nesting)
+    @define_app
+    class x:
+        def main(self, data: hint) -> bool:
+            return True
 
 
 @pytest.mark.parametrize("hint", [int, set[str]])

--- a/tests/test_app/test_data_store.py
+++ b/tests/test_app/test_data_store.py
@@ -367,7 +367,7 @@ def test_summary_not_completed_func(nc_objects, use_dser):
     dstore = io_app.open_data_store(":memory:", mode="w")
     writer = io_app.write_db(dstore)
     deser = io_app.load_db().deserialiser if use_dser else None
-    for nc in nc_objects:
+    for nc in nc_objects.values():
         writer(nc)
 
     got = summary_not_completeds(dstore, deserialise=deser)

--- a/tests/test_app/test_dist.py
+++ b/tests/test_app/test_dist.py
@@ -154,8 +154,8 @@ class FastSlowDistTests(TestCase):
             got = app + calc_dist
             assert isinstance(got, type(calc_dist))
             assert got.input is app
-            assert isinstance(got._data_types, frozenset)
-            assert isinstance(got._return_types, frozenset)
+            assert got._input_type is not None
+            assert got._return_type is not None
             assert got.input is app
             app.disconnect()
             calc_dist.disconnect()

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -228,3 +228,42 @@ def test_available_apps_license_col():
     available = available_apps()
     assert "licenses" in available.columns
     assert "BSD" in available.columns["licenses"]
+
+
+def test_app_module_lazy_import_open_data_store(monkeypatch):
+    """accessing cogent3.app.open_data_store triggers lazy import"""
+    import cogent3.app as app_mod
+
+    monkeypatch.delattr(app_mod, "open_data_store", raising=False)
+
+    result = app_mod.open_data_store
+    from cogent3.app.io import open_data_store as ods
+
+    assert result is ods
+    assert "open_data_store" in vars(app_mod)
+
+
+def test_app_module_getattr_unknown():
+    """accessing unknown attribute on cogent3.app raises AttributeError"""
+    import cogent3.app as app_mod
+
+    with pytest.raises(AttributeError, match="has no attribute"):
+        app_mod.nonexistent_attr_xyz
+
+
+def test_make_signature_callable_default_without_app_type():
+    """_make_signature handles callable defaults that lack app_type"""
+    from cogent3.app import _get_app_matching_name, _make_signature
+
+    app = _get_app_matching_name("write_tabular")
+    got = _make_signature(app)
+    assert "'write_tabular'" in got
+    assert "get_unique_id" in got
+
+
+def test_clean_params_docs_trailing_empty_line():
+    """_clean_params_docs removes trailing empty lines"""
+    from cogent3.app import _clean_params_docs
+
+    result = _clean_params_docs("        Parameters\n        ----------\n\n")
+    assert result == "Parameters\n----------"

--- a/tests/test_app/test_init.py
+++ b/tests/test_app/test_init.py
@@ -67,6 +67,8 @@ def test_available_apps():
 
 def _get_incompat_app_pairs(tmp_path):
     """Generate all incompatible application pairs"""
+    from cogent3.app.typing import check_type_compatibility
+
     applications = _get_all_composables(tmp_path / "delme")
     return [
         (app1, app2)
@@ -76,24 +78,22 @@ def _get_incompat_app_pairs(tmp_path):
         or (
             app2.app_type is LOADER
             and app1 != app2
-            and not app1._return_types & app2._data_types
-            and not app1._return_types & {"SerialisableType", "IdentifierType"}
+            and not check_type_compatibility(app1._return_type, app2._input_type)
         )
     ]
 
 
 def _get_compat_app_pairs(tmp_path):
-    """Generate all incompatible application pairs"""
+    """Generate all compatible application pairs"""
+    from cogent3.app.typing import check_type_compatibility
+
     applications = _get_all_composables(tmp_path / "delme")
     return [
         (app1, app2)
         for app1 in applications
         for app2 in applications
         if app1 != app2
-        and (
-            app1._return_types & app2._data_types
-            or app1._return_types & {"SerialisableType", "IdentifierType"}
-        )
+        and check_type_compatibility(app1._return_type, app2._input_type)
         and app1.app_type is not WRITER
         and app2.app_type is not LOADER
     ]

--- a/tests/test_app/test_typing.py
+++ b/tests/test_app/test_typing.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import TypeVar, Union
 
 import pytest
 
@@ -14,8 +14,6 @@ from cogent3.app.typing import (
     get_type_display_names,
     resolve_type_hint,
 )
-
-# --- Tests for resolve_type_hint ---
 
 
 def test_resolve_type_hint_typevar_bound():
@@ -69,6 +67,22 @@ def test_resolve_type_hint_container():
     assert resolved == list[Alignment]
 
 
+def test_resolve_type_hint_typevar_str_bound():
+    """TypeVar with a plain str bound resolves via _resolve_name"""
+    from cogent3.core.alignment import Alignment
+
+    T = TypeVar("T", bound="Alignment")
+    resolved = resolve_type_hint(T)
+    assert resolved is Alignment
+
+
+def test_resolve_type_hint_unconstrained_typevar():
+    """unconstrained TypeVar raises TypeError"""
+    T = TypeVar("T")
+    with pytest.raises(TypeError, match="unconstrained TypeVar"):
+        resolve_type_hint(T)
+
+
 def test_resolve_type_hint_unresolvable():
     """Unresolvable string raises TypeError"""
     with pytest.raises(TypeError, match="cannot resolve"):
@@ -83,9 +97,6 @@ def test_resolve_type_hint_user_module_globals():
 
     resolved = resolve_type_hint("MyCustomType", {"MyCustomType": MyCustomType})
     assert resolved is MyCustomType
-
-
-# --- Tests for SerialisableType Protocol ---
 
 
 def test_serialisable_type_isinstance():
@@ -110,9 +121,6 @@ def test_serialisable_type_custom_class():
             return {}
 
     assert isinstance(MyObj(), SerialisableType)
-
-
-# --- Tests for get_type_display_names ---
 
 
 def test_get_type_display_names_concrete():
@@ -141,7 +149,11 @@ def test_get_type_display_names_resolved_typevar():
     assert names == frozenset({"Alignment"})
 
 
-# --- Tests for check_type_compatibility ---
+def test_get_type_display_names_typevar_fallback():
+    """unresolved TypeVar returns its __name__"""
+    T = TypeVar("T")
+    names = get_type_display_names(T)
+    assert names == frozenset({"T"})
 
 
 def test_check_type_compatibility_same_type():
@@ -173,7 +185,28 @@ def test_check_type_compatibility_incompatible():
     assert check_type_compatibility(int, str) is False
 
 
-# --- Tests for defined_types ---
+@pytest.fixture
+def broken_subclasscheck():
+    """a class whose metaclass makes issubclass() raise TypeError"""
+
+    class BadMeta(type):
+        def __subclasscheck__(cls, subclass):
+            raise TypeError("broken")
+
+    class Weird(metaclass=BadMeta):
+        pass
+
+    return Weird
+
+
+def test_check_type_compatibility_issubclass_typeerror_same(broken_subclasscheck):
+    """issubclass TypeError with identity match returns True"""
+    assert check_type_compatibility(broken_subclasscheck, broken_subclasscheck) is True
+
+
+def test_check_type_compatibility_issubclass_typeerror_diff(broken_subclasscheck):
+    """issubclass TypeError with different classes returns False"""
+    assert check_type_compatibility(int, broken_subclasscheck) is False
 
 
 def test_defined_types():
@@ -181,3 +214,16 @@ def test_defined_types():
     # TabularType should resolve to Table, DictArray, DistanceMatrix
     includes = types["TabularType"][0, "includes"]
     assert len(includes.split(",")) == 3
+
+
+def test_defined_types_resolve_failure(monkeypatch):
+    """unresolvable type in _all_types falls back to name"""
+    import cogent3.app.typing as typing_mod
+
+    bad = TypeVar("BrokenType")
+    patched = {**typing_mod._all_types, "BrokenType": bad}
+    monkeypatch.setattr(typing_mod, "_all_types", patched)
+
+    table = defined_types()
+    includes = table["BrokenType"][0, "includes"]
+    assert includes == "BrokenType"

--- a/tests/test_app/test_typing.py
+++ b/tests/test_app/test_typing.py
@@ -1,137 +1,183 @@
+from pathlib import Path
 from typing import Union
 
 import pytest
 
+from cogent3.app.data_store import DataMemberABC
 from cogent3.app.typing import (
     AlignedSeqsType,
     IdentifierType,
-    SeqsCollectionType,
     SerialisableType,
     TabularType,
-    UnalignedSeqsType,
+    check_type_compatibility,
     defined_types,
-    get_constraint_names,
-    type_tree,
+    get_type_display_names,
+    resolve_type_hint,
 )
 
+# --- Tests for resolve_type_hint ---
 
-def test_get_constraint_names():
-    """returns the correct names"""
-    from cogent3.core.alignment import (
-        Alignment,
-        SequenceCollection,
-    )
+
+def test_resolve_type_hint_typevar_bound():
+    """TypeVar with string bound resolves to actual class"""
+    from cogent3.core.alignment import Alignment
+
+    resolved = resolve_type_hint(AlignedSeqsType)
+    assert resolved is Alignment
+
+
+def test_resolve_type_hint_typevar_constraints():
+    """TypeVar with string constraints resolves to Union of classes"""
     from cogent3.core.table import Table
     from cogent3.evolve.fast_distance import DistanceMatrix
     from cogent3.util.dict_array import DictArray
 
-    got = get_constraint_names(AlignedSeqsType)
-    assert got == {obj.__name__ for obj in (Alignment,)}
-    got = get_constraint_names(UnalignedSeqsType)
-    assert got == {SequenceCollection.__name__}
-    got = get_constraint_names(SeqsCollectionType)
-    assert got == {obj.__name__ for obj in (Alignment, SequenceCollection)}
-    got = get_constraint_names(TabularType)
-    assert got == {obj.__name__ for obj in (Table, DictArray, DistanceMatrix)}
+    resolved = resolve_type_hint(TabularType)
+    # Should be a Union of Table, DictArray, DistanceMatrix
+    from typing import get_args
+
+    args = set(get_args(resolved))
+    assert args == {Table, DictArray, DistanceMatrix}
 
 
-@pytest.mark.parametrize("constraint", [Union[str, bytes], str | bytes])  # noqa: UP007
-def test_get_constraint_names_builtins(constraint):
-    """handles built-in types"""
-    expected = {"str", "bytes"}
-
-    got = get_constraint_names(constraint)
-    assert got == expected
+def test_resolve_type_hint_concrete_class():
+    """Concrete classes pass through unchanged"""
+    resolved = resolve_type_hint(int)
+    assert resolved is int
 
 
-def test_get_constraint_names_serilisable():
-    """SerialisableType does define compatible types"""
-
-    got = get_constraint_names(SerialisableType)
-    # cogent3 builtin types should also be included
-    assert {"SerialisableType", "SequenceCollection", "Alignment", "PhyloNode"} <= got
+def test_resolve_type_hint_protocol():
+    """Protocol classes pass through unchanged"""
+    resolved = resolve_type_hint(SerialisableType)
+    assert resolved is SerialisableType
 
 
-def test_get_constraint_names_identifiertype():
-    """IdentifierType does not define any compatible types"""
+def test_resolve_type_hint_union():
+    """Union types are resolved recursively"""
+    resolved = resolve_type_hint(IdentifierType)
+    from typing import get_args
 
-    got = get_constraint_names(IdentifierType)
-    assert got == {"IdentifierType"}
-
-
-@pytest.mark.parametrize(
-    "constraint",
-    [
-        Union[SerialisableType, IdentifierType, AlignedSeqsType],  # noqa: UP007
-        SerialisableType | IdentifierType | AlignedSeqsType,
-    ],
-)
-def test_get_constraint_names_mixed_serilisable_identifiertype(constraint):
-    """SerialisableType does not define any compatible types"""
-    expected = {"SerialisableType", "IdentifierType", "Alignment"}
-
-    got = get_constraint_names(constraint)
-    assert expected <= got
+    args = set(get_args(resolved))
+    assert args == {str, Path, DataMemberABC}
 
 
-@pytest.mark.parametrize(
-    "constraint",
-    [Union[SerialisableType, "DnaSequence"], SerialisableType | "DnaSequence"],
-)
-def test_hints_resolved_from_str(constraint):
-    got = get_constraint_names("DnaSequence")
-    assert got == {"DnaSequence"}
+def test_resolve_type_hint_container():
+    """Container types resolved recursively"""
+    from cogent3.core.alignment import Alignment
 
-    expected = {"SerialisableType", "DnaSequence"}
-    got = get_constraint_names(constraint)
-    assert expected <= got
+    resolved = resolve_type_hint(list[AlignedSeqsType])
+    assert resolved == list[Alignment]
 
 
-@pytest.mark.parametrize("container", [list, tuple, set])
-def test_hints_from_container_type(container):
-    got = get_constraint_names(container[AlignedSeqsType])
-    assert got == {"Alignment"}
+def test_resolve_type_hint_unresolvable():
+    """Unresolvable string raises TypeError"""
+    with pytest.raises(TypeError, match="cannot resolve"):
+        resolve_type_hint("NoSuchType")
 
 
-@pytest.mark.parametrize("container", [list, set, tuple])
-def test_hints_from_container_type_obj(container):
-    got = get_constraint_names(container[AlignedSeqsType])
-    assert got == {"Alignment"}
+def test_resolve_type_hint_user_module_globals():
+    """module_globals are checked first for resolution"""
+
+    class MyCustomType:
+        pass
+
+    resolved = resolve_type_hint("MyCustomType", {"MyCustomType": MyCustomType})
+    assert resolved is MyCustomType
 
 
-def test_hint_inherited_class():
-    from collections.abc import MutableSequence
-
-    class dummy(MutableSequence): ...
-
-    got = get_constraint_names(dummy)
-    assert got == frozenset(["dummy"])
+# --- Tests for SerialisableType Protocol ---
 
 
-@pytest.mark.parametrize(
-    ("hint", "expect"),
-    [(int, 1), (set[int], 2), (list[list[set[float]]], 4)],
-)
-def test_typing_tree_depth(hint, expect):
-    d, _ = type_tree(hint)
-    assert d == expect, (d, expect)
+def test_serialisable_type_isinstance():
+    """objects with to_rich_dict satisfy SerialisableType"""
+    from cogent3 import make_aligned_seqs
+
+    aln = make_aligned_seqs({"s1": "ACGT", "s2": "ACGT"}, moltype="dna")
+    assert isinstance(aln, SerialisableType)
 
 
-@pytest.mark.parametrize(
-    ("hint", "expect"),
-    [
-        (int, int),
-        (set[int], (set, (int,))),
-        (list[set[int]], (list, (set, (int,)))),
-    ],
-)
-def test_type_tree(hint, expect):
-    _, t = type_tree(hint)
-    assert t == expect, (t, expect)
+def test_serialisable_type_not_isinstance():
+    """objects without to_rich_dict do not satisfy SerialisableType"""
+    assert not isinstance("hello", SerialisableType)
+    assert not isinstance(42, SerialisableType)
+
+
+def test_serialisable_type_custom_class():
+    """custom class with to_rich_dict satisfies SerialisableType"""
+
+    class MyObj:
+        def to_rich_dict(self) -> dict:
+            return {}
+
+    assert isinstance(MyObj(), SerialisableType)
+
+
+# --- Tests for get_type_display_names ---
+
+
+def test_get_type_display_names_concrete():
+    """concrete class returns its name"""
+    names = get_type_display_names(int)
+    assert names == frozenset({"int"})
+
+
+def test_get_type_display_names_union():
+    """Union returns names of all constituents"""
+    names = get_type_display_names(Union[str, int])  # noqa: UP007
+    assert names == frozenset({"str", "int"})
+
+
+def test_get_type_display_names_protocol():
+    """Protocol returns its own name"""
+    names = get_type_display_names(SerialisableType)
+    assert names == frozenset({"SerialisableType"})
+
+
+def test_get_type_display_names_resolved_typevar():
+    """resolved TypeVar (now a class) returns the class name"""
+
+    resolved = resolve_type_hint(AlignedSeqsType)
+    names = get_type_display_names(resolved)
+    assert names == frozenset({"Alignment"})
+
+
+# --- Tests for check_type_compatibility ---
+
+
+def test_check_type_compatibility_same_type():
+    """same type is compatible"""
+    from cogent3.core.alignment import Alignment
+
+    assert check_type_compatibility(Alignment, Alignment) is True
+
+
+def test_check_type_compatibility_subclass():
+    """subclass is compatible"""
+    from cogent3.core.alignment import Alignment, CollectionBase
+
+    assert check_type_compatibility(Alignment, CollectionBase) is True
+
+
+def test_check_type_compatibility_protocol_input():
+    """Protocol on input side is lenient"""
+    assert check_type_compatibility(int, SerialisableType) is True
+
+
+def test_check_type_compatibility_protocol_return():
+    """Protocol on return side is lenient"""
+    assert check_type_compatibility(SerialisableType, int) is True
+
+
+def test_check_type_compatibility_incompatible():
+    """incompatible concrete types"""
+    assert check_type_compatibility(int, str) is False
+
+
+# --- Tests for defined_types ---
 
 
 def test_defined_types():
     types = defined_types()
-    # we are checking a single value which we know has 3 entries
-    # also indexing by the type name
-    assert len(types["TabularType"][0, "includes"].split(",")) == 3
+    # TabularType should resolve to Table, DictArray, DistanceMatrix
+    includes = types["TabularType"][0, "includes"]
+    assert len(includes.split(",")) == 3


### PR DESCRIPTION
[CHANGED] Replace cogent3's custom string-based type checking
  system with typeguard for both composition-time and runtime
  validation of app types. This enables proper isinstance-based
  checking (including inheritance support for subclasses) and
  delegates type introspection to a focused library.

[NEW] Add typeguard>=4.0,<5 as a dependency

[CHANGED] Replace SerialisableType TypeVar with @runtime_checkable
  Protocol requiring to_rich_dict()

[CHANGED] IdentifierType TypeVar becomes Union[str, Path, DataMemberABC]

[NEW] Add resolve_type_hint(), get_type_display_names(), and
    check_type_compatibility() to cogent3.app.typing

[CHANGED] Deprecate get_constraint_names() and type_tree()
    and remove depth-2 nesting restriction on type hints
    (typeguard handles arbitrary nesting)

[CHANGED] pickle_it/unpickle_it/to_primitive/from_primitive use
    typing.Any. Changed to_json/from_json use dict/str

[FIXED] pre-existing bug in test_data_store.py iterating dict keys
    instead of values

## Summary by Sourcery

Migrate application type handling to use concrete type hints and typeguard-based validation instead of custom string-based type sets.

New Features:
- Introduce resolve_type_hint(), get_type_display_names(), and check_type_compatibility() utilities for resolving and comparing application type hints.
- Add lazy attribute access to cogent3.app.open_data_store via __getattr__ for on-demand import.

Bug Fixes:
- Correct iteration in test_data_store summary_not_completed tests to iterate over dict values instead of keys, ensuring all NotCompleted objects are written.

Enhancements:
- Redefine SerialisableType as a runtime-checkable Protocol and expand IdentifierType to accept str, pathlib.Path, and DataMemberABC.
- Replace set-based app input/output type metadata with resolved type hints stored on apps, and use typeguard.check_type for runtime validation of app inputs.
- Update app composition logic to use structural type compatibility checks rather than string name intersections, allowing inheritance-aware compatibility.
- Relax previous restrictions on nested/complex type hints so arbitrarily deep container types are supported.
- Adjust pickle/json IO apps to use typing.Any or concrete dict/str types in signatures, aligning them with the new typing model.
- Refine defined_types reporting to derive human-readable type names from resolved hints instead of custom constraint introspection.
- Improve tests to cover new typing utilities, Protocol behaviour, deep type nesting support, and revised compatibility logic.

Build:
- Add typeguard (>=4.0,<5) as a runtime dependency and configure mypy to ignore its missing type hints.