### PR TITLE
MAINT: address circular import issue identified from MutationMotif

### DIFF
--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -20,7 +20,6 @@ import numpy
 import numpy.typing as npt
 
 from cogent3.core import alphabet as c3_alphabet
-from cogent3.core import sequence as c3_sequence
 from cogent3.data.molecular_weight import DnaMW, ProteinMW, RnaMW, WeightCalculator
 from cogent3.util.deserialise import register_deserialiser
 from cogent3.util.misc import get_object_provenance
@@ -29,6 +28,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable, Generator, Mapping
     from collections.abc import Sequence as PySeq
 
+    from cogent3.core import sequence as c3_sequence
     from cogent3.core.seqview import SeqViewABC
     from cogent3.core.table import Table
 
@@ -430,7 +430,7 @@ class MolType(Generic[TStrOrBytes]):
         self,
         name: str,
         monomers: TStrOrBytes,
-        make_seq: type[c3_sequence.Sequence],
+        make_seq: type[c3_sequence.Sequence] | str,
         gap: str | None = IUPAC_gap,
         missing: str | None = IUPAC_missing,
         complements: dict[str, str] | None = None,
@@ -453,12 +453,17 @@ class MolType(Generic[TStrOrBytes]):
     def __post_init__(
         self,
         monomers: TStrOrBytes,
-        make_seq: type[c3_sequence.Sequence],
+        make_seq: type[c3_sequence.Sequence] | str,
         complements: dict[str, str] | None,
         colors: dict[str, str] | None,
     ) -> None:
         self._colors = colors or defaultdict(_DefaultValue("black"))
-        self._make_seq = make_seq
+        if isinstance(make_seq, str):
+            self._make_seq_name: str | None = make_seq
+            self._make_seq: type[c3_sequence.Sequence] | None = None
+        else:
+            self._make_seq_name = None
+            self._make_seq = make_seq
         gap = c3_alphabet._coerce_to_type(monomers, self.gap or "")
         missing = c3_alphabet._coerce_to_type(monomers, self.missing or "")
         ambigs = c3_alphabet._coerce_to_type(monomers, "".join(self.ambiguities or ""))
@@ -681,7 +686,13 @@ class MolType(Generic[TStrOrBytes]):
             msg = f"{values} not valid for moltype {self.name!r} alphabet {alpha}"
             raise c3_alphabet.AlphabetError(msg)
 
-        return self._make_seq(moltype=self, seq=seq, name=name, **kwargs)
+        make_seq_cls = self._make_seq
+        if make_seq_cls is None:
+            from cogent3.core import sequence as _seq
+
+            make_seq_cls = getattr(_seq, cast("str", self._make_seq_name))
+            self._make_seq = make_seq_cls
+        return make_seq_cls(moltype=self, seq=seq, name=name, **kwargs)
 
     @overload
     def complement(self, seq: str, validate: bool = True) -> str: ...
@@ -1654,7 +1665,7 @@ ASCII = MolType(
     # characters that could be present in any of those files.
     monomers="".join(ascii_letters),
     name="text",
-    make_seq=c3_sequence.Sequence,
+    make_seq="Sequence",
 )
 
 DNA = MolType(
@@ -1663,7 +1674,7 @@ DNA = MolType(
     name="dna",
     complements=IUPAC_DNA_ambiguities_complements,
     colors=NT_COLORS,
-    make_seq=c3_sequence.DnaSequence,
+    make_seq="DnaSequence",
     pairing_rules=DNA_STANDARD_PAIRS,
     mw_calculator=DnaMW,
     coerce_to=coerce_to_dna,
@@ -1675,7 +1686,7 @@ RNA = MolType(
     name="rna",
     complements=IUPAC_RNA_ambiguities_complements,
     colors=NT_COLORS,
-    make_seq=c3_sequence.RnaSequence,
+    make_seq="RnaSequence",
     pairing_rules=RNA_STANDARD_PAIRS,
     mw_calculator=RnaMW,
     coerce_to=coerce_to_rna,
@@ -1685,7 +1696,7 @@ PROTEIN = MolType(
     ambiguities=IUPAC_PROTEIN_ambiguities,
     name="protein",
     colors=AA_COLORS,
-    make_seq=c3_sequence.ProteinSequence,
+    make_seq="ProteinSequence",
     mw_calculator=ProteinMW,
     coerce_to=coerce_to_protein,
 )
@@ -1695,7 +1706,7 @@ PROTEIN_WITH_STOP = MolType(
     ambiguities=PROTEIN_WITH_STOP_ambiguities,
     name="protein_with_stop",
     colors=AA_COLORS,
-    make_seq=c3_sequence.ProteinWithStopSequence,
+    make_seq="ProteinWithStopSequence",
     mw_calculator=ProteinMW,
     coerce_to=coerce_to_protein,
 )
@@ -1704,7 +1715,7 @@ BYTES = MolType(
     # want to prematurely assume _anything_ about the data.
     monomers=bytes(bytearray(range(2**8))),
     name="bytes",
-    make_seq=c3_sequence.ByteSequence,
+    make_seq="ByteSequence",
     gap=None,
     missing=None,
 )

--- a/src/cogent3/core/profile.py
+++ b/src/cogent3/core/profile.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from collections.abc import Sequence as PySeq
+from typing import TYPE_CHECKING
 
 import numpy
 import numpy.typing as npt
 from numpy import array, digitize
 from numpy.random import random
 
-import cogent3.core.sequence as c3_sequence
 from cogent3.maths.util import safe_log, safe_p_log_p, validate_freqs_array
 from cogent3.util.dict_array import DictArray, DictArrayTemplate
 from cogent3.util.misc import extend_docstring_from
+
+if TYPE_CHECKING:
+    import cogent3.core.sequence as c3_sequence
 
 NumpyIntArrayType = npt.NDArray[numpy.integer]
 NumpyFloatArrayType = npt.NDArray[numpy.floating]
@@ -206,14 +211,14 @@ def make_motif_counts_from_tabular(tab_data):
 
 
 @extend_docstring_from(make_motif_counts_from_tabular)
-def make_motif_freqs_from_tabular(tab_data: numpy.ndarray) -> "MotifFreqsArray":
+def make_motif_freqs_from_tabular(tab_data: numpy.ndarray) -> MotifFreqsArray:
     motif = _get_ordered_motifs_from_tabular(tab_data)
     data = _get_data_from_tabular(tab_data, motif, "float")
     return MotifFreqsArray(data, motif)
 
 
 @extend_docstring_from(make_motif_counts_from_tabular)
-def make_pssm_from_tabular(tab_data: numpy.ndarray) -> "PSSM":
+def make_pssm_from_tabular(tab_data: numpy.ndarray) -> PSSM:
     motif = _get_ordered_motifs_from_tabular(tab_data)
     data = _get_data_from_tabular(tab_data, motif, "float")
     return PSSM(data, motif)
@@ -238,7 +243,7 @@ class MotifCountsArray(_MotifNumberArray):
         row_sum = data.sum(axis=axis)
         return data / numpy.vstack(row_sum) if axis is not None else data / row_sum
 
-    def to_freq_array(self, pseudocount: int = 0) -> "MotifFreqsArray":
+    def to_freq_array(self, pseudocount: int = 0) -> MotifFreqsArray:
         """
         Parameters
         ----------

--- a/tests/test_top_level_imports.py
+++ b/tests/test_top_level_imports.py
@@ -1,4 +1,6 @@
 import importlib
+import subprocess
+import sys
 
 import pytest
 
@@ -33,3 +35,36 @@ def test_toplevel_types(name, expected_type):
     """core return types are accessible as cogent3.<Type>"""
     attr = getattr(cogent3, name)
     assert isinstance(attr, expected_type), f"cogent3.{name} is not a {expected_type}"
+
+
+def test_profile_first_import_no_circular_error():
+    """Importing cogent3.core.profile first must not trigger a circular import."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import cogent3.core.profile"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"Importing cogent3.core.profile failed:\n{result.stderr}"
+    )
+
+
+def test_profile_import_then_make_seq():
+    """After importing profile first, MolType.make_seq must still work."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import cogent3.core.profile\n"
+            "from cogent3.core.moltype import DNA\n"
+            "seq = DNA.make_seq(seq='ACGT', name='t')\n"
+            "assert str(seq) == 'ACGT'\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"make_seq after profile-first import failed:\n{result.stderr}"
+    )


### PR DESCRIPTION
[CHANGED] MolType make_seq argument is now a string and
    resolved to a class on first usage. This allows us
    to avoid importing from sequence.py at runtime and thus
    the circular import.

## Summary by Sourcery

Address a circular import between moltype, sequence, and profile by deferring sequence class resolution in MolType and relaxing profile’s dependency on sequence.

Bug Fixes:
- Prevent circular import errors when importing cogent3.core.profile before using MolType.make_seq.

Enhancements:
- Allow MolType to accept sequence class names as strings and resolve them lazily on first use, enabling more flexible import ordering.
- Simplify core.profile’s imports and type hints to avoid runtime dependencies on sequence while preserving type checking.
- Add tests ensuring importing cogent3.core.profile and subsequently calling MolType.make_seq succeeds without errors.

Tests:
- Add subprocess-based tests verifying that importing cogent3.core.profile does not fail and that MolType.make_seq still works after a profile-first import.