### PR TITLE
MAINT: further harden against potential for circular imports

### DIFF
--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -50,7 +50,6 @@ from cogent3.core.location import (
     _LostSpan,
 )
 from cogent3.core.seqview import SeqView, SeqViewABC
-from cogent3.draw.drawable import Shape
 from cogent3.format.fasta import seqs_to_fasta
 from cogent3.maths.stats.number import CategoryCounter
 from cogent3.util.deserialise import register_deserialiser

--- a/src/cogent3/parse/cogent3_json.py
+++ b/src/cogent3/parse/cogent3_json.py
@@ -4,7 +4,6 @@ import json
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
-from cogent3.app import data_store
 from cogent3.util.deserialise import deserialise_object
 from cogent3.util.io import open_
 from cogent3.util.misc import get_object_provenance
@@ -27,10 +26,12 @@ def load_from_json(filename: "PathType", classes: Iterable[type]) -> Any:
         "classes should be a series of Cogent3 types, for example: (Alignment, SequenceCollection)"
     )
 
+    from cogent3.app.data_store import load_record_from_json
+
     with open_(filename) as f:
         content = json.loads(f.read())
     try:
-        _, data, completed = data_store.load_record_from_json(content)
+        _, data, completed = load_record_from_json(content)
         if not completed:
             msg = "json file is a record for type NotCompleted."
             raise TypeError(msg)

--- a/tests/test_top_level_imports.py
+++ b/tests/test_top_level_imports.py
@@ -68,3 +68,42 @@ def test_profile_import_then_make_seq():
     assert result.returncode == 0, (
         f"make_seq after profile-first import failed:\n{result.stderr}"
     )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "module",
+    [
+        "cogent3.core.alignment",
+        "cogent3.core.sequence",
+        "cogent3.core.tree",
+        "cogent3.core.table",
+        "cogent3.core.moltype",
+        "cogent3.core.profile",
+        "cogent3.evolve.models",
+        "cogent3.evolve.distance",
+        "cogent3.evolve.fast_distance",
+        "cogent3.evolve.parameter_controller",
+        "cogent3.align.pairwise",
+        "cogent3.align.progressive",
+        "cogent3.app",
+        "cogent3.app.io",
+        "cogent3.app.evo",
+        "cogent3.parse.fasta",
+        "cogent3.parse.genbank",
+        "cogent3.parse.cogent3_json",
+        "cogent3.draw.dotplot",
+        "cogent3.draw.dendrogram",
+        "cogent3.phylo.nj",
+        "cogent3.maths.optimisers",
+    ],
+)
+def test_no_circular_imports(module):
+    """Each subpackage must be importable in a fresh process without circular import errors."""
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"Importing {module} failed:\n{result.stderr}"


### PR DESCRIPTION
## Summary by Sourcery

Harden the package against circular import issues and verify top-level imports remain reliable across key submodules.

Enhancements:
- Refactor JSON parsing to rely on a localized import of the data store record loader, reducing circular import risk.

Tests:
- Add a slow parametrized test that imports key submodules in fresh processes to detect circular import failures.