### PR TITLE
DEP: replaced deserialise functions with scinexus ones

### DIFF
--- a/src/cogent3/util/deserialise.py
+++ b/src/cogent3/util/deserialise.py
@@ -1,9 +1,7 @@
-import json
-import re
 import warnings
-from collections.abc import Callable
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+
+from scinexus.deserialise import deserialise_object, register_deserialiser  # noqa: F401
 
 warnings.warn(
     "cogent3.util.deserialise is discontinued and will be removed in version 2026.9, "
@@ -11,45 +9,6 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from cogent3.util.io import PathType
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-_deserialise_func_map: dict[str, Callable[..., Any]] = {}
-
-
-class register_deserialiser:  # pragma: no cover
-    """
-    registration decorator for functions to inflate objects that were
-    serialised using json.
-
-    Functions are added to a dict which is used by the deserialise_object()
-    function. The type string(s) must uniquely identify the appropriate
-    value for the dict 'type' entry, e.g. 'cogent3.core.table.Table'.
-
-    Parameters
-    ----------
-    args: str or sequence of str
-        must be unique
-    """
-
-    def __init__(self, *args: str) -> None:
-        for type_str in args:
-            if not isinstance(type_str, str):
-                msg = f"{type_str!r} is not a string"
-                raise TypeError(msg)
-            assert type_str not in _deserialise_func_map, (
-                f"{type_str!r} already in {list(_deserialise_func_map)}"
-            )
-        self._type_str = args
-
-    def __call__(self, func: Callable[P, R]) -> Callable[P, R]:
-        for type_str in self._type_str:
-            _deserialise_func_map[type_str] = func
-        return func
 
 
 def get_class(provenance: str) -> type:  # pragma: no cover
@@ -60,56 +19,3 @@ def get_class(provenance: str) -> type:  # pragma: no cover
     klass = nc if nc in klass else klass
     mod = import_module(provenance[:index])
     return getattr(mod, klass)
-
-
-_pat = re.compile("[a-z]")
-
-
-def str_to_version(v):  # pragma: no cover
-    letter = _pat.search(v)
-    return tuple(f"{v[: letter.start()]}.{letter.group()}.{letter.end():}".split("."))
-
-
-def deserialise_object(
-    data: "PathType | str | dict[str, Any]",
-) -> Any:  # pragma: no cover
-    """
-    deserialises from json
-
-    Parameters
-    ----------
-    data
-        path to json file, json string or a dict
-
-    Returns
-    -------
-    If the dict from json.loads does not contain a "type" key, the object will
-    be returned as is. Otherwise, it will be deserialised to a cogent3 object.
-
-    Notes
-    -----
-    The value of the "type" key is used to identify the specific function for recreating
-    the original instance.
-    """
-    from scinexus.io_util import open_, path_exists
-
-    if path_exists(path := cast("PathType", data)):
-        with open_(path) as infile:
-            data = json.load(infile)
-
-    if isinstance(data, str):
-        data = json.loads(str(data))
-
-    data = cast("dict[str, Any]", data)
-    type_ = data.get("type", None) if hasattr(data, "get") else None
-    if type_ is None:
-        return data
-
-    for type_str, func in _deserialise_func_map.items():
-        if type_str in type_:
-            break
-    else:
-        msg = f"deserialising '{type_}' from json"
-        raise NotImplementedError(msg)
-
-    return func(data)

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -2210,7 +2210,6 @@ def test_group_by_iter():
 
 
 def test_group_by_repr():
-
     t = _make_group_table()
     gb = t.group_by("cat")
     r = repr(gb)

--- a/tests/test_top_level_imports.py
+++ b/tests/test_top_level_imports.py
@@ -41,6 +41,7 @@ def test_profile_first_import_no_circular_error():
     """Importing cogent3.core.profile first must not trigger a circular import."""
     result = subprocess.run(
         [sys.executable, "-c", "import cogent3.core.profile"],
+        check=False,
         capture_output=True,
         text=True,
         timeout=60,
@@ -61,6 +62,7 @@ def test_profile_import_then_make_seq():
             "seq = DNA.make_seq(seq='ACGT', name='t')\n"
             "assert str(seq) == 'ACGT'\n",
         ],
+        check=False,
         capture_output=True,
         text=True,
         timeout=60,
@@ -102,6 +104,7 @@ def test_no_circular_imports(module):
     """Each subpackage must be importable in a fresh process without circular import errors."""
     result = subprocess.run(
         [sys.executable, "-c", f"import {module}"],
+        check=False,
         capture_output=True,
         text=True,
         timeout=60,


### PR DESCRIPTION
[CHANGED] avoids errors from mismatch of registration dicts

## Summary by Sourcery

Replace custom JSON deserialisation utilities with external scinexus-based implementation and adjust related tests.

Bug Fixes:
- Prevent deserialisation errors caused by mismatched registration dictionaries by relying on scinexus deserialisation utilities instead of a local registry.

Enhancements:
- Remove obsolete deserialiser registry and helper functions from the deserialise utility module.
- Relax subprocess.run test invocations to not raise exceptions on non-zero exit codes while still capturing output for assertions.