### PR TITLE
More changes in scinexus migration

### DIFF
--- a/doc/app/app_overview/app-overview.rst
+++ b/doc/app/app_overview/app-overview.rst
@@ -13,12 +13,14 @@ What are apps?
 
 Apps are ready-made "functions" that you can apply to your data without needing to know all the technical details. They are easy to use, even if you're not an expert programmer. Multiple apps can be naturally composed into "pipelines", which are fully equipped for robust and reproducible application to data. In fact, apps and app pipelines can be applied to a single, or thousands, of data file(s) without writing loops or conditionals.
 
-Apps have several key features, they:
+The composable app infrastructure is provided by the `scinexus <https://pypi.org/project/scinexus/>`_ package. See the scinexus documentation for details on composability rules, type checking, batch processing, parallel execution, and progress tracking.
 
-#. trap errors
-#. check the validity of input data
-#. can be used by themselves or combined into a "composed" app (aka pipeline)
-#. automatically track the relationship between an input data record and its output record
+.. todo::
+
+    Link to scinexus composable apps documentation once available.
+
+..
+    Placeholder: <scinexus composable apps docs URL>
 
 .. _app_start:
 
@@ -31,9 +33,9 @@ Three top-level functions are very useful:
 - ``app_help()`` shows what a given app can do (see :ref:`app_help`)
 - ``get_app()`` returns an app instance for you to use (see :ref:`get_app`)
 
-Two other crucial concepts concern: 
+Two other crucial concepts concern:
 
-- :ref:`data stores <data_stores>` and 
+- :ref:`data stores <data_stores>` and
 - :ref:`tracking failures <not_completed>`
 
 .. _app_types:
@@ -49,55 +51,13 @@ There are 3 types of apps:
 
 As their names imply, loaders load, writers write and generic apps do other operations on data.
 
-.. _app_composability:
-
-Composability
--------------
-
-Most ``cogent3`` apps are "composable", meaning that multiple apps can be combined into a single function by addition. For example, say we have an app (``fit_model``) that performs a molecular evolutionary analysis on an alignment, and another app (``extract_stats``) that gets the statistics from the result. We could perform these steps sequentially as follows
-
-.. code-block:: python
-
-    fitted = fit_model(alignment)
-    stats = extract_stats(fitted)
-
-Composability allows us to simplify this as follows
-
-.. code-block:: python
-
-    app = fit_model + extract_stats
-    stats = app(fitted)
-
-We can have many more apps in a composed function than just the two shown here.
-
-.. _composability_rules:
-
-Composability rules
-^^^^^^^^^^^^^^^^^^^
-
-There are rules around app composition, starting with app types. Loaders and writers are special cases. If included, a loader must always be first, e.g.
-
-.. code-block:: python
-
-    app = a_loader + a_generic
-
-If included, a writer must always be last, e.g.
-
-.. code-block:: python
-
-    app = a_generic + a_writer
-
-Changing the order for either of the above will result in a ``TypeError``.
-
-The next constraint on app composition are the input and output types of the apps involved. Specifically, apps define the type of input they work on and the type of output they produce. For two apps to be composed, the output (or return) type of app on the left (e.g. ``a_loader``) must overlap with the input type of the app on the right (e.g. ``a_generic``). If they don't match, a ``TypeError`` is raised.
-
 An example
 ----------
 
 .. jupyter-execute::
     :hide-code:
 
-    
+
     from tempfile import TemporaryDirectory
 
     tmpdir = TemporaryDirectory(dir=".")
@@ -153,56 +113,6 @@ To apply a composed function to multiple files requires a :ref:`data store <data
     result = process.apply_to(dstore)
 
 .. note:: ``result`` is ``out_dstore``.
-
-Other important features
-------------------------
-
-The settings and data analysed will be logged
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-A log file will be written into the same data store as the output. The log includes information on the conditions under which the analysis was run and fingerprint all input and output files.
-
-.. jupyter-execute::
-
-    out_dstore.summary_logs
-
-Failures are recorded
-^^^^^^^^^^^^^^^^^^^^^
-
-Any "failures" (see :ref:`not_completed`) are saved. The data store class provides methods for interrogating those. First, a general summary of the output data store indicates we have 6 records that did not complete.
-
-.. jupyter-execute::
-
-    out_dstore.describe
-
-These occur for this example primarily because some of the files contain sequences that are not aligned
-
-.. jupyter-execute::
-
-    out_dstore.summary_not_completed
-
-You can track progress
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. jupyter-execute::
-
-    result = process.apply_to(dstore, show_progress=True)
-
-You can do parallel computation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-    result = process.apply_to(dstore, parallel=True)
-
-By default, this will use all available processors on your machine. (See :ref:`parallel` for more details plus how to take advantage of multiple machines using MPI.)
-
-All of the above
-^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-    process.apply_to(dstore, parallel=True, show_progress=True)
 
 .. jupyter-execute::
     :hide-code:

--- a/doc/app/app_overview/dstore.rst
+++ b/doc/app/app_overview/dstore.rst
@@ -1,311 +1,69 @@
-.. jupyter-execute::
-    :hide-code:
-
-    import set_working_directory
-
 .. _data_stores:
 
 Data stores -- collections of data records
 ==========================================
 
+Data stores are provided by the `scinexus <https://pypi.org/project/scinexus/>`_ package. A :index:`data store` is a collection of data members of the same type (e.g. all ``.fasta`` files in a directory). Data stores allow you to apply an app or composed pipeline to many data records without writing loops.
 
-If you download :download:`raw.zip <data/raw.zip>` and unzip it, you will see it contains 1,035 files ending with a ``.fa`` filename suffix. (It also contains a tab delimited file and a log file, which we ignore for now.) The directory ``raw`` is a "data store" and the ``.fa`` files are "members" of it. In summary, a :index:`data store` is a collection of members of the same "type". This means we can apply the same application to every member.
+.. todo::
 
-How do I use a data store?
---------------------------
+    Link to scinexus data store documentation once available.
 
-A data store is just a "container". To open a data store you use the ``open_data_store()`` function. To load the data for a member of a data store you need an appropriately selected :ref:`loader <app_types>` type of app.
+..
+    Placeholder: <scinexus data store docs URL>
 
-Types of data store
--------------------
-
-.. csv-table::
-    :header: "Class Name", "Supported Operations", "Supported Data Types", "Identifying Suffix"
-
-    ``DataStoreDirectory``, "read / write / append", text, None
-    ``ReadOnlyDataStoreZipped``, read, text, ``.zip``
-    ``DataStoreSqlite``, "read, write, append", "text or bytes", ``.sqlitedb``
-
-.. note:: The ``ReadOnlyDataStoreZipped`` is just a compressed ``DataStoreDirectory``.
-
-The structure of data stores
-----------------------------
-
-If a directory was not created by ``cogent3`` as a ``DataStoreDirectory`` then it has only the structure that existed previously.
-
-If a data store was created by ``cogent3``, either as a directory or as a ``sqlitedb``, then it contains four types of data: completed records, *not* completed records, log files and md5 files. In a ``DataStoreDirectory``, these are organised using the file system. The :index:`completed members` are valid data records (as distinct from :ref:`not completed <not_completed>`) and are at the top level. The remaining types are in subdirectories.
-
-::
-
-    demo_dstore
-    ├── logs
-    ├── md5
-    ├── not_completed
-    └── ... <the completed members>
-
-``logs/`` stores scitrack_ log files produced by ``cogent3.app`` writer apps. ``md5/`` stores plain text files with the md5 sum of a corresponding data member which are used to check the integrity of the data store.
-
-The ``DataStoreSqlite`` stores the same information, just in SQL tables.
-
-.. _scitrack: https://github.com/HuttleyLab/scitrack
-
-Supported operations on a data store
-------------------------------------
-
-All data store classes can be iterated over, indexed, checked for membership. These operations return a ``DataMember`` object. In addition to providing access to members, the data store classes have convenience methods for describing their contents and providing summaries of log files that are included and of the ``NotCompleted`` members (see :ref:`not_completed`).
-
-Opening a data store
---------------------
-
-Use the :index:`open_data_store()` function, illustrated below. Use the mode argument to identify whether to open as read only (``mode="r"``), write (``mode=w``) or append(``mode="a"``).
-
-Opening a read only data store
+Using data stores with cogent3
 ------------------------------
 
-We open the zipped directory described above, defining the filenames ending in ``.fa`` as the data store members. All files within the directory become members of the data store (unless we use the ``limit`` argument).
-
-.. jupyter-execute::
-
-    from cogent3 import open_data_store
-
-    dstore = open_data_store("data/raw.zip", suffix="fa", mode="r")
-    print(dstore)
-
-Summarising the data store
---------------------------
-
-The ``.describe`` property demonstrates that there are only completed members.
-
-.. jupyter-execute::
-
-    dstore.describe
-
-.. _data_member:
-
-Data store “members”
---------------------
-
-Get one member
-^^^^^^^^^^^^^^
-
-You can index a data store like other Python series, in the folowing case the first member.
-
-.. jupyter-execute::
-
-    m = dstore[0]
-    m
-
-Looping over a data store
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This gives you one member at a time.
-
-.. jupyter-execute::
-
-    for m in dstore[:5]:
-        print(m)
-
-Members can read their own data
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. jupyter-execute::
-
-    m.read()[:20] # truncating
-
-.. note:: For a ``DataStoreSqlite`` member, the default data storage format is bytes. So reading the content of an individual record is best done using the ``load_db`` app.
-
-Making a writeable data store
------------------------------
-
-The creation of a writeable data store is specified with ``mode="w"``, or (to append) ``mode="a"``. In the former case, any existing records are overwritten. In the latter case, existing records are ignored.
-
-``DataStoreSqlite`` stores serialised data
-------------------------------------------
-
-When you specify a Sqlitedb data store as your output (by using ``open_data_store()``) you write multiple records into a single file making distribution easier.
-
-One important issue to note is the process which creates a Sqlitedb “locks” the file. If that process exits unnaturally (e.g. the run that was producing it was interrupted) then the file may remain in a locked state. If the db is in this state, ``cogent3`` will not modify it unless you explicitly unlock it.
-
-This is represented in the display as shown below.
-
-.. jupyter-execute::
-
-    dstore = open_data_store("data/demo-locked.sqlitedb")
-    dstore.describe
-
-To unlock, you execute the following:
-
-.. jupyter-execute::
-
-    dstore.unlock(force=True)
-
-Interrogating run logs
-----------------------
-
-If you use the ``apply_to()`` method, a scitrack_ logfile will be stored in the data store. This includes useful information regarding the run conditions that produced the contents of the data store.
-
-.. jupyter-execute::
-
-    dstore.summary_logs
-
-Log files can be accessed vial a special attribute.
-
-.. jupyter-execute::
-
-    dstore.logs
-
-Each element in that list is a ``DataMember`` which you can use to get the data contents.
-
-.. jupyter-execute::
-
-    print(dstore.logs[0].read()[:225]) # truncated for clarity
-
-.. _data_store_citations:
-
-Citations -- attributing the tools that produced your results
--------------------------------------------------------------
-
-When apps declare citations (see :ref:`app_citations`), those citations are automatically saved alongside your results when you use ``apply_to()``.
-
-.. jupyter-execute::
-
-    from citeable import Software
-    from cogent3 import get_app, open_data_store
-    from cogent3.app.composable import define_app
-    from cogent3.app.typing import AlignedSeqsType
-
-    my_cite = Software(
-        author=["Doe, J"],
-        title="My Sequence Filter",
-        year=2025,
-    )
-
-    @define_app(cite=my_cite)
-    def strict_filter(val: AlignedSeqsType) -> AlignedSeqsType:
-        return val.omit_bad_seqs()
-
-    in_dstore = open_data_store("data/raw.zip", suffix="fa", limit=5)
-    out_dstore = open_data_store("cited_results", suffix="fa", mode="w")
-
-    loader = get_app("load_aligned", moltype="dna", format_name="fasta")
-    writer = get_app("write_seqs", data_store=out_dstore, format_name="fasta")
-    process = loader + strict_filter() + writer
-    result = process.apply_to(in_dstore)
-
-The ``summary_citations`` property returns a table of all citations stored in the data store.
-
-.. jupyter-execute::
-
-    result.summary_citations
-
-You can export the citations to a BibTeX file with ``write_bib()``.
-
-.. jupyter-execute::
-
-    result.write_bib("my_analysis.bib")
+Use the ``open_data_store()`` function to open a data store and a :ref:`loader <app_types>` app to read member data.
 
 .. jupyter-execute::
     :hide-code:
 
-    import pathlib
-    print(pathlib.Path("my_analysis.bib").read_text())
+    import set_working_directory
+
+.. jupyter-execute::
+
+    from cogent3 import get_app, open_data_store
+
+    dstore = open_data_store("data/raw.zip", suffix="fa", mode="r")
+    print(dstore)
+
+.. jupyter-execute::
+
+    loader = get_app("load_unaligned", moltype="dna")
+    seqs = loader(dstore[0])
+    seqs
+
+.. _data_member:
+
+Applying a pipeline to a data store
+------------------------------------
+
+.. jupyter-execute::
+    :hide-code:
+
+    from tempfile import TemporaryDirectory
+
+    tmpdir = TemporaryDirectory(dir=".")
+    path_to_dir = tmpdir.name
+
+.. jupyter-execute::
+
+    out_dstore = open_data_store(path_to_dir, suffix="fa", mode="w")
+    loader = get_app("load_aligned", moltype="dna", format_name="fasta")
+    take3 = get_app("take_codon_positions", 3)
+    writer = get_app("write_seqs", data_store=out_dstore, format_name="fasta")
+    app = loader + take3 + writer
+    result = app.apply_to(dstore)
+    result.describe
 
 .. jupyter-execute::
     :hide-code:
 
     import shutil
-    pathlib.Path("my_analysis.bib").unlink()
-    shutil.rmtree("cited_results")
+    shutil.rmtree(path_to_dir, ignore_errors=True)
 
-.. note::
+.. _data_store_citations:
 
-    ``ReadOnlyDataStoreZipped`` supports reading stored citations but
-    not writing them.
-
-Pulling it all together
-=======================
-
-We will translate the DNA sequences in ``raw.zip`` into amino acid and store them as sqlite database. We will interrogate the generated data store to gtet a synopsis of the results.
-
-Defining the data stores for analysis
--------------------------------------
-
-Loading our input data
-
-.. jupyter-execute::
-
-    from cogent3 import open_data_store
-
-    in_dstore = open_data_store("data/raw.zip", suffix="fa")
-
-Creating our output ``DataStoreSqlite``
-
-.. jupyter-execute::
-
-    out_dstore = open_data_store("translated.sqlitedb", mode="w")
-
-Create an app and apply it
---------------------------
-
-We need apps to load the data, translate it and then to write the translated sequences out. We define those and compose into a single app.
-
-.. jupyter-execute::
-
-    from cogent3 import get_app
-
-    load = get_app("load_unaligned", moltype="dna")
-    translate = get_app("translate_seqs")
-    write = get_app("write_db", data_store=out_dstore)
-    app = load + translate + write
-    app
-
-We apply the app to all members of ``in_dstore``. The results will be written to ``out_dstore``.
-
-.. jupyter-execute::
-
-    out_dstore = app.apply_to(in_dstore)
-
-Inspecting the outcome
-----------------------
-
-The ``.describe`` method gives us an analysis level summary.
-
-.. jupyter-execute::
-
-    out_dstore.describe
-
-We confirm the data store integrity
-
-.. jupyter-execute::
-
-    out_dstore.validate()
-
-We can examine why some input data could not be processed by looking at the summary of the not completed records.
-
-.. jupyter-execute::
-
-    out_dstore.summary_not_completed
-
-We see they all came from the ``translate_seqs`` step. Some had a terminal stop codon while others had a length that was not divisible by 3.
-
-.. note::
-    
-    The ``.completed`` and ``.not_completed`` attributes give access to the different types of members while the ``.members`` attribute gives them all. For example,
-
-    .. jupyter-execute::
-
-        len(out_dstore.not_completed)
-
-    is the same as in the ``describe`` output and each element is a ``DataMember``.
-
-    .. jupyter-execute::
-
-        out_dstore.not_completed[:2]
-
-.. jupyter-execute::
-    :hide-code:
-
-    import pathlib
-
-    fn = pathlib.Path("translated.sqlitedb")
-    fn.unlink()
+See the scinexus documentation for full details on data store types, structure, operations, locking, logging, and citations.

--- a/doc/app/app_overview/not-completed.rst
+++ b/doc/app/app_overview/not-completed.rst
@@ -1,24 +1,26 @@
+.. _not_completed:
+
+Tracking records that could not be processed
+=============================================
+
+``NotCompleted`` is a special result type provided by the `scinexus <https://pypi.org/project/scinexus/>`_ package. Apps return a ``NotCompleted`` result when a condition is not met (``FALSE`` type) or an unexpected error occurs (``ERROR`` type). These objects evaluate to ``False``, carry information about the failure, and propagate through composed pipelines so that subsequent steps are skipped.
+
+.. todo::
+
+    Link to scinexus NotCompleted documentation once available.
+
+..
+    Placeholder: <scinexus NotCompleted docs URL>
+
+A cogent3 example
+-----------------
+
 .. jupyter-execute::
     :hide-code:
 
     import set_working_directory
 
-Tracking records that could not be processed
-============================================
-
-.. _not_completed:
-
-The ``NotCompleted`` object
----------------------------
-
-``NotCompleted`` is a special result type that can be produced by a composable app. These objects evaluate to ``False``.
-
-An app can return a ``NotCompleted`` result for one of 2 reasons. The object contains information regarding the input data, where the issue arose and whatever message was provided by the code (like an exception traceback).
-
-``NotCompleted`` FALSE type
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The results when a condition was not met. For example, below I create an app that will return alignments with 2 specific sequences. I'm applying this to a data set where a "Mouse" sequence does not exist. This will produce a FALSE type.
+Below, an app that selects specific sequences returns a ``NotCompleted`` because the requested sequence ``"Mouse"`` does not exist in the primate data set.
 
 .. jupyter-execute::
 
@@ -49,31 +51,13 @@ and the reason for the failure
 
     result.message
 
-
-``NotCompleted`` ERROR type
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An ``ERROR`` type is returned if an unexpected condition occurs. This can be an exception raised during the calculation. In our example, we illustrate this by trying to open a file with an incorrect path.
-
-.. jupyter-execute::
-
-    result = reader("primate_brca1.fasta")
-    result
-
 Composed functions propagate ``NotCompleted`` results
 -----------------------------------------------------
 
-If you have a composed function, with multiple steps and an error occurs then the resulting ``NotCompleted`` result is returned without any of the other steps being applied to it. For example, we make a composed app from both of the above apps.
+If you have a composed function and an error occurs, the ``NotCompleted`` result is returned without any subsequent steps being applied.
 
 .. jupyter-execute::
 
     app = reader + select_seqs
     result = app("data/primate_brca1.fasta")
-    result
-
-and
-
-.. jupyter-execute::
-
-    result = app("primate_brca1.fasta")
     result

--- a/doc/app/index-custom.rst
+++ b/doc/app/index-custom.rst
@@ -1,7 +1,7 @@
 Custom Apps
 ===========
 
-You can write your own apps.
+You can write your own apps using the ``define_app`` decorator from the `scinexus <https://pypi.org/project/scinexus/>`_ package. The examples below show how to use it with cogent3 data types.
 
 .. toctree::
     :maxdepth: 1

--- a/doc/app/user_function.rst
+++ b/doc/app/user_function.rst
@@ -1,98 +1,38 @@
-Why write apps?
-===============
-
-Cogent3 apps solve several problems. Here are just a few.
-
-.. dropdown:: **An analysis that requires multiple apps can be composed into a single process.**
-
-    Defining and using composed apps is simple, and the code is easier to read and check. Compare using a "composed" app, made up of three separate apps
-
-    .. code-block:: python
-
-        # making a composed
-        my_steps = step_1 + step_2 + step_3
-        step_3_output = my_steps(step_1_input)
-
-    to using each app in order.
-
-    .. code-block:: python
-
-        step_1_output = step_1(step_1_input)
-        step_2_output = step_2(step_1_output)
-        step_3_output = step_3(step_2_input)
-
-.. dropdown:: **Applying a process to multiple data records can be done without looping.**
-
-    Cogent3 :ref:`data stores <data_stores>` simplify selecting data for analysis and can be applied for batch execution by an app.
-
-    .. code-block:: python
-
-        step_1_inputs = open_data_store("path/to/seqs", suffix="fasta")
-        results = list(my_steps.as_completed(step_1_inputs))
-
-.. dropdown:: **Distributing your app as a Cogent3 plugin reduces the learning curve for users.**
-
-    Cogent3 provides mechanisms for discovering your app, getting help on it with an example of how to use it. This mechanism is the same for all apps, which means users do not need to know the structure of your package (see the :ref:`app overview <app_start>`).
-
-.. dropdown:: **The app infrastructure comes with freebies!**
-
-    When used as part of a composed function, they automatically provide logging. Composed apps can record run failures (everyone encounters bad data ☹️) and make it easier to see how much of an analysis was affected. They also greatly simplify running analyses in parallel. 
-
-.. dropdown:: **Apps are seriously easy to write!**
-
-    Read on to see just how easy they are. In summary, just two lines of code extra plus two extra lines in your projects' `pyproject.toml`, and you have everything you need to distribute your app.
-
-    Use the `cogent3 app cookiecutter template <https://github.com/cogent3/app_template>`_ to get a head start.
+.. _custom_apps:
 
 Writing your own apps
 =====================
 
-Consider the case where you have a directory of files with the same format. You want to apply a consistent procedure to each file separately and produce a corresponding output. If one of the files is incompatible with the calculations, you want to record that and continue processing the rest. This is the use case for which Cogent3 apps are designed. By building your own apps, you can easily incorporate them as a part of a more substantial algorithm. You also get invaluable capabilities such as automated logging and simplifying their execution in parallel.
+The app infrastructure is provided by the `scinexus <https://pypi.org/project/scinexus/>`_ package. See the scinexus documentation for full details on ``define_app``, app types, handling ``NotCompleted``, and citations.
 
-To write a Cogent3 app, you must make some decisions. What type of processing will your app do? What data type(s) will it accept as input? What data type will it produce as output? Do you need to deal with data that doesn't satisfy a condition?
+.. todo::
 
-Defining apps is achieved with the ``define_app``  decorator. Below, we describe the different configuration options and give three examples of writing apps.
+    Link to scinexus custom app documentation once available.
 
-.. dropdown:: Specifying the type of app
+..
+    Placeholder: <scinexus custom app docs URL>
 
-    The :ref:`supported app types <app_types>` are indicated by the ``AppType`` enum
+Below are cogent3-specific examples showing how to write apps that work with cogent3 data types.
 
-    .. jupyter-execute::
+.. _app_types_custom:
 
-        from cogent3.app.composable import AppType
+Available cogent3 types
+-----------------------
 
-        list(AppType)
+You can use existing type hints if your function takes or returns ``cogent3`` types.
 
-    The decorator has a default value of ``"generic"``. This means that the app does data transformation and does not, for example, load data from disk or write data to disk (those are the ``loader`` and ``writer`` types).
+.. jupyter-execute::
 
-    If your application is not intended to be applied sequentially, before or after other cogent3 apps, to a series of independent data records of the same type, then you set ``define_app(app_type=AppType.NON_COMPOSABLE)`` (or equivalently ``define_app(app_type="non_composable")``).
-    
-    .. note:: Non-composable apps cannot be added (or composed) with other apps.
+    from cogent3.app.typing import defined_types
 
-.. dropdown:: Handling not completed values
+    defined_types()
 
-    Cogent3 apps are designed to handle conditions under which data cannot be completely processed. For example, any errors during execution are stored in a :ref:`not completed <not_completed>` object (``NotCompleted``). All subsequent steps are skipped whenever an app returns a ``NotCompleted`` object.
-
-    These objects can also be used to stop the processing of a particular data record. For example, say you're writing an application that requires sequences to have some minimum length. If an input sequence is shorter than this, then you can create a :ref:`not completed <not_completed>` object and return it. This prevents any future processing, but the reasons for the failure (which you get to specify) can be saved for future reference.
-
-    You may want access to ``NotCompleted`` instances if, for example, you are developing an ``AppType.WRITER``. You can allow your code to "see" them with ``define_app(skip_not_completed=False)``.
-
-.. dropdown:: Supported cogent3 types
-
-    You can use the existing type hints if your function takes or returns ``cogent3`` types. To see these, use the ``defined_types()`` function.
-
-    .. jupyter-execute::
-
-        from cogent3.app.typing import defined_types
-
-        defined_types()
-
-    .. note:: You don't have to use cogent3 types. You can also use standard python types.
+.. note:: You don't have to use cogent3 types. You can also use standard Python types.
 
 Defining a cogent3 app from a function
 --------------------------------------
 
-We will write a function that takes a Cogent3 alignment and returns the first *n* positions where the user defines *n*.
+We write a function that takes a cogent3 alignment and returns the first *n* positions.
 
 .. jupyter-execute::
 
@@ -103,12 +43,10 @@ We will write a function that takes a Cogent3 alignment and returns the first *n
     def n_positions(val: AlignedSeqsType, n=2) -> AlignedSeqsType:
         return val[:n]
 
-The critical elements of a function being defined as an app are:
+The critical elements are:
 
 1. The ``define_app`` decorator is used.
 2. Type hints are specified for the function's first argument and its return type.
-
-.. note: Currently, your function can only have one required argument. It can have any number of optional arguments.
 
 .. dropdown:: Using the custom app
 
@@ -132,7 +70,7 @@ The critical elements of a function being defined as an app are:
         result
 
 Defining a cogent3 app from a class
------------------------------------
+------------------------------------
 
 .. jupyter-execute::
 
@@ -147,11 +85,11 @@ Defining a cogent3 app from a class
         def main(self, val: AlignedSeqsType) -> AlignedSeqsType:
             return val[:self.n]
 
-The critical elements of a class being defined as an app are:
+The critical elements are:
 
 1. The ``define_app`` decorator is used.
 2. The class has a ``main()`` method.
-3. Type hints are specified for the ``main()`` methods first argument and its return type.
+3. Type hints are specified for the ``main()`` method's first argument and its return type.
 
 .. dropdown:: Using the custom app
 
@@ -166,41 +104,6 @@ The critical elements of a class being defined as an app are:
         result = first4(aln)
         result
 
-Custom apps for standard python types
--------------------------------------
-
-In this example, we have two apps that process pure Python types only.
-
-.. jupyter-execute::
-
-    from cogent3.app.composable import define_app
-
-    @define_app
-    def lower(arg: str | bytes) -> str | bytes:
-        return arg.lower()
-
-    @define_app
-    def space(arg: str | bytes) -> str | bytes:
-        sep = " " if isinstance(arg, str) else b" "
-        arg = arg.split()
-        return sep.join(arg)
-
-The only difference to the above examples is we use standard python types for the type hints.
-
-.. dropdown:: Using the two apps
-
-    We create a composed app and apply it.
-    
-    .. jupyter-execute::
-
-        app = lower() + space()
-        app
-
-    .. jupyter-execute::
-
-        app(b"HELLO   there")
-
-
 App naming conventions
 ----------------------
 
@@ -210,8 +113,8 @@ If you will make your app available on the Python package index, we recommend pr
 
 .. _app_citations:
 
-Add a citation to your app so users can acknowledge your work
--------------------------------------------------------------
+Add a citation to your app
+---------------------------
 
 Correctly attributing the authors of algorithms and software is a requirement of good scientific practice. cogent3 makes this easy by letting app authors declare citations that are automatically tracked through composed pipelines.
 
@@ -235,12 +138,6 @@ Use the ``cite`` parameter of ``define_app`` to attach a citation to your own ap
     def strict_filter(val: AlignedSeqsType) -> AlignedSeqsType:
         """Remove sequences shorter than the alignment."""
         return val.omit_bad_seqs()
-
-The ``.app`` attribute on the citation is set automatically to the class name (but this can be over-ridden internally if a citation is assigned to multiple apps).
-
-.. jupyter-execute::
-
-    my_cite.app
 
 The ``.citations`` property on an app instance returns its citations as a tuple.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "charset_normalizer",
     "citeable",
-    "loky!=3.5.0",
-    # prevent release candidate of numpy 2.4 
+    # prevent release candidate of numpy 2.4
     # until numba modified to handle removal
     # of numpy.trapz
     "numpy<2.5",
@@ -31,7 +30,7 @@ dependencies = [
     "numba>=0.61.0; python_version=='3.13'",
     "numba>=0.63.0rc1; python_version=='3.14'",
     "scipy",
-    "scinexus",
+    "scinexus[loky]",
     "stevedore",
     "tqdm",
     "typeguard>=4.0,<5",

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -17,6 +17,7 @@ from cogent3._version import __version__
 if typing.TYPE_CHECKING:  # pragma: no cover
     import numpy
     import numpy.typing as npt
+    from scinexus.progress import Progress
 
     from cogent3.core.alignment import Alignment, SequenceCollection
     from cogent3.core.annotation_db import AnnotationDbABC
@@ -163,7 +164,7 @@ def _load_files_to_unaligned_seqs(
     label_to_name: Callable | None = None,
     parser_kw: dict | None = None,
     info: dict | None = None,
-    show_progress: bool = False,
+    show_progress: "bool | Progress | dict[str, typing.Any]" = False,  # type: ignore[type-arg]
     **kwargs: typing.Any,  # noqa: ANN401
 ) -> "SequenceCollection":
     """loads multiple files and returns as a sequence collection"""
@@ -171,7 +172,11 @@ def _load_files_to_unaligned_seqs(
 
     from cogent3.core.alignment import make_unaligned_seqs
 
-    progress = get_progress(show_progress)
+    progress = (
+        get_progress(show_progress=True, **show_progress)
+        if isinstance(show_progress, dict)
+        else get_progress(show_progress)
+    )
     file_names = list(path.parent.glob(path.name))
     seqs = [
         load_seq(

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Callable
 from importlib import import_module
 
-from scinexus import open_, open_data_store  # noqa: F401
+from scinexus import open_, open_data_store, set_parallel_backend  # noqa: F401
 
 from cogent3._version import __version__
 
@@ -27,6 +27,8 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 __copyright__ = "Copyright 2007-date, The Cogent Project"
 __credits__ = "https://github.com/cogent3/cogent3/graphs/contributors"
 __license__ = "BSD-3"
+
+set_parallel_backend("loky")
 
 
 def __getattr__(name: str) -> typing.Any:  # noqa: ANN401

--- a/src/cogent3/align/progressive.py
+++ b/src/cogent3/align/progressive.py
@@ -1,4 +1,6 @@
-from scinexus.progress import get_progress
+from typing import Any
+
+from scinexus.progress import Progress, get_progress
 
 from cogent3 import get_app, get_model, make_unaligned_seqs
 from cogent3.core import alignment as c3_alignment
@@ -16,7 +18,7 @@ def tree_align(
     tree: PhyloNode | None = None,
     indel_rate: float = 1e-10,
     indel_length: float = 1e-1,
-    show_progress: bool = False,
+    show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
     params_from_pairwise: bool = True,
     param_vals: dict | None = None,
     iters: int | None = None,
@@ -125,7 +127,11 @@ def tree_align(
     fix_lengths = get_app("scale_branches", nuc_to_codon=num_states >= 60)
     tree = fix_lengths(tree)
 
-    progress = get_progress(show_progress)
+    progress = (
+        get_progress(show_progress=True, **show_progress)
+        if isinstance(show_progress, dict)
+        else get_progress(show_progress)
+    )
     ctx = progress.context(msg="Doing progressive alignment")
     ctx.update(progress=0.0, msg="Doing progressive alignment")
     # this is the point at which we do the iterations

--- a/src/cogent3/app/evo.py
+++ b/src/cogent3/app/evo.py
@@ -1,9 +1,12 @@
 import contextlib
 from collections.abc import Callable, Iterable
 from copy import deepcopy
-from typing import Union
+from typing import TYPE_CHECKING, Any, Union
 
 from scinexus import get_id_from_source, parallel
+
+if TYPE_CHECKING:  # pragma: no cover
+    from scinexus.progress import Progress
 from scinexus.composable import ComposableApp, NotCompleted
 from scinexus.io_util import path_exists
 
@@ -76,7 +79,7 @@ class model(ComposableApp, cite=cite_cogent3):
         lower: float = 1e-6,
         upper: float = 50,
         split_codons: bool = False,
-        show_progress: bool = False,
+        show_progress: "bool | Progress | dict[str, Any]" = False,  # type: ignore[type-arg]
         verbose: bool = False,
     ) -> None:
         """
@@ -729,7 +732,7 @@ class natsel_neutral(ComposableApp, cite=cite_cogent3):
         optimise_motif_probs=False,
         lf_args=None,
         opt_args=None,
-        show_progress=False,
+        show_progress: "bool | Progress | dict[str, Any]" = False,  # type: ignore[type-arg]
         verbose=False,
     ) -> None:
         """
@@ -838,7 +841,7 @@ class natsel_zhang(ComposableApp, cite=cite_cogent3):
         lf_args=None,
         upper_omega=20,
         opt_args=None,
-        show_progress=False,
+        show_progress: "bool | Progress | dict[str, Any]" = False,  # type: ignore[type-arg]
         verbose=False,
     ) -> None:
         """
@@ -1041,7 +1044,7 @@ class natsel_sitehet(ComposableApp, cite=cite_cogent3):
         upper_omega=20.0,
         lf_args=None,
         opt_args=None,
-        show_progress=False,
+        show_progress: "bool | Progress | dict[str, Any]" = False,  # type: ignore[type-arg]
         verbose=False,
     ) -> None:
         """
@@ -1206,7 +1209,7 @@ class natsel_timehet(ComposableApp, cite=cite_cogent3):
         lf_args=None,
         upper_omega=20,
         opt_args=None,
-        show_progress=False,
+        show_progress: "bool | Progress | dict[str, Any]" = False,  # type: ignore[type-arg]
         verbose=False,
     ) -> None:
         """

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -29,7 +29,7 @@ import numpy.typing as npt
 from scinexus.deserialise import register_deserialiser
 from scinexus.io_util import atomic_write, get_format_suffixes
 from scinexus.misc import extend_docstring_from, get_object_provenance
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 from typing_extensions import override
 
 import cogent3
@@ -681,7 +681,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
         title: str | None = None,
         rc: bool = False,
         biotype: str | tuple[str] | None = None,
-        show_progress: bool = False,
+        show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
     ) -> Dotplot | AnnotatedDrawable:
         """make a dotplot between two sequences.
 
@@ -2132,7 +2132,7 @@ class SequenceCollection(CollectionBase[c3_sequence.Sequence]):
         background: NumpyFloatArrayType | None = None,
         pseudocount: int = 0,
         names: list[str] | str | None = None,
-        show_progress: bool = False,
+        show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
     ) -> NumpyFloatArrayType:
         """scores sequences using the specified pssm
 
@@ -2170,7 +2170,11 @@ class SequenceCollection(CollectionBase[c3_sequence.Sequence]):
         assert set(pssm.motifs) == set(self.moltype)
 
         seqs = [self.seqs[n] for n in names] if names else self.seqs
-        progress = get_progress(show_progress)
+        progress = (
+            get_progress(show_progress=True, **show_progress)
+            if isinstance(show_progress, dict)
+            else get_progress(show_progress)
+        )
         result = [pssm.score_seq(seq) for seq in progress(seqs, msg="Scoring")]
 
         return numpy.array(result)
@@ -4576,7 +4580,7 @@ class Alignment(CollectionBase[Aligned]):
         stat: str = "nmi",
         segments: list[tuple[int, int]] | None = None,
         drawable: str | None = None,
-        show_progress: bool = False,
+        show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
         parallel: bool = False,
         par_kw: dict[str, Any] | None = None,
     ) -> DictArray:

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -29,7 +29,7 @@ from scinexus import warning as snx_warn
 from scinexus.deserialise import deserialise_object, register_deserialiser
 from scinexus.io_util import get_format_suffixes, iter_line_blocks
 from scinexus.misc import extend_docstring_from, get_object_provenance
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 from cogent3._version import __version__
 from cogent3.core.location import Strand, deserialise_map_spans
@@ -3130,7 +3130,11 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
         # Get progress display
         show_progress = kwargs.pop("show_progress", False)
         kwargs.pop("ui", None)  # remove legacy ui kwarg
-        progress = get_progress(show_progress)
+        progress = (
+            get_progress(show_progress=True, **show_progress)
+            if isinstance(show_progress, dict)
+            else get_progress(show_progress)
+        )
         series = progress(paths, msg="Loading annotations")
 
         # Process each file, passing db from one to the next
@@ -3153,7 +3157,7 @@ def load_annotations(
     db: AnnotationDbABC | None = None,
     write_path: PathType = ":memory:",
     lines_per_block: int | None = 500_000,
-    show_progress: bool = False,
+    show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
     format_name: str | None = None,
     storage_backend: str | None = None,
 ) -> AnnotationDbABC:

--- a/src/cogent3/draw/dotplot.py
+++ b/src/cogent3/draw/dotplot.py
@@ -1,6 +1,9 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy
+
+if TYPE_CHECKING:  # pragma: no cover
+    from scinexus.progress import Progress
 
 from cogent3 import get_moltype
 from cogent3.align.pycompare import (
@@ -138,7 +141,7 @@ class Dotplot(Drawable):
         ytitle=None,
         title=None,
         width=500,
-        show_progress=False,
+        show_progress: "bool | Progress | dict[str, Any]" = False,  # type: ignore[type-arg]
     ) -> None:
         """
         Parameters

--- a/src/cogent3/evolve/bootstrap.py
+++ b/src/cogent3/evolve/bootstrap.py
@@ -23,8 +23,9 @@ the EstimateProbability class.
 """
 
 import random
+from typing import Any
 
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 
 class ParametricBootstrapCore:
@@ -42,7 +43,11 @@ class ParametricBootstrapCore:
     def set_seed(self, seed) -> None:
         self.seed = seed
 
-    def run(self, show_progress=False, **opt_args) -> None:
+    def run(
+        self,
+        show_progress: bool | Progress | dict[str, Any] = False,
+        **opt_args,  # type: ignore[type-arg]
+    ) -> None:
         # Sets self.observed and self.results (a list _numreplicates long) to
         # whatever is returned from self.simplify([LF result from each PC]).
         # self.simplify() is used as the entire LF result might not be picklable
@@ -64,7 +69,11 @@ class ParametricBootstrapCore:
             concise_result = self.simplify(*self.parameter_controllers)
             return (memos, concise_result)
 
-        progress = get_progress(show_progress)
+        progress = (
+            get_progress(show_progress=True, **show_progress)
+            if isinstance(show_progress, dict)
+            else get_progress(show_progress)
+        )
         ctx = progress.context(msg="Bootstrap")
 
         ctx.update(progress=0.0, msg="Original data")

--- a/src/cogent3/evolve/coevolution.py
+++ b/src/cogent3/evolve/coevolution.py
@@ -13,6 +13,8 @@ from cogent3.evolve.pairwise_distance_numba import index_to_lower_tri
 from cogent3.util import dict_array
 
 if typing.TYPE_CHECKING:  # pragma: no cover
+    from scinexus.progress import Progress
+
     from cogent3.core.alignment import Alignment
 
 
@@ -818,7 +820,7 @@ def coevolution_matrix(
     stat: str = "nmi",
     parallel: bool = False,
     par_kw: dict | None = None,
-    show_progress: bool = False,
+    show_progress: "bool | Progress | dict[str, typing.Any]" = False,  # type: ignore[type-arg]
 ) -> dict_array.DictArray:
     """measure pairwise coevolution
 

--- a/src/cogent3/evolve/distance.py
+++ b/src/cogent3/evolve/distance.py
@@ -2,9 +2,10 @@
 
 import os
 from itertools import combinations
+from typing import Any
 from warnings import warn
 
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 from cogent3 import make_tree
 from cogent3.core import table
@@ -185,7 +186,11 @@ class EstimateDistances:
         return result
 
     def run(
-        self, dist_opt_args=None, aln_opt_args=None, show_progress=False, **kwargs
+        self,
+        dist_opt_args=None,
+        aln_opt_args=None,
+        show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
+        **kwargs,
     ) -> None:
         """Start estimating the distances between sequences. Distance estimation
         is done using the Powell local optimiser. This can be changed using the
@@ -222,7 +227,11 @@ class EstimateDistances:
         else:
             combination_aligns = get_name_combinations(self._seq_collection.names, 2)
 
-        progress = get_progress(show_progress)
+        progress = (
+            get_progress(show_progress=True, **show_progress)
+            if isinstance(show_progress, dict)
+            else get_progress(show_progress)
+        )
         results = (
             (comp, self._doset(comp, dist_opt_args, aln_opt_args))
             for comp in combination_aligns

--- a/src/cogent3/evolve/fast_distance.py
+++ b/src/cogent3/evolve/fast_distance.py
@@ -9,7 +9,7 @@ from numpy import array, diag, dot, eye, float64, int32, log, sqrt, zeros
 from numpy.linalg import det, inv
 from scinexus.deserialise import register_deserialiser
 from scinexus.misc import get_object_provenance
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 import cogent3
 from cogent3._version import __version__
@@ -390,7 +390,11 @@ class _PairwiseDistance:
     def func() -> None:
         pass  # over ride in subclasses
 
-    def run(self, alignment=None, show_progress=False) -> None:
+    def run(
+        self,
+        alignment=None,
+        show_progress: bool | Progress | dict[str, typing.Any] = False,  # type: ignore[type-arg]
+    ) -> None:
         """computes the pairwise distances"""
         self._dupes = None
         self._duped = None
@@ -408,7 +412,11 @@ class _PairwiseDistance:
         ]
         off_diag = tuple(tuple(a) for a in zip(*off_diag, strict=False))
 
-        progress = get_progress(show_progress)
+        progress = (
+            get_progress(show_progress=True, **show_progress)
+            if isinstance(show_progress, dict)
+            else get_progress(show_progress)
+        )
         ctx = progress.context(msg="Pairwise distances")
         done = 0.0
         to_do = (len(names) ** 2 - 1) / 2

--- a/src/cogent3/maths/optimisers.py
+++ b/src/cogent3/maths/optimisers.py
@@ -6,7 +6,7 @@ import warnings
 from functools import singledispatch
 
 import numpy
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 from .scipy_optimisers import Powell
 from .simannealingoptimiser import SimulatedAnnealing
@@ -142,7 +142,7 @@ def maximise(
     max_evaluations=None,
     tolerance=1e-6,
     global_tolerance=1e-1,
-    show_progress=False,
+    show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
     return_eval_count=False,
     warn=False,
     **kw,
@@ -225,7 +225,11 @@ def maximise(
 
     f = bounds_exception_catching_function(f)
 
-    progress = get_progress(show_progress)
+    progress = (
+        get_progress(show_progress=True, **show_progress)
+        if isinstance(show_progress, dict)
+        else get_progress(show_progress)
+    )
     with progress.context(msg="Optimising") as ctx:
         try:
             # Global optimisation

--- a/src/cogent3/phylo/nj.py
+++ b/src/cogent3/phylo/nj.py
@@ -11,9 +11,10 @@ Generalised as described by Pearson, Robins & Zhang, 1999.
 
 import contextlib
 from collections import deque
+from typing import Any
 
 import numpy
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 from cogent3.core.tree import TreeBuilder
 from cogent3.phylo.tree_collection import ScoredTreeCollection
@@ -161,7 +162,12 @@ def uniq_neighbour_joins(trees, encode_partition):
         topologies.add(topology)
 
 
-def gnj(dists, keep=None, dkeep=0, show_progress=False):
+def gnj(
+    dists,
+    keep=None,
+    dkeep=0,
+    show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
+):
     """Arguments:
         - dists: dict of (name1, name2): distance
         - keep: number of best partial trees to keep at each iteration,
@@ -219,7 +225,11 @@ def gnj(dists, keep=None, dkeep=0, show_progress=False):
         max_candidates = min(all_keep, max_candidates * L * (L - 1) // 2)
         total_work += max_candidates
 
-    progress = get_progress(show_progress)
+    progress = (
+        get_progress(show_progress=True, **show_progress)
+        if isinstance(show_progress, dict)
+        else get_progress(show_progress)
+    )
     ctx = progress.context(msg="GNJ")
 
     def _show_progress() -> None:
@@ -288,7 +298,7 @@ def gnj(dists, keep=None, dkeep=0, show_progress=False):
     return ScoredTreeCollection(result)
 
 
-def nj(dists, show_progress=True):
+def nj(dists, show_progress: bool | Progress | dict[str, Any] = True):  # type: ignore[type-arg]
     """Arguments:
     - dists: dict of (name1, name2): distance
     """

--- a/src/cogent3/phylo/tree_space.py
+++ b/src/cogent3/phylo/tree_space.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 import itertools
+from typing import Any
 
 import numpy
-from scinexus.progress import get_progress
+from scinexus.progress import Progress, get_progress
 
 from cogent3.core.tree import TreeBuilder
 from cogent3.phylo.tree_collection import ScoredTreeCollection
@@ -153,7 +154,7 @@ class TreeEvaluator:
         return_all=False,
         filename=None,
         interval=None,
-        show_progress=False,
+        show_progress: bool | Progress | dict[str, Any] = False,  # type: ignore[type-arg]
     ):
         """TrexML policy for tree sampling - all trees up to size 'a' and
         then keep no more than 'k' best trees at each tree size.
@@ -238,7 +239,11 @@ class TreeEvaluator:
                 for edge in range(n * 2 - 5)
             ]
 
-            progress = get_progress(show_progress)
+            progress = (
+                get_progress(show_progress=True, **show_progress)
+                if isinstance(show_progress, dict)
+                else get_progress(show_progress)
+            )
             candidates = (
                 grown_tree(spec)
                 for spec in progress(specs, total=len(specs), msg=f"{n} leaf tree")


### PR DESCRIPTION
## Summary by Sourcery

Allow passing detailed progress configuration across various evolutionary analysis, alignment, and optimisation APIs by accepting either a boolean, Progress instance, or configuration dict for show_progress and wiring these through to scinexus.progress.get_progress.

New Features:
- Support passing a configuration dictionary for progress reporting to multiple high-level APIs, in addition to the existing boolean and Progress instance options.

Enhancements:
- Standardise show_progress type hints across evolutionary analyses, distance calculations, alignment, coevolution, and drawing utilities to use the shared Progress abstraction.
- Update bootstrap and tree search components to construct progress contexts based on flexible show_progress inputs, improving integration with scinexus progress handling.