### PR TITLE
MAINT: replace a hasattr with isinstance, fixes #2490

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -960,10 +960,7 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             sequences to add
         """
         assign_names = _SeqNamer()
-        named_seqs = cast(
-            "dict[str, str | bytes | NumpyIntArrayType]",
-            _make_name_seq_mapping(seqs, assign_names),
-        )
+        named_seqs = _make_name_seq_mapping(seqs, assign_names)
         name_map = make_name_map(named_seqs)
         data, offsets, _ = prep_for_seqs_data(
             named_seqs,
@@ -5268,32 +5265,27 @@ def _make_name_seq_mapping(
 
         return {seq_namer(seq=record): record for record in data}
 
-    if not hasattr(data, "seqs"):
+    if not isinstance(data, CollectionBase):
         msg = f"_make_name_seq_mapping not implemented for {type(data)}"
         raise NotImplementedError(msg)
 
-    return {
-        seq_namer(seq=record): record
-        for record in cast("SequenceCollection", data).seqs
-    }
+    return {seq_namer(seq=record): record for record in data.seqs}
 
 
 def _seqname_parent_name(
     record: str | bytes | NumpyIntArrayType | c3_sequence.Sequence | Aligned,
     name: str | None = None,
 ) -> tuple[str, str]:
-    if hasattr(record, "parent_coordinates"):
-        record = cast("c3_sequence.Sequence | Aligned", record)
+    if isinstance(record, (c3_sequence.Sequence, Aligned)):
         parent_name, *_ = record.parent_coordinates()
         return name or cast("str", record.name), parent_name or cast("str", name)
-    if hasattr(record, "name"):
-        record = cast("Aligned", record)
-        return name or record.name, name or record.name
     name = cast("str", name)
     return name, name
 
 
-def make_name_map(data: dict[str, str | bytes | NumpyIntArrayType]) -> dict[str, str]:
+def make_name_map(
+    data: dict[str, str | bytes | NumpyIntArrayType | c3_sequence.Sequence | Aligned],
+) -> dict[str, str]:
     """returns a dict mapping names to parent names
 
     Parameters
@@ -5430,7 +5422,9 @@ def coerce_to_raw_seq_data(
 
 
 def prep_for_seqs_data(
-    data: Mapping[str, str | bytes | NumpyIntArrayType | c3_sequence.Sequence],
+    data: Mapping[
+        str, str | bytes | NumpyIntArrayType | c3_sequence.Sequence | Aligned
+    ],
     moltype: c3_moltype.MolType[Any],
     seq_namer: _SeqNamer,
 ) -> tuple[dict[str, bytes | NumpyIntArrayType], dict[str, int], set[str]]:
@@ -5471,7 +5465,9 @@ def prep_for_seqs_data(
 
 
 def make_unaligned_storage(
-    data: dict[str, str | bytes | NumpyIntArrayType],
+    data: Mapping[
+        str, str | bytes | NumpyIntArrayType | c3_sequence.Sequence | Aligned
+    ],
     *,
     moltype: MolTypes,
     label_to_name: Callable[[str], str] | None = None,
@@ -5623,15 +5619,12 @@ def make_unaligned_seqs(
 
     annotation_db = annotation_db or merged_db_collection(data)
     assign_names = _SeqNamer(name_func=label_to_name)
-    data = cast(
-        "dict[str, str | bytes | NumpyIntArrayType]",
-        _make_name_seq_mapping(data, assign_names),
-    )
+    named_seqs = _make_name_seq_mapping(data, assign_names)
     if name_map is None:
-        name_map = make_name_map(data) or None
+        name_map = make_name_map(named_seqs) or None
 
     seqs_data = make_unaligned_storage(
-        data,
+        named_seqs,
         label_to_name=label_to_name,
         moltype=moltype,
         offset=offset,
@@ -5688,7 +5681,9 @@ def deserialise_old_to_new_type_seqcoll(
 
 
 def make_aligned_storage(
-    data: Mapping[str, str | bytes | NumpyIntArrayType],
+    data: Mapping[
+        str, str | bytes | NumpyIntArrayType | c3_sequence.Sequence | Aligned
+    ],
     *,
     moltype: MolTypes,
     label_to_name: Callable[[str], str] | None = None,
@@ -5840,15 +5835,12 @@ def make_aligned_seqs(
     # the AlignedSeqsData object - however, if a name_map is provided, we assume that it
     # corrects for any naming differences in data and skip this step
     assign_names = _SeqNamer(name_func=label_to_name)
-    data = cast(
-        "dict[str, str | bytes | NumpyIntArrayType]",
-        _make_name_seq_mapping(data, assign_names),
-    )
+    named_seqs = _make_name_seq_mapping(data, assign_names)
     if name_map is None:
-        name_map = make_name_map(data) or None
+        name_map = make_name_map(named_seqs) or None
 
     seqs_data = make_aligned_storage(
-        data,
+        named_seqs,
         moltype=moltype,
         label_to_name=label_to_name,
         offset=offset,

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -12,12 +12,13 @@ import numpy.typing as npt
 from scinexus.deserialise import register_deserialiser
 from scinexus.misc import get_object_provenance
 
+from cogent3.core.seqview import SeqViewABC
+
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable, Iterable, Iterator, Sized
     from collections.abc import Sequence as PySeq
 
     from cogent3.core.moltype import MolType, MolTypeLiteral
-    from cogent3.core.seqview import SeqViewABC
 
 NumpyIntArrayType = npt.NDArray[numpy.integer]
 
@@ -530,10 +531,9 @@ class CharAlphabet(
         if isinstance(seq, numpy.ndarray):
             return bool(seq.min() >= 0 and seq.max() < len(self) if len(seq) else True)
 
-        # refactor: design
-        if hasattr(seq, "alphabet"):
-            # assume a SeqView instance
-            return cast("SeqViewABC", seq).alphabet == self
+        if isinstance(seq, SeqViewABC):
+            return seq.alphabet == self
+
         msg = f"{type(seq)} is invalid"
         raise TypeError(msg)
 

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -2098,12 +2098,11 @@ class SqliteAnnotationDbMixin:
         if not isinstance(other_db, AnnotationDbABC):
             msg = f"{type(other_db)} does not support features"
             raise TypeError(msg)
-        if not hasattr(other_db, "table_names"):
+        if not isinstance(other_db, SqliteAnnotationDbMixin):
             return False
 
-        other = cast("SqliteAnnotationDbMixin", other_db)
         mine = set(self.table_names)
-        theirs = set(other.table_names)
+        theirs = set(other_db.table_names)
         return mine <= theirs or mine > theirs if symmetric else mine >= theirs
 
     def update(

--- a/src/cogent3/core/location.py
+++ b/src/cogent3/core/location.py
@@ -452,7 +452,7 @@ class Span(SpanI):
 
     def __lt__(self, other: SpanI) -> bool:
         """Compares indices of self with indices of other."""
-        if hasattr(other, "start") and hasattr(other, "end"):
+        if isinstance(other, SpanI):
             s = (self.start, self.end, self.reverse)
             o = (other.start, other.end, other.reverse)
             return s < o

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -671,8 +671,9 @@ class MolType(Generic[TStrOrBytes]):
         string will be converted via that callable into a character set
         compatible with the moltype. Only applies to nucleic acid moltypes.
         """
-        if hasattr(seq, "moltype"):
-            seq = cast("c3_sequence.Sequence", seq)
+        from cogent3.core import sequence as c3_sequence
+
+        if isinstance(seq, c3_sequence.Sequence):
             return seq if seq.moltype is self else seq.to_moltype(self)
 
         seq = cast("str | bytes | SeqViewABC", seq)

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -42,6 +42,7 @@ from cogent3.core.annotation_db import (
     AnnotatableMixin,
     AnnotationDbABC,
     FeatureDataType,
+    SqliteAnnotationDbMixin,
 )
 from cogent3.core.info import Info as InfoClass
 from cogent3.core.location import (
@@ -321,9 +322,7 @@ class Sequence(AnnotatableMixin):
 
         if make_seqlabel is not None:
             label = make_seqlabel(self)
-        elif hasattr(self, "label") and self.label:
-            label = self.label
-        elif hasattr(self, "name") and self.name:
+        elif self.name:
             label = self.name
         return seqs_to_fasta({label: str(self)}, block_size=block_size)
 
@@ -357,14 +356,12 @@ class Sequence(AnnotatableMixin):
             "type": get_object_provenance(self),
             "version": __version__,
         }
-        if hasattr(self, "annotation_offset"):
-            offset = int(self._seq.slice_record.parent_start)
-            data |= {"annotation_offset": offset}
+        data["annotation_offset"] = int(self._seq.slice_record.parent_start)
 
         if (
             self.has_annotation_db()
             and not exclude_annotations
-            and hasattr(self.annotation_db, "to_rich_dict")
+            and isinstance(self.annotation_db, SqliteAnnotationDbMixin)
         ):
             data["annotation_db"] = self.annotation_db.to_rich_dict()
 
@@ -1079,7 +1076,7 @@ class Sequence(AnnotatableMixin):
 
     def __add__(self, other: Self) -> Self:
         """Adds two sequences (other can be a string as well)."""
-        if hasattr(other, "moltype") and self.moltype != other.moltype:
+        if isinstance(other, Sequence) and self.moltype != other.moltype:
             msg = f"MolTypes don't match: ({self.moltype},{other.moltype})"
             raise ValueError(
                 msg,
@@ -1657,8 +1654,7 @@ class Sequence(AnnotatableMixin):
             msg = "cannot slice using float"
             raise TypeError(msg)
 
-        if hasattr(self, "_repr_policy"):
-            new._repr_policy.update(self._repr_policy)
+        new._repr_policy.update(self._repr_policy)
 
         return new
 

--- a/src/cogent3/core/seqview.py
+++ b/src/cogent3/core/seqview.py
@@ -57,11 +57,11 @@ class SeqViewABC(ABC):
         If from storage with an offset attribute, returns
         that value or 0
         """
-        return (
-            cast("SeqsDataABC", self.parent).offset.get(cast("str", self.seqid), 0)
-            if hasattr(self.parent, "offset")
-            else 0
-        )
+        from cogent3.core.seq_storage import SeqsDataABC
+
+        if isinstance(self.parent, SeqsDataABC):
+            return self.parent.offset.get(cast("str", self.seqid), 0)
+        return 0
 
     @property
     @abstractmethod

--- a/src/cogent3/core/table.py
+++ b/src/cogent3/core/table.py
@@ -17,7 +17,7 @@ import pickle
 import re
 import typing
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sized
 from collections.abc import Sequence as PySeq
 from itertools import product
 from typing import Self
@@ -112,14 +112,14 @@ def _group_indices(table: "Table", columns: list[str]) -> dict[tuple, numpy.ndar
     if len(columns) == 1:
         col_data = table.columns[columns[0]]
         unique_keys, inverse = numpy.unique(col_data, return_inverse=True)
-        keys = [(k.item() if hasattr(k, "item") else k,) for k in unique_keys]
+        keys = [(k.item() if isinstance(k, numpy.generic) else k,) for k in unique_keys]
     else:
         col_arrays = [table.columns[c] for c in columns]
         if any(arr.dtype.kind == "O" for arr in col_arrays):
             combined = numpy.empty(table.shape[0], dtype="O")
             for i in range(table.shape[0]):
                 combined[i] = tuple(
-                    v.item() if hasattr(v, "item") else v
+                    v.item() if isinstance(v, numpy.generic) else v
                     for v in (arr[i] for arr in col_arrays)
                 )
             unique_keys, inverse = numpy.unique(combined, return_inverse=True)
@@ -129,7 +129,10 @@ def _group_indices(table: "Table", columns: list[str]) -> dict[tuple, numpy.ndar
             rec = numpy.rec.fromarrays(col_arrays, dtype=dtypes)
             unique_keys, inverse = numpy.unique(rec, return_inverse=True)
             keys = [
-                tuple(v.item() if hasattr(v, "item") else v for v in unique_keys[i])
+                tuple(
+                    v.item() if isinstance(v, numpy.generic) else v
+                    for v in unique_keys[i]
+                )
                 for i in range(len(unique_keys))
             ]
 
@@ -582,7 +585,7 @@ class Table:
                 msg,
             )
 
-        if len(data) if hasattr(data, "__len__") else 0:
+        if isinstance(data, Sized) and data:
             row_order = kwargs.get("row_order")
             data = cast_to_1d_dict(data, row_order=row_order)
             if has_index:
@@ -663,7 +666,7 @@ class Table:
             rows, _ = self._template.interpret_index(rows)
             rows = rows[0]
 
-        if not hasattr(rows, "__len__") and not isinstance(rows, slice):
+        if not isinstance(rows, (Sized, slice)):
             rows = (rows,)
 
         if isinstance(rows, numpy.ndarray):

--- a/tests/test_core/test_alphabet.py
+++ b/tests/test_core/test_alphabet.py
@@ -168,6 +168,23 @@ def test_is_valid_typerror():
         _ = alpha.is_valid(list("ACGT"))
 
 
+def test_is_valid_seqview():
+    from cogent3.core.sequence import SeqView
+
+    alpha = c3_alphabet.CharAlphabet(list("TCAG"))
+    sv = SeqView(parent="ACGT", parent_len=4, alphabet=alpha)
+    assert alpha.is_valid(sv)
+
+
+def test_is_valid_seqview_wrong_alphabet():
+    from cogent3.core.sequence import SeqView
+
+    alpha1 = c3_alphabet.CharAlphabet(list("TCAG"))
+    alpha2 = c3_alphabet.CharAlphabet(list("UCAG"))
+    sv = SeqView(parent="ACGU", parent_len=4, alphabet=alpha2)
+    assert not alpha1.is_valid(sv)
+
+
 @pytest.mark.parametrize(("num_states", "ndim"), [(2, 1), (4, 2), (4, 4)])
 def test_interconversion_of_coords_indices(num_states, ndim):
     # make sure match numpy functions

--- a/tests/test_core/test_location.py
+++ b/tests/test_core/test_location.py
@@ -276,6 +276,19 @@ class MapTests(TestCase):
         assert dict(got) == {0: 1, 2: 2, 4: 1, 7: 2}
 
 
+def test_span_lt_orders_by_indices():
+    a = Span(start=0, end=10)
+    b = Span(start=5, end=10)
+    assert a < b
+    assert not (b < a)
+
+
+def test_span_lt_with_non_span_raises():
+    s = Span(start=0, end=10)
+    with pytest.raises(TypeError, match="Unsupported type"):
+        _ = s < object()
+
+
 def test_map_plus_position():
     # seq is 9 long
     # plus coords  012345678

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -224,6 +224,13 @@ def test_add_bad():
         _ = seq1 + "s8d3j%31 s-']"
 
 
+def test_add_mismatched_moltype_raises():
+    dna = c3_moltype.DNA.make_seq(seq="ACGT", name="d")
+    rna = c3_moltype.RNA.make_seq(seq="ACGU", name="r")
+    with pytest.raises(ValueError, match="MolTypes don't match"):
+        _ = dna + rna
+
+
 @pytest.mark.parametrize(
     ("moltype", "label"),
     [
@@ -2326,6 +2333,14 @@ def test_to_rich_dict():
     assert got == expect
 
 
+def test_to_rich_dict_with_annotation_db_serialises():
+    """to_rich_dict includes the annotation_db when exclude_annotations=False"""
+    seq = c3_moltype.DNA.make_seq(seq="ACGTACGT", name="s1")
+    seq.add_feature(biotype="exon", name="e1", spans=[(0, 4)])
+    rd = seq.to_rich_dict(exclude_annotations=False)
+    assert "annotation_db" in rd
+
+
 def test_sequence_to_json():
     """to_json roundtrip recreates to_dict"""
     dna = c3_moltype.DNA
@@ -2857,6 +2872,15 @@ def test_seqview_parent_offset(offset, dna_alphabet):
     got = sv[offset:]
     # parent offset is not a slice offset
     assert got.parent_offset == 0
+
+
+def test_seqview_parent_offset_seqsdata_parent():
+    # parent is a SeqsDataABC: parent_offset must read from its offset dict
+    from cogent3 import make_unaligned_seqs
+
+    sc = make_unaligned_seqs({"s1": "ACGT"}, moltype="dna")
+    sv = sc.get_seq("s1")._seq  # noqa: SLF001
+    assert sv.parent_offset == 0
 
 
 @pytest.mark.parametrize("offset", [0, 4])


### PR DESCRIPTION
## Summary by Sourcery

Standardise type and capability checks across core sequence, alignment, alphabet, table, and location modules while tightening type hints and improving robustness around sequence collections and annotations.

Bug Fixes:
- Ensure sequence concatenation raises a ValueError when adding sequences with mismatched MolTypes.
- Always serialise annotation offsets and correctly include SQLite-backed annotation databases in sequence rich-dict representations when annotations are not excluded.
- Fix SeqView parent_offset resolution when the parent is a SeqsData storage object, using its offset mapping.
- Make alphabet validity checks work correctly for SeqView instances and respect their associated alphabet.
- Constrain span ordering to Span-like objects and raise a TypeError when comparing to unsupported types.

Enhancements:
- Replace hasattr-based feature checks with explicit isinstance checks and protocol types for sequences, collections, annotation databases, NumPy scalars, and sized objects, improving clarity and type safety.
- Broaden alignment and storage helper functions to accept additional sequence-like types (including Aligned and Sequence instances) and propagate the resulting named sequence mappings through the call chain.

Tests:
- Add unit tests covering mismatched MolType addition, rich-dict serialisation of annotation databases, SeqView alphabet validation, SeqView parent_offset for SeqsData parents, and span comparison semantics.