### PR TITLE
Performance tweak

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -1349,12 +1349,8 @@ class CollectionBase(AnnotatableMixin, ABC, Generic[TSequenceOrAligned]):
             if True, motifs containing a gap character are included.
 
         """
-        counts = self.counts_per_seq(
-            motif_length=1,
-            include_ambiguity=include_ambiguity,
-            allow_gap=allow_gap,
-        )
-        return cast("MotifCountsArray", counts).row_sum()
+        msg = "get_lengths not implemented yet"
+        raise NotImplementedError(msg)
 
     def pad_seqs(self, pad_length: int | None = None) -> Self:
         """Returns copy in which sequences are padded with the gap character to same length.
@@ -2380,6 +2376,23 @@ class SequenceCollection(CollectionBase[c3_sequence.Sequence]):
             len({self._seqs_data.get_seq_length(n) for n in self._name_map.values()})
             > 1
         )
+
+    def get_lengths(
+        self,
+        include_ambiguity: bool = False,
+        allow_gap: bool = False,
+    ) -> DictArray:
+        counts = numpy.zeros(len(self.names), dtype=int)
+        for idx, n in enumerate(self.names):
+            seq = self.seqs[n]
+            length = len(seq)
+            if not allow_gap:
+                length -= seq.count_gaps()
+            if not include_ambiguity:
+                length -= seq.count_ambiguous()
+            counts[idx] = length
+
+        return DictArray.from_array_names(counts, self.names)
 
     def count_kmers(
         self,
@@ -3496,6 +3509,28 @@ class Alignment(CollectionBase[Aligned]):
         """by definition False for an Alignment"""
         return False
 
+    def get_lengths(
+        self,
+        include_ambiguity: bool = False,
+        allow_gap: bool = False,
+    ) -> DictArray:
+        counts = numpy.zeros(len(self.names), dtype=int)
+        if not allow_gap:
+            gap_counts = self.count_gaps_per_seq()
+
+        if not include_ambiguity:
+            amb_counts = self.count_ambiguous_per_seq()
+        aln_len = len(self)
+        for idx, n in enumerate(self.names):
+            length = aln_len
+            if not allow_gap:
+                length -= cast("int", gap_counts[n])
+            if not include_ambiguity:
+                length -= cast("int", amb_counts[n])
+            counts[idx] = length
+
+        return DictArray.from_array_names(counts, self.names)
+
     def counts_per_seq(
         self,
         motif_length: int = 1,
@@ -3557,8 +3592,11 @@ class Alignment(CollectionBase[Aligned]):
 
     def count_ambiguous_per_seq(self) -> DictArray:
         """Return the counts of ambiguous characters per sequence as a DictArray."""
-
         gap_index = cast("int", self.moltype.most_degen_alphabet().gap_index)
+        if gap_index is None:
+            counts = numpy.zeros(len(self.names), dtype=int)
+            return DictArray.from_array_names(counts, self.names)
+
         ambigs_pos = self.array_seqs > gap_index
         ambigs = ambigs_pos.sum(axis=1)
         return DictArray.from_array_names(ambigs, self.names)

--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -106,8 +106,8 @@ class Aligned(AnnotatableMixin):
         self._data = data
         self._moltype = moltype
         self._name = name or data.seqid
-        self._annotation_db: list[AnnotationDbABC] = self._init_annot_db_value(
-            annotation_db
+        self._annotation_db: list[AnnotationDbABC] = (
+            [] if annotation_db is None else self._init_annot_db_value(annotation_db)
         )
 
     @classmethod
@@ -3561,7 +3561,6 @@ class Alignment(CollectionBase[Aligned]):
         gap_index = cast("int", self.moltype.most_degen_alphabet().gap_index)
         ambigs_pos = self.array_seqs > gap_index
         ambigs = ambigs_pos.sum(axis=1)
-
         return DictArray.from_array_names(ambigs, self.names)
 
     def strand_symmetry(self, motif_length: int = 1) -> dict[str, TestResult]:

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -299,9 +299,9 @@ class array_to_bytes:
 
 class CharAlphabet(
     tuple[TStrOrBytes, ...],
-    Generic[TStrOrBytes],
     AlphabetABC[TStrOrBytes],
     MonomerAlphabetABC[TStrOrBytes],
+    Generic[TStrOrBytes],
 ):
     """representing fundamental monomer character sets.
 
@@ -1029,9 +1029,9 @@ class KmerAlphabetABC(ABC, Generic[TStrOrBytes]):
 
 class KmerAlphabet(
     tuple[TStrOrBytes, ...],
-    Generic[TStrOrBytes],
     AlphabetABC[TStrOrBytes],
     KmerAlphabetABC[TStrOrBytes],
+    Generic[TStrOrBytes],
 ):
     """k-mer alphabet represents complete non-monomer alphabets
 

--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -3400,14 +3400,15 @@ class AnnotatableMixin:
             Ccan be None, an annotation db instance or a list containing an annotation
             db instance.
         """
+        if isinstance(value, list):
+            return value
 
         if value is None:
-            value = []
-        elif not isinstance(value, list):
-            # if annotation_db is not a list, assume it is a single
-            # annotation database instance
-            value = [value]
-        return value
+            return []
+
+        # if annotation_db is not a list, assume it is a single
+        # annotation database instance
+        return [value]
 
     @property
     def annotation_db(self) -> AnnotationDbABC:
@@ -3447,6 +3448,10 @@ class AnnotatableMixin:
         -----
         The check can be very expensive, so if you're confident set it to False
         """
+        if not value and isinstance(value, list):
+            self._annotation_db = value
+            return
+
         if isinstance(value, list) and len(value) > 0:
             value = value[0]
 
@@ -3455,10 +3460,6 @@ class AnnotatableMixin:
 
         if value is None:
             self._annotation_db = self._init_annot_db_value(None)
-            return
-
-        if not value and isinstance(value, list):
-            self._annotation_db = value
             return
 
         if check and value and not isinstance(value, AnnotationDbABC):

--- a/src/cogent3/core/moltype.py
+++ b/src/cogent3/core/moltype.py
@@ -1310,7 +1310,9 @@ class MolType(Generic[TStrOrBytes]):
         assert self.degen_gapped_alphabet is not None
         return numpy.sum(seq == self.degen_gapped_alphabet.gap_index)
 
-    def count_degenerate(self, seq: str | bytes, validate: bool = True) -> int:
+    def count_degenerate(
+        self, seq: NumpyIntArrayType | str | bytes, validate: bool = True
+    ) -> int:
         """returns the number of degenerate characters in a sequence
 
         Parameters
@@ -1328,6 +1330,9 @@ class MolType(Generic[TStrOrBytes]):
         c3_alphabet.AlphabetError
             if invalid characters present
         """
+        if isinstance(seq, numpy.ndarray):
+            return self._count_degenerate(seq)
+
         if isinstance(seq, str):
             seq = seq.encode("utf8")
 
@@ -1343,7 +1348,7 @@ class MolType(Generic[TStrOrBytes]):
     def _count_degenerate(self, seq: NumpyIntArrayType) -> int:
         assert self.degen_gapped_alphabet is not None
         assert self.degen_gapped_alphabet.gap_index is not None
-        return int(numpy.sum(seq >= self.degen_gapped_alphabet.gap_index))
+        return int(numpy.sum(seq > self.degen_gapped_alphabet.gap_index))
 
     def count_variants(self, seq: str | bytes) -> int:
         """Counts number of possible sequences matching the sequence, given

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -492,9 +492,7 @@ class Sequence(AnnotatableMixin):
 
     def count_ambiguous(self) -> int:
         """Returns the number of ambiguous characters in the sequence."""
-        data = numpy.array(self)
-        gap_index = cast("int", self.moltype.most_degen_alphabet().gap_index)
-        return int(numpy.sum(data > gap_index))
+        return self.moltype.count_degenerate(self.to_array())
 
     def count_kmers(
         self,

--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -2515,20 +2515,20 @@ def ambigs_coll():
 def test_sequence_collection_get_lengths(ambigs_coll):
     got = ambigs_coll.get_lengths()
     expect = {"a": 4, "b": 6}
-    assert got == expect
+    assert got.to_dict() == expect
 
 
 def test_sequence_collection_get_lengths_include_ambiguity(ambigs_coll):
-    # NOTE '?' is excluded as it could be a gap
     got = ambigs_coll.get_lengths(include_ambiguity=True)
-    expect = {"a": 4, "b": 8}
-    assert got == expect
+    # '?' now included in ambiguity
+    expect = {"a": 10, "b": 8}
+    assert got.to_dict() == expect
 
 
 def test_sequence_collection_get_lengths_allow_gap(ambigs_coll):
     got = ambigs_coll.get_lengths(include_ambiguity=True, allow_gap=True)
     expect = {"a": 10, "b": 10}
-    assert got == expect
+    assert got.to_dict() == expect
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Improve performance and correctness of alignment length and ambiguity counting while simplifying annotation DB handling.

New Features:
- Implement get_lengths for sequence collections and alignments returning DictArray results instead of raising NotImplementedError.

Bug Fixes:
- Fix ambiguous character counting to exclude gaps correctly and handle moltypes without a defined gap index.
- Correct count_degenerate behaviour for numpy array inputs and ensure only indices above the gap index are treated as ambiguous.
- Preserve existing empty annotation DB lists when replacing annotation DBs to avoid unintended reinitialisation.
- Ensure annotation DB initialisation handles list and non-list values consistently.

Enhancements:
- Return DictArray objects from get_lengths and update tests accordingly.
- Optimise length computation for alignments by reusing precomputed gap and ambiguity counts.
- Refine generic base class ordering for CharAlphabet and KmerAlphabet for better typing support.
- Simplify sequence ambiguity counting by delegating to moltype.count_degenerate.