### PR TITLE
ENH: iterating parsers use new scinexus streaming record parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numba>=0.61.0; python_version=='3.13'",
     "numba>=0.63.0rc1; python_version=='3.14'",
     "scipy",
-    "scinexus[loky]>=2026.4.20b1",
+    "scinexus[loky]>=2026.5.16",
     "stevedore",
     "tqdm",
     "typeguard>=4.0,<5",

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -230,7 +230,7 @@ def load_seq(
     filename: os.PathLike | str,
     annotation_path: os.PathLike | str | None = None,
     format_name: str | None = None,
-    moltype: "MolTypeLiteral | None" = None,
+    moltype: "MolTypeLiteral" = "text",
     label_to_name: Callable | None = None,
     parser_kw: dict | None = None,
     info: dict | None = None,
@@ -292,6 +292,18 @@ def load_seq(
         seq.name = label_to_name(seq.name) if label_to_name else seq.name
         return seq
 
+    parser = get_seq_format_parser_plugin(
+        format_name=format_name,
+        file_suffix=file_suffix,
+        unaligned_seqs=True,
+    )
+    if parser.accepts_converter:
+        from cogent3.core.alphabet import alphabet_converter
+        from cogent3.core.moltype import get_moltype
+
+        mt = get_moltype(moltype)
+        parser_kw.setdefault("converter", alphabet_converter(mt.most_degen_alphabet()))
+
     if is_genbank(format_name or file_suffix):
         name, seq, db = _load_genbank_seq(
             pathlib.Path(filename),
@@ -300,11 +312,6 @@ def load_seq(
         )
     else:
         db = None
-        parser = get_seq_format_parser_plugin(
-            format_name=format_name,
-            file_suffix=file_suffix,
-            unaligned_seqs=True,
-        )
         if parser.result_is_storage:
             msg = (
                 "Cannot reliably derive single sequence from multi-sequence storage. "
@@ -336,7 +343,7 @@ def load_seq(
 def load_unaligned_seqs(
     filename: str | pathlib.Path,
     format_name: str | None = None,
-    moltype: "MolTypeLiteral | None" = None,
+    moltype: "MolTypeLiteral" = "text",
     label_to_name: typing.Callable[[str], str] | None = None,
     parser_kw: dict | None = None,
     info: dict | None = None,
@@ -404,6 +411,12 @@ def load_unaligned_seqs(
         unaligned_seqs=True,
     )
     parser_kw = parser_kw or {}
+    if parser.accepts_converter:
+        from cogent3.core.alphabet import alphabet_converter
+        from cogent3.core.moltype import get_moltype
+
+        mt = get_moltype(moltype)
+        parser_kw.setdefault("converter", alphabet_converter(mt.most_degen_alphabet()))
     if parser.result_is_storage:
         data = parser.loader(path=filename, **parser_kw)
     else:
@@ -422,7 +435,7 @@ def load_unaligned_seqs(
 def load_aligned_seqs(
     filename: str | pathlib.Path,
     format_name: str | None = None,
-    moltype: "MolTypeLiteral | None" = None,
+    moltype: "MolTypeLiteral" = "text",
     label_to_name: typing.Callable[[str], str] | None = None,
     parser_kw: dict | None = None,
     info: dict | None = None,
@@ -469,6 +482,12 @@ def load_aligned_seqs(
         unaligned_seqs=False,
     )
     parser_kw = parser_kw or {}
+    if parser.accepts_converter:
+        from cogent3.core.alphabet import alphabet_converter
+        from cogent3.core.moltype import get_moltype
+
+        mt = get_moltype(moltype)
+        parser_kw.setdefault("converter", alphabet_converter(mt.most_degen_alphabet()))
     if parser.result_is_storage:
         data = parser.loader(path=filename, **parser_kw)
     else:

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -431,7 +431,7 @@ class CharAlphabet(
             seq = self._bytes2arr(seq)
 
         if isinstance(seq, numpy.ndarray):
-            seq = seq.astype(self.dtype)
+            seq = seq.astype(self.dtype, copy=False)
             if validate and not self.is_valid(seq):
                 msg = "sequence has invalid characters"
                 raise AlphabetError(msg)

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import itertools
 import json
+import string
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, Literal, Self, TypeVar, cast, overload
 
@@ -1006,6 +1007,30 @@ def kmer_indices_to_seq(
             result[index + k - 1] = coord[-1]
 
     return result
+
+
+class alphabet_converter:
+    """maps record bytes to an alphabet-indexed ndarray.
+
+    Notes
+    -----
+    Uppercases the input bytes, strips configured characters, then uses the
+    supplied alphabet to map the result to uint8 indices.
+    """
+
+    def __init__(
+        self,
+        alphabet: CharAlphabet[Any],
+        delete: bytes = b"\n\r\t 0123456789",
+    ) -> None:
+        lc = string.ascii_lowercase.encode("utf8")
+        self._translate = b"".maketrans(lc, lc.upper())
+        self._delete = delete
+        self._alphabet = alphabet
+
+    def __call__(self, text: bytes) -> NumpyIntArrayType:
+        cleaned = text.translate(self._translate, delete=self._delete)
+        return self._alphabet.to_indices(cleaned, validate=False)
 
 
 class KmerAlphabetABC(ABC, Generic[TStrOrBytes]):

--- a/src/cogent3/core/location.py
+++ b/src/cogent3/core/location.py
@@ -984,8 +984,8 @@ class IndelMap(MapABC):
             )
 
         # force all to int32
-        self.gap_pos = self.gap_pos.astype(numpy.int32)
-        self.cum_gap_lengths = self.cum_gap_lengths.astype(numpy.int32)
+        self.gap_pos = self.gap_pos.astype(numpy.int32, copy=False)
+        self.cum_gap_lengths = self.cum_gap_lengths.astype(numpy.int32, copy=False)
         # make gap array immutable
         self.gap_pos.flags.writeable = False
         self.cum_gap_lengths.flags.writeable = False

--- a/src/cogent3/core/seq_storage.py
+++ b/src/cogent3/core/seq_storage.py
@@ -800,7 +800,7 @@ class AlignedSeqsData(AlignedSeqsDataABC):
             msg = "Number of names must match number of rows in data."
             raise ValueError(msg)
 
-        gapped_seqs = data.astype(alphabet.dtype)
+        gapped_seqs = data.astype(alphabet.dtype, copy=False)
         gapped_seqs.flags.writeable = False
         return cls(
             gapped_seqs=gapped_seqs,
@@ -1298,7 +1298,7 @@ def decompose_gapped_seq(
         else:
             missing_index = -1
         return decompose_gapped_seq_array(
-            seq.astype(alphabet.dtype),
+            seq.astype(alphabet.dtype, copy=False),
             cast("int", alphabet.gap_index),
             missing_index=missing_index,
         )

--- a/src/cogent3/core/sequence.py
+++ b/src/cogent3/core/sequence.py
@@ -2388,7 +2388,7 @@ def _coerce_to_seqview(
 
     if isinstance(data, numpy.ndarray):
         return SeqView(
-            parent=data.astype(alphabet.dtype),
+            parent=data.astype(alphabet.dtype, copy=False),
             parent_len=len(data),
             seqid=seqid,
             alphabet=alphabet,

--- a/src/cogent3/core/seqview.py
+++ b/src/cogent3/core/seqview.py
@@ -258,7 +258,7 @@ class SeqView(SeqViewABC):
     ) -> NumpyIntArrayType:
         arr = self.array_value
         if dtype is not None:
-            arr = arr.astype(dtype)
+            arr = arr.astype(dtype, copy=False)
         return arr
 
     def __bytes__(self) -> bytes:
@@ -650,7 +650,7 @@ class AlignedDataView(AlignedDataViewABC):
     ) -> NumpyIntArrayType:
         arr = self.gapped_array_value
         if dtype:
-            arr = arr.astype(dtype)
+            arr = arr.astype(dtype, copy=False)
         return arr
 
     def __bytes__(self) -> bytes:

--- a/src/cogent3/parse/fasta.py
+++ b/src/cogent3/parse/fasta.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from functools import singledispatch
 
 import numpy
-from scinexus.io_util import is_url, open_
+from scinexus.io_util import is_url, iter_record_chunks, open_, path_exists
 
 from cogent3.core.info import Info
 from cogent3.parse.record import RecordError
@@ -257,6 +257,36 @@ def iter_fasta_records(
     raise TypeError(msg)
 
 
+def _process_fasta_record(
+    record: bytes,
+    converter: typing.Callable[[bytes], OutTypes],
+    label_to_name: RenamerType,
+) -> tuple[str, OutTypes] | None:
+    if not record:
+        return None
+    eol = record.find(b"\n")
+    if eol == -1:
+        return None
+    label = record[:eol].strip().decode("utf8")
+    if label_to_name:
+        label = label_to_name(label)
+    return label, converter(record[eol + 1 :])
+
+
+def _iter_fasta_records_from_path(
+    path: str | pathlib.Path,
+    converter: OptConverterType,
+    label_to_name: RenamerType,
+    chunk_size: int | None,
+) -> typing.Iterable[tuple[str, OutTypes]]:
+    if converter is None:
+        converter = minimal_converter()
+    for record in iter_record_chunks(path=path, delimiter=b">", chunk_size=chunk_size):
+        result = _process_fasta_record(record, converter, label_to_name)
+        if result is not None:
+            yield result
+
+
 @iter_fasta_records.register
 def _(
     data: bytes,
@@ -265,36 +295,25 @@ def _(
 ) -> typing.Iterable[tuple[str, OutTypes]]:
     if converter is None:
         converter = minimal_converter()
-
-    records = data.split(b">")
-    for record in records:
-        if not len(record):
-            continue
-
-        eol = record.find(b"\n")
-        if eol == -1:
-            continue
-        label = record[:eol].strip().decode("utf8")
-        if label_to_name:
-            label = label_to_name(label)
-        seq = converter(record[eol + 1 :])
-        yield label, seq
+    for record in data.split(b">"):
+        result = _process_fasta_record(record, converter, label_to_name)
+        if result is not None:
+            yield result
 
 
 @iter_fasta_records.register
-def _(data: str, converter: OptConverterType = None, label_to_name: RenamerType = str):
-    if not is_url(data):
-        try:
-            os.stat(data)
-        except OSError:
-            msg = "data is a string but not a file path, directly provided data must be bytes"
-            raise TypeError(
-                msg,
-            )
-
-    with open_(data, mode="rb") as infile:
-        data: bytes = infile.read()
-    return iter_fasta_records(data, converter=converter, label_to_name=label_to_name)
+def _(
+    data: str,
+    converter: OptConverterType = None,
+    label_to_name: RenamerType = str,
+    chunk_size: int | None = 5_000_000,
+) -> typing.Iterable[tuple[str, OutTypes]]:
+    if not is_url(data) and not path_exists(data):
+        msg = (
+            "data is a string but not a file path, directly provided data must be bytes"
+        )
+        raise TypeError(msg)
+    yield from _iter_fasta_records_from_path(data, converter, label_to_name, chunk_size)
 
 
 @iter_fasta_records.register
@@ -302,10 +321,9 @@ def _(
     data: pathlib.Path,
     converter: OptConverterType = None,
     label_to_name: RenamerType = str,
-):
-    with open_(data, mode="rb") as infile:
-        data: bytes = infile.read()
-    return iter_fasta_records(data, converter=converter, label_to_name=label_to_name)
+    chunk_size: int | None = 5_000_000,
+) -> typing.Iterable[tuple[str, OutTypes]]:
+    yield from _iter_fasta_records_from_path(data, converter, label_to_name, chunk_size)
 
 
 @iter_fasta_records.register

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy
 import numpy.typing as npt
+from scinexus.io_util import iter_record_chunks
 
 from cogent3.core import alphabet as c3_alphabet
 
@@ -607,6 +608,37 @@ def iter_genbank_records(
     raise TypeError(msg)
 
 
+def _process_genbank_record(
+    record: bytes,
+    converter: SeqConverterType,
+    convert_features: OptFeatureConverterType,
+) -> tuple[str, OutTypes, Any] | None:
+    if record.isspace():
+        return None
+    features, seq = record.split(b"\nORIGIN")
+    line = features[: features.find(b"\n")].split()
+    locus = line[1].decode("utf8")
+    seq = converter(seq) if converter else seq
+    features = features.decode("utf8")
+    if convert_features:
+        features = convert_features(features)
+    return locus, seq, features
+
+
+def _iter_genbank_records_from_path(
+    path: str | pathlib.Path,
+    converter: SeqConverterType,
+    convert_features: OptFeatureConverterType,
+    chunk_size: int | None,
+) -> Iterator[tuple[str, OutTypes, Any]]:
+    for record in iter_record_chunks(
+        path=path, delimiter=b"\n//", chunk_size=chunk_size
+    ):
+        result = _process_genbank_record(record, converter, convert_features)
+        if result is not None:
+            yield result
+
+
 @iter_genbank_records.register
 def _(
     data: bytes,
@@ -614,22 +646,9 @@ def _(
     convert_features: OptFeatureConverterType = default_parse_metadata,
 ) -> Iterator[tuple[str, OutTypes, Any]]:
     for record in data.split(b"\n//"):
-        if record.isspace():
-            # trailing newline
-            continue
-        # split on the delimiter between feature data and sequence
-        features, seq = record.split(b"\nORIGIN")
-        # we get the locus data
-        line = features[: features.find(b"\n")].split()
-        locus = line[1].decode("utf8")
-        # processing the seq
-        seq = converter(seq)
-        # then the features
-        features = features.decode("utf8")
-        if convert_features:
-            features = convert_features(features)
-
-        yield locus, seq, features
+        result = _process_genbank_record(record, converter, convert_features)
+        if result is not None:
+            yield result
 
 
 @iter_genbank_records.register
@@ -637,16 +656,10 @@ def _(
     data: str,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
+    chunk_size: int | None = 5_000_000,
 ) -> Iterator[tuple[str, OutTypes, Any]]:
-    from scinexus.io_util import open_
-
-    with open_(data, mode="rb") as infile:
-        data: bytes = infile.read()
-
-    return iter_genbank_records(
-        data,
-        converter=converter,
-        convert_features=convert_features,
+    yield from _iter_genbank_records_from_path(
+        data, converter, convert_features, chunk_size
     )
 
 
@@ -655,16 +668,10 @@ def _(
     data: pathlib.Path,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
+    chunk_size: int | None = 5_000_000,
 ) -> Iterator[tuple[str, OutTypes, Any]]:
-    from scinexus.io_util import open_
-
-    with open_(data, mode="rb") as infile:
-        data: bytes = infile.read()
-
-    return iter_genbank_records(
-        data,
-        converter=converter,
-        convert_features=convert_features,
+    yield from _iter_genbank_records_from_path(
+        data, converter, convert_features, chunk_size
     )
 
 

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -732,6 +732,7 @@ def rich_parser(
     skip_contigs=False,
     db: "GenbankAnnotationDb | None" = None,
     just_seq: bool = False,
+    **kwargs: Any,
 ):
     """Returns annotated sequences from GenBank formatted file.
 
@@ -751,6 +752,7 @@ def rich_parser(
         return only the sequence, excludes include any feature data and
         does not create an annotation_db. Overrides db argument.
     """
+    kwargs.pop("converter", None)
     from cogent3.core.annotation_db import GenbankAnnotationDb
     from cogent3.core.info import Info
     from cogent3.core.moltype import get_moltype

--- a/src/cogent3/parse/sequence.py
+++ b/src/cogent3/parse/sequence.py
@@ -56,6 +56,17 @@ class SequenceParserBase(abc.ABC):
         return True
 
     @property
+    def accepts_converter(self) -> bool:
+        """True if the loader accepts a converter keyword argument.
+
+        Notes
+        -----
+        Default is False. Override and return True when the loader accepts a
+        converter kwarg that maps record bytes to an alphabet-indexed ndarray.
+        """
+        return False
+
+    @property
     @abc.abstractmethod
     def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         """a callable for loading from a file"""
@@ -130,6 +141,10 @@ class FastaParser(SequenceParserBase):
     @property
     def supported_suffixes(self) -> set[str]:
         return {"fasta", "fa", "fna", "faa", "mfa"}
+
+    @property
+    def accepts_converter(self) -> bool:
+        return True
 
     @property
     def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
@@ -226,6 +241,10 @@ class GenbankParser(SequenceParserBase):
     @property
     def supported_suffixes(self) -> set[str]:
         return {"gb", "gbk", "gbff", "genbank"}
+
+    @property
+    def accepts_converter(self) -> bool:
+        return True
 
     @property
     def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:


### PR DESCRIPTION
## Summary by Sourcery

Switch FASTA and GenBank iterating parsers to use chunked streaming record parsing for file and path inputs, while reusing shared record-processing helpers.

New Features:
- Support chunked streaming iteration over FASTA records from file paths and URLs via a configurable chunk_size parameter.
- Support chunked streaming iteration over GenBank records from file paths and paths with a configurable chunk_size parameter.

Enhancements:
- Refactor FASTA iterators to share common record-processing logic between in-memory and streamed parsing paths.
- Refactor GenBank iterators to share common record-processing logic between in-memory and streamed parsing paths.