### PR TITLE
ENH: extend bytes_to_array to enable passing explicit dest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@
 !tests/data/*.json
 !tests/data/*.psl
 !tests/data/*.sff
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -314,11 +314,13 @@ def load_seq(
         unaligned_seqs=True,
     )
     if parser.accepts_converter:
-        from cogent3.core.alphabet import alphabet_converter
+        from cogent3.core.alphabet import make_text_to_array_converter
         from cogent3.core.moltype import get_moltype
 
         mt = get_moltype(moltype)
-        parser_kw.setdefault("converter", alphabet_converter(mt.most_degen_alphabet()))
+        parser_kw.setdefault(
+            "converter", make_text_to_array_converter(mt.most_degen_alphabet())
+        )
 
     if is_genbank(format_name or file_suffix):
         name, seq, db = _load_genbank_seq(
@@ -428,11 +430,13 @@ def load_unaligned_seqs(
     )
     parser_kw = parser_kw or {}
     if parser.accepts_converter:
-        from cogent3.core.alphabet import alphabet_converter
+        from cogent3.core.alphabet import make_text_to_array_converter
         from cogent3.core.moltype import get_moltype
 
         mt = get_moltype(moltype)
-        parser_kw.setdefault("converter", alphabet_converter(mt.most_degen_alphabet()))
+        parser_kw.setdefault(
+            "converter", make_text_to_array_converter(mt.most_degen_alphabet())
+        )
     if parser.result_is_storage:
         data = parser.loader(path=filename, **parser_kw)
     else:
@@ -499,11 +503,13 @@ def load_aligned_seqs(
     )
     parser_kw = parser_kw or {}
     if parser.accepts_converter:
-        from cogent3.core.alphabet import alphabet_converter
+        from cogent3.core.alphabet import make_text_to_array_converter
         from cogent3.core.moltype import get_moltype
 
         mt = get_moltype(moltype)
-        parser_kw.setdefault("converter", alphabet_converter(mt.most_degen_alphabet()))
+        parser_kw.setdefault(
+            "converter", make_text_to_array_converter(mt.most_degen_alphabet())
+        )
     if parser.result_is_storage:
         data = parser.loader(path=filename, **parser_kw)
     else:

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -299,9 +299,30 @@ def make_text_to_array_converter(
     alphabet: CharAlphabet[Any],
     delete: bytes = b"\n\r\t 0123456789",
 ) -> bytes_to_array:
-    """returns a bytes_to_array that strips ``delete`` characters, folds case,
-    and maps alphabet characters to their indices in a single translate pass.
+    """make a converter from text bytes to alphabet indices.
+
+    Parameters
+    ----------
+    alphabet
+        the target character alphabet; must have at most 256 elements
+    delete
+        bytes stripped from the input before mapping
+
+    Notes
+    -----
+    The returned converter performs case folding, deletion, and char-to-index
+    mapping in a single ``bytes.translate`` call. Indices are packed as single
+    bytes in the translation table, which is why ``len(alphabet)`` cannot
+    exceed 256.
     """
+    # indices are packed into a bytes object below, so each index must fit
+    # in a single byte
+    if len(alphabet) > 256:
+        msg = (
+            f"alphabet size {len(alphabet)} exceeds 256; cannot represent "
+            "indices in a byte-level translation table"
+        )
+        raise ValueError(msg)
     alpha_bytes = alphabet.as_bytes()
     chars = alpha_bytes.lower() + alpha_bytes.upper()
     dest = bytes(bytearray(range(len(alphabet)))) * 2

--- a/src/cogent3/core/alphabet.py
+++ b/src/cogent3/core/alphabet.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import itertools
 import json
-import string
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, Literal, Self, TypeVar, cast, overload
 
@@ -258,26 +257,55 @@ class bytes_to_array:
         chars: bytes,
         dtype: type[numpy.unsignedinteger],
         delete: bytes | None = None,
+        dest: bytes | None = None,
     ) -> None:
         """
         Parameters
         ----------
         chars
-            unique series of characters
+            series of characters in the source alphabet
         delete
             characters to be deleted from the result
+        dest
+            destination bytes that ``chars`` are mapped to. If None (the
+            default), uses ``bytes(bytearray(range(len(chars))))`` and requires
+            ``chars`` to be unique. If provided, must have the same length as
+            ``chars``; duplicates in ``chars`` are permitted so callers can
+            collapse multiple source characters (eg case variants) onto the
+            same index.
         """
-        # we want a bytes translation map
+        if dest is None:
+            dest = bytes(bytearray(range(len(chars))))
+            allow_duplicates = False
+        else:
+            if len(dest) != len(chars):
+                msg = f"length of dest={len(dest)} != length of chars {len(chars)}"
+                raise ValueError(msg)
+            allow_duplicates = True
         self._converter = convert_alphabet(
             chars,
-            bytes(bytearray(range(len(chars)))),
+            dest,
             delete=delete,
+            allow_duplicates=allow_duplicates,
         )
         self.dtype = dtype
 
     def __call__(self, seq: bytes) -> NumpyIntArrayType:
         b = self._converter(seq)
         return numpy.array(memoryview(b), dtype=self.dtype)
+
+
+def make_text_to_array_converter(
+    alphabet: CharAlphabet[Any],
+    delete: bytes = b"\n\r\t 0123456789",
+) -> bytes_to_array:
+    """returns a bytes_to_array that strips ``delete`` characters, folds case,
+    and maps alphabet characters to their indices in a single translate pass.
+    """
+    alpha_bytes = alphabet.as_bytes()
+    chars = alpha_bytes.lower() + alpha_bytes.upper()
+    dest = bytes(bytearray(range(len(alphabet)))) * 2
+    return bytes_to_array(chars, dtype=alphabet.dtype, delete=delete, dest=dest)
 
 
 class array_to_bytes:
@@ -1007,30 +1035,6 @@ def kmer_indices_to_seq(
             result[index + k - 1] = coord[-1]
 
     return result
-
-
-class alphabet_converter:
-    """maps record bytes to an alphabet-indexed ndarray.
-
-    Notes
-    -----
-    Uppercases the input bytes, strips configured characters, then uses the
-    supplied alphabet to map the result to uint8 indices.
-    """
-
-    def __init__(
-        self,
-        alphabet: CharAlphabet[Any],
-        delete: bytes = b"\n\r\t 0123456789",
-    ) -> None:
-        lc = string.ascii_lowercase.encode("utf8")
-        self._translate = b"".maketrans(lc, lc.upper())
-        self._delete = delete
-        self._alphabet = alphabet
-
-    def __call__(self, text: bytes) -> NumpyIntArrayType:
-        cleaned = text.translate(self._translate, delete=self._delete)
-        return self._alphabet.to_indices(cleaned, validate=False)
 
 
 class KmerAlphabetABC(ABC, Generic[TStrOrBytes]):

--- a/tests/test_core/test_alphabet.py
+++ b/tests/test_core/test_alphabet.py
@@ -162,6 +162,19 @@ def test_make_text_to_array_converter_returns_correct_dtype():
     assert conv(b"ACGT").dtype == alpha.dtype
 
 
+def test_make_text_to_array_converter_max_size_alphabet():
+    # BYTES alphabet has exactly 256 chars; the guard should not trip and
+    # construction should succeed at the boundary
+    alpha = c3_moltype.BYTES.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha, delete=b"")
+    assert isinstance(conv, c3_alphabet.bytes_to_array)
+
+
+def test_make_text_to_array_converter_oversize_alphabet_raises():
+    with pytest.raises(ValueError, match="exceeds 256"):
+        c3_alphabet.make_text_to_array_converter("a" * 300)
+
+
 def test_arr2bytes():
     a2b = c3_alphabet.array_to_bytes(b"TCAG")
     got = a2b(numpy.array([2, 2, 3, 0, 2], dtype=numpy.uint8))

--- a/tests/test_core/test_alphabet.py
+++ b/tests/test_core/test_alphabet.py
@@ -70,6 +70,98 @@ def test_bytes2arr():
     assert (got == numpy.array([2, 2, 3, 0, 2], dtype=numpy.uint8)).all()
 
 
+def test_bytes2arr_dest_explicit_matches_default():
+    explicit = c3_alphabet.bytes_to_array(
+        b"TCAG", dtype=numpy.uint8, dest=bytes(bytearray(range(4)))
+    )
+    default = c3_alphabet.bytes_to_array(b"TCAG", dtype=numpy.uint8)
+    seq = b"AAGTA"
+    assert (explicit(seq) == default(seq)).all()
+
+
+def test_bytes2arr_dest_length_mismatch():
+    with pytest.raises(ValueError):
+        c3_alphabet.bytes_to_array(b"TCAG", dtype=numpy.uint8, dest=b"\x00\x01")
+
+
+def test_bytes2arr_dest_with_duplicate_src():
+    # collapse case variants onto the same indices
+    chars = b"tcag" + b"TCAG"
+    dest = bytes(bytearray(range(4))) * 2
+    b2a = c3_alphabet.bytes_to_array(chars, dtype=numpy.uint8, dest=dest)
+    got = b2a(b"AaCcGgTt")
+    expect = numpy.array([2, 2, 1, 1, 3, 3, 0, 0], dtype=numpy.uint8)
+    assert (got == expect).all()
+
+
+def test_bytes2arr_dest_with_delete():
+    chars = b"tcag" + b"TCAG"
+    dest = bytes(bytearray(range(4))) * 2
+    b2a = c3_alphabet.bytes_to_array(
+        chars, dtype=numpy.uint8, delete=b"-", dest=dest
+    )
+    got = b2a(b"A-aC-cG-g")
+    expect = numpy.array([2, 2, 1, 1, 3, 3], dtype=numpy.uint8)
+    assert (got == expect).all()
+
+
+def test_make_text_to_array_converter_basic():
+    alpha = c3_moltype.DNA.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha)
+    upper = conv(b"ACGT")
+    lower = conv(b"acgt")
+    assert (upper == lower).all()
+    assert (upper == alpha.to_indices(b"ACGT", validate=False)).all()
+
+
+def test_make_text_to_array_converter_strips_default_delete():
+    alpha = c3_moltype.DNA.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha)
+    got = conv(b" A\tC\n G\r123T")
+    expect = alpha.to_indices(b"ACGT", validate=False)
+    assert (got == expect).all()
+
+
+def test_make_text_to_array_converter_custom_delete():
+    alpha = c3_moltype.DNA.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha, delete=b"X")
+    got = conv(b"AXCXGXT")
+    expect = alpha.to_indices(b"ACGT", validate=False)
+    assert (got == expect).all()
+
+
+@pytest.mark.parametrize(
+    "moltype", [c3_moltype.DNA, c3_moltype.RNA, c3_moltype.PROTEIN]
+)
+def test_make_text_to_array_converter_handles_non_letter_chars(moltype):
+    # most-degen alphabets include gap/missing/stop chars that have no
+    # distinct case form, so case-folded variants must still map correctly
+    alpha = moltype.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha)
+    seq = alpha.as_bytes()
+    expect = alpha.to_indices(seq, validate=False)
+    assert (conv(seq) == expect).all()
+    assert (conv(seq.lower()) == expect).all()
+    assert (conv(seq.upper()) == expect).all()
+
+
+def test_make_text_to_array_converter_ascii_folds_lower_to_upper():
+    # ASCII alphabet contains both cases as distinct chars; the converter
+    # must fold lower-case input onto the upper-case index, matching the
+    # legacy uppercase-then-index behaviour
+    alpha = c3_moltype.ASCII.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha)
+    upper_idx = alpha.to_indices(b"ABC", validate=False)
+    assert (conv(b"abc") == upper_idx).all()
+    assert (conv(b"ABC") == upper_idx).all()
+
+
+def test_make_text_to_array_converter_returns_correct_dtype():
+    alpha = c3_moltype.DNA.most_degen_alphabet()
+    conv = c3_alphabet.make_text_to_array_converter(alpha)
+    assert conv(b"ACGT").dtype == alpha.dtype
+
+
 def test_arr2bytes():
     a2b = c3_alphabet.array_to_bytes(b"TCAG")
     got = a2b(numpy.array([2, 2, 3, 0, 2], dtype=numpy.uint8))


### PR DESCRIPTION
[CHANGED] deleted recent alphabet_converter in favour of using
    this new bytes_to_array instance.

[NEW] added alphabet.make_text_to_array_converter() helper function

## Summary by Sourcery

Extend bytes_to_array to support explicit destination mappings and replace the previous alphabet_converter with a new make_text_to_array_converter helper used by sequence-loading APIs.

New Features:
- Allow bytes_to_array to accept an explicit dest mapping for custom character-to-index translations, including collapsing multiple source characters onto shared indices.
- Introduce make_text_to_array_converter helper to build case-folding, delete-aware text-to-index converters from CharAlphabet definitions.

Enhancements:
- Update sequence-loading functions (load_seq, load_unaligned_seqs, load_aligned_seqs) to use make_text_to_array_converter instead of alphabet_converter for parser converters.

Tests:
- Add unit tests covering explicit dest behavior in bytes_to_array and the semantics of make_text_to_array_converter across DNA, RNA, protein, and ASCII alphabets.