### PR TITLE
BUG: fix load_annotations handling of format_name

### DIFF
--- a/src/cogent3/core/annotation_db.py
+++ b/src/cogent3/core/annotation_db.py
@@ -2974,6 +2974,7 @@ class SqliteAnnotationDbLoader(AnnotationDbLoaderBase):
             ".gbk",
             ".gbff",
             ".json",
+            ".genbank",
             f".{ANNDB_SUFFIX_GENBANK}",
             f".{ANNDB_SUFFIX_GFF}",
             f".{ANNDB_SUFFIX_BASIC}",
@@ -3149,8 +3150,21 @@ def load_annotations(
 
     # Determine file suffix for format detection
     if format_name:
-        # Explicit format specified - map to suffix
-        suffix = format_name if format_name.startswith(".") else f".{format_name}"
+        # Map known format names to a canonical suffix the plugin recognises
+        _format_to_suffix = {
+            "gff": ".gff",
+            "gff3": ".gff",
+            "genbank": ".gb",
+            "json": ".json",
+        }
+        fmt = format_name.lower().lstrip(".")
+        if fmt not in _format_to_suffix:
+            msg = (
+                f"Unknown format_name {format_name!r}; "
+                f"expected one of {sorted(_format_to_suffix)}"
+            )
+            raise ValueError(msg)
+        suffix = _format_to_suffix[fmt]
     else:
         # Auto-detect from file suffix
         suffix, _ = get_format_suffixes(path)

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -2335,3 +2335,18 @@ def test_chunked_load_preserves_forward_parent_references(
         c["name"] for c in chunked.get_feature_children(name="Gene:WBGene00000138")
     )
     assert chunked_children == expected_children
+
+def test_load_annotations_format_name(tmp_path, DATA_DIR):
+    path = DATA_DIR / "annotated_seq.gb"
+    outpath = tmp_path / "annotated_seq.gb"
+    outpath.write_text(path.read_text())
+    db = load_annotations(path=outpath, format_name="genbank")
+    assert isinstance(db, GenbankAnnotationDb)
+
+
+def test_load_annotations_unknown_format_name(tmp_path, DATA_DIR):
+    path = DATA_DIR / "annotated_seq.gb"
+    outpath = tmp_path / "annotated_seq.gb"
+    outpath.write_text(path.read_text())
+    with pytest.raises(ValueError):
+        load_annotations(path=outpath, format_name="bogus")


### PR DESCRIPTION
## Summary by Sourcery

Fix explicit format handling in load_annotations and expand supported annotation formats.

Bug Fixes:
- Correct load_annotations to map known format_name values to the canonical suffixes expected by annotation plugins and to reject unknown format names with a clear error.

Enhancements:
- Add .genbank to the set of recognised annotation file suffixes.

Tests:
- Add tests covering load_annotations with a valid genbank format_name and with an unknown format_name producing an error.