### PR TITLE
API: iterative parser signatures all now positional then keyword only

### DIFF
--- a/src/cogent3/parse/fasta.py
+++ b/src/cogent3/parse/fasta.py
@@ -231,8 +231,10 @@ class minimal_converter:
 @singledispatch
 def iter_fasta_records(
     data,
+    *,
     converter: OptConverterType = None,
     label_to_name: RenamerType = str,
+    chunk_size: int | None = 5_000_000,
 ) -> typing.Iterable[tuple[str, OutTypes]]:
     """generator returns labels and sequences converted from a fasta file
 
@@ -248,6 +250,9 @@ def iter_fasta_records(
     label_to_name
         a callable that takes the sequence label as input and returns a new label.
         Defaults to the label itself.
+    chunk_size
+        size in bytes of chunks read from a file path. Ignored for in-memory
+        inputs.
 
     Returns
     -------
@@ -290,8 +295,10 @@ def _iter_fasta_records_from_path(
 @iter_fasta_records.register
 def _(
     data: bytes,
+    *,
     converter: OptConverterType = None,
     label_to_name: RenamerType = str,
+    chunk_size: int | None = 5_000_000,
 ) -> typing.Iterable[tuple[str, OutTypes]]:
     if converter is None:
         converter = minimal_converter()
@@ -304,6 +311,7 @@ def _(
 @iter_fasta_records.register
 def _(
     data: str,
+    *,
     converter: OptConverterType = None,
     label_to_name: RenamerType = str,
     chunk_size: int | None = 5_000_000,
@@ -319,6 +327,7 @@ def _(
 @iter_fasta_records.register
 def _(
     data: pathlib.Path,
+    *,
     converter: OptConverterType = None,
     label_to_name: RenamerType = str,
     chunk_size: int | None = 5_000_000,
@@ -329,15 +338,26 @@ def _(
 @iter_fasta_records.register
 def _(
     data: io.TextIOWrapper,
+    *,
     converter: OptConverterType = None,
     label_to_name: RenamerType = str,
+    chunk_size: int | None = 5_000_000,
 ):
     read_data: bytes = data.read().encode("utf8")
     return iter_fasta_records(
-        read_data, converter=converter, label_to_name=label_to_name
+        read_data,
+        converter=converter,
+        label_to_name=label_to_name,
+        chunk_size=chunk_size,
     )
 
 
 @iter_fasta_records.register
-def _(data: list, converter: OptConverterType = None, label_to_name: RenamerType = str):
+def _(
+    data: list,
+    *,
+    converter: OptConverterType = None,
+    label_to_name: RenamerType = str,
+    chunk_size: int | None = 5_000_000,
+):
     return MinimalFastaParser(data, strict=False, label_to_name=label_to_name)

--- a/src/cogent3/parse/fastq.py
+++ b/src/cogent3/parse/fastq.py
@@ -39,6 +39,7 @@ def iter_fastq_records(
     *,
     converter: OptConverterType = None,
     qual_converter: OptConverterType = None,
+    chunk_size: int | None = 5_000_000,
 ) -> Iterable[tuple[str, OutTypes, OutTypes]]:
     """yields (label, sequence, quality) tuples from a fastq source.
 
@@ -52,6 +53,8 @@ def iter_fastq_records(
     qual_converter
         applied to the quality line as bytes. If None, the line is decoded
         to str.
+    chunk_size
+        size in bytes of chunks read from the file path.
 
     Returns
     -------
@@ -67,5 +70,5 @@ def iter_fastq_records(
     """
     seq_conv = converter if converter is not None else bytes.decode
     qual_conv = qual_converter if qual_converter is not None else bytes.decode
-    for block in iter_line_blocks(data, num_lines=4):
+    for block in iter_line_blocks(data, num_lines=4, chunk_size=chunk_size):
         yield _process_fastq_block(block, seq_conv, qual_conv)

--- a/src/cogent3/parse/genbank.py
+++ b/src/cogent3/parse/genbank.py
@@ -583,8 +583,10 @@ def default_seq_converter(data: bytes) -> str:
 @functools.singledispatch
 def iter_genbank_records(
     data,
+    *,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
+    chunk_size: int | None = 5_000_000,
 ) -> Iterator[tuple[str, OutTypes, Any]]:
     """generator returning sequence labels and sequences converted bytes from a fasta file
 
@@ -599,12 +601,15 @@ def iter_genbank_records(
     convert_features
         a callable that converts the feature block of the genbank record, passed as
         a string
+    chunk_size
+        size in bytes of chunks read from a file path. Ignored for in-memory
+        inputs.
 
     Returns
     -------
     the sequence label as a string and the sequence as transformed by converter
     """
-    msg = f"iter_fasta_records not implemented for {type(data)}"
+    msg = f"iter_genbank_records not implemented for {type(data)}"
     raise TypeError(msg)
 
 
@@ -642,8 +647,10 @@ def _iter_genbank_records_from_path(
 @iter_genbank_records.register
 def _(
     data: bytes,
+    *,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
+    chunk_size: int | None = 5_000_000,
 ) -> Iterator[tuple[str, OutTypes, Any]]:
     for record in data.split(b"\n//"):
         result = _process_genbank_record(record, converter, convert_features)
@@ -654,6 +661,7 @@ def _(
 @iter_genbank_records.register
 def _(
     data: str,
+    *,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
     chunk_size: int | None = 5_000_000,
@@ -666,6 +674,7 @@ def _(
 @iter_genbank_records.register
 def _(
     data: pathlib.Path,
+    *,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
     chunk_size: int | None = 5_000_000,
@@ -678,8 +687,10 @@ def _(
 @iter_genbank_records.register
 def _(
     data: io.TextIOBase,
+    *,
     converter: SeqConverterType = default_seq_converter,
     convert_features: OptFeatureConverterType = default_parse_metadata,
+    chunk_size: int | None = 5_000_000,
 ) -> Iterator[tuple[str, OutTypes, Any]]:
     data: bytes = data.read().encode("utf8")
 
@@ -687,6 +698,7 @@ def _(
         data,
         converter=converter,
         convert_features=convert_features,
+        chunk_size=chunk_size,
     )
 
 
@@ -719,7 +731,9 @@ def minimal_parser(
     primitives. (The default feature parser creates many more keys from the
     genbank record metadata.)
     """
-    for locus, seq, features in iter_genbank_records(data, converter, convert_features):
+    for locus, seq, features in iter_genbank_records(
+        data, converter=converter, convert_features=convert_features
+    ):
         if isinstance(features, str):
             features = {"features": features}
         yield {"locus": locus, "sequence": seq, **features}

--- a/tests/test_parse/test_fasta.py
+++ b/tests/test_parse/test_fasta.py
@@ -225,3 +225,16 @@ def test_iter_fasta_records_compressed_file_uri(fa_gz):
 def test_iter_fasta_records_invalid():
     with pytest.raises(TypeError):
         list(iter_fasta_records(numpy.array([">abcd", "ACGG"])))
+
+
+def test_iter_fasta_records_keyword_only(DATA_DIR):
+    path = DATA_DIR / "brca1.fasta"
+    with pytest.raises(TypeError):
+        list(iter_fasta_records(path, None))
+
+
+@pytest.mark.parametrize("chunk_size", [1_000, 10_000, None])
+def test_iter_fasta_records_chunk_size(DATA_DIR, chunk_size):
+    path = DATA_DIR / "brca1.fasta"
+    got = dict(iter_fasta_records(path, chunk_size=chunk_size))
+    assert len(got) == 55

--- a/tests/test_parse/test_fastq.py
+++ b/tests/test_parse/test_fastq.py
@@ -102,3 +102,20 @@ def test_iter_fastq_records_bad_separator_raises(tmp_path):
 def test_iter_fastq_records_empty_file(tmp_path):
     path = _write_fastq(tmp_path, "")
     assert list(iter_fastq_records(path)) == []
+
+
+def test_iter_fastq_records_keyword_only(DATA_DIR):
+    path = DATA_DIR / "fastq.txt"
+    with pytest.raises(TypeError):
+        list(iter_fastq_records(path, None))
+
+
+@pytest.mark.parametrize("chunk_size", [100, 10_000, None])
+def test_iter_fastq_records_chunk_size(DATA_DIR, chunk_size):
+    path = DATA_DIR / "fastq.txt"
+    records = list(iter_fastq_records(path, chunk_size=chunk_size))
+    assert len(records) == 5
+    labels, seqs, quals = zip(*records)
+    assert list(labels) == EXPECTED_LABELS
+    assert list(seqs) == EXPECTED_SEQS
+    assert list(quals) == EXPECTED_QUALS

--- a/tests/test_parse/test_genbank.py
+++ b/tests/test_parse/test_genbank.py
@@ -612,6 +612,20 @@ def test_iter_genbank_records_invalid_input(gb_rec):
         list(genbank.iter_genbank_records(data))
 
 
+def test_iter_genbank_records_keyword_only(gb_rec):
+    with pytest.raises(TypeError):
+        list(genbank.iter_genbank_records(gb_rec, genbank.default_seq_converter))
+
+
+@pytest.mark.parametrize("chunk_size", [1_000, 10_000, None])
+def test_iter_genbank_records_chunk_size(gb_rec, chunk_size):
+    name, seq, _ = next(
+        iter(genbank.iter_genbank_records(gb_rec, chunk_size=chunk_size)),
+    )
+    assert name == "AE017341"
+    assert len(seq) == 6201
+
+
 @pytest.mark.parametrize("as_string", [True, False])
 def test_default_parse_metadata(gb_rec, as_string):
     *_, features = next(


### PR DESCRIPTION
[CHANGED] iter_fasta/genbank/fastq API changed

[NEW] added chunk_size argument to allow users to disk read size

## Summary by Sourcery

Make FASTA, FASTQ, and GenBank iterative parsers keyword-only for optional arguments and introduce a configurable chunk_size for file-based parsing.

New Features:
- Add a chunk_size parameter to FASTA, FASTQ, and GenBank iter_*_records APIs to control file read block size.

Enhancements:
- Change iter_fasta_records, iter_fastq_records, and iter_genbank_records signatures so optional parameters are keyword-only for all supported input types.

Tests:
- Extend FASTA, FASTQ, and GenBank parser tests to cover keyword-only enforcement and various chunk_size values.