### PR TITLE
BUG: cap max_workers for coevo matrix, fixes #2646

### DIFF
--- a/src/cogent3/evolve/coevolution.py
+++ b/src/cogent3/evolve/coevolution.py
@@ -869,6 +869,8 @@ def coevolution_matrix(
     prev_threads = None
     if max_workers is not None and parallel:
         prev_threads = numba.get_num_threads()
+        # don't exceed available threads
+        max_workers = min(max_workers, numba.get_num_threads())
         numba.set_num_threads(max_workers)
 
     try:

--- a/tests/test_evolve/test_coevolution.py
+++ b/tests/test_evolve/test_coevolution.py
@@ -403,13 +403,16 @@ def test_parallel_protein(stat):
     assert_allclose(got.array, serial.array)
 
 
-def test_par_kw_max_workers(alignment):
+@pytest.mark.parametrize("max_workers", [2, 20_000])
+def test_par_kw_max_workers(alignment, max_workers):
     """par_kw max_workers is accepted without error"""
+    # larger than num threads should be silently
+    # reduced to num threads
     got = c3_coevo.coevolution_matrix(
         alignment=alignment,
         stat="nmi",
         parallel=True,
-        par_kw={"max_workers": 2},
+        par_kw={"max_workers": max_workers},
         show_progress=False,
     )
     serial = c3_coevo.coevolution_matrix(


### PR DESCRIPTION
Thanks for the report and proposed changes @sanvila!

## Summary by Sourcery

Cap coevolution matrix parallel execution to available threads when max_workers is specified and extend tests to cover oversized max_workers values.

Bug Fixes:
- Prevent coevolution_matrix from configuring more worker threads than are available by capping max_workers to the current numba thread count.

Tests:
- Parametrize the parallel max_workers test to verify that both small and excessively large max_workers values are accepted and handled correctly.