### PR TITLE
ENH: add with_support kwarg to PhyloNode.get_newick

### DIFF
--- a/doc/cookbook/simple_trees.rst
+++ b/doc/cookbook/simple_trees.rst
@@ -360,6 +360,28 @@ Newick format
 
     tr.get_newick(with_distances=True, with_node_names=True)
 
+Including support values
+""""""""""""""""""""""""
+
+Use ``with_support=True`` to include the value of ``node.support`` on each
+node in the newick string.
+
+.. jupyter-execute::
+
+    from cogent3 import make_tree
+
+    supported = make_tree(treestring="(a:1,b:2,(c:3,d:4)e1/95:5);")
+    supported.get_newick(with_distances=True, with_support=True)
+
+Combining ``with_support=True`` with ``with_node_names=True`` retains the
+internal node names alongside their support values.
+
+.. jupyter-execute::
+
+    supported.get_newick(
+        with_distances=True, with_node_names=True, with_support=True
+    )
+
 Tree traversal
 ^^^^^^^^^^^^^^
 

--- a/src/cogent3/core/tree.py
+++ b/src/cogent3/core/tree.py
@@ -74,12 +74,21 @@ class TreeError(Exception):
     pass
 
 
+def _format_support(support: float) -> str:
+    """Render a support value, dropping a trailing .0 for integer-valued floats."""
+    as_float = float(support)
+    if as_float.is_integer():
+        return str(int(as_float))
+    return str(as_float)
+
+
 def _format_node_name(
     node: PhyloNode,
     with_node_names: bool,
     escape_name: bool,
     with_distances: bool,
     with_root_name: bool = False,
+    with_support: bool = False,
 ) -> str:
     """Helper function to format node name according to parameters"""
     if (node.is_root() and not with_root_name) or (
@@ -98,6 +107,14 @@ def _format_node_name(
             node_name = "'{}'".format(node_name.replace("'", "''"))
         else:
             node_name = node_name.replace(" ", "_")
+
+    if (
+        with_support
+        and node.support is not None
+        and not (node.is_root() and not with_root_name)
+    ):
+        support_str = _format_support(node.support)
+        node_name = f"{node_name}/{support_str}" if node_name else support_str
 
     if with_distances and (length := node.length) is not None:
         node_name = f"{node_name}:{length}"
@@ -869,6 +886,7 @@ class PhyloNode:
         escape_name: bool = True,
         with_node_names: bool = False,
         with_root_name: bool = False,
+        with_support: bool = False,
     ) -> str:
         """Return the newick string of node and its descendents
 
@@ -886,6 +904,10 @@ class PhyloNode:
         with_root_name
             if True and with_node_names, the root node will have
             its name included
+        with_support
+            include the value of ``node.support`` for every node that has
+            one. Integer-valued supports are written without a trailing ``.0``.
+            The root is only emitted when ``with_root_name`` is True.
         """
         # Stack contains tuples of (tree node, visit flag)
         stack = [(self, False)]
@@ -907,6 +929,7 @@ class PhyloNode:
                     escape_name=escape_name,
                     with_distances=with_distances,
                     with_root_name=with_root_name,
+                    with_support=with_support,
                 )
 
                 # for tips with parent, the typical case

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -152,6 +152,83 @@ def test_get_newick(empty_node: PhyloNode, one_child: PhyloNode, big_parent: Phy
     )
 
 
+@pytest.mark.parametrize(
+    ("treestring", "kwargs", "expected"),
+    [
+        # support shown for internal node, name suppressed
+        ("(a,b,(c,d)e1/95);", {"with_support": True}, "(a,b,(c,d)95);"),
+        # default off — support absent even when present in input
+        ("(a,b,(c,d)e1/95);", {}, "(a,b,(c,d));"),
+        # non-integer float preserved
+        ("(a,b,(c,d)e1/0.95);", {"with_support": True}, "(a,b,(c,d)0.95);"),
+        # combined with internal node names
+        (
+            "(a,b,(c,d)e1/95);",
+            {"with_node_names": True, "with_support": True},
+            "(a,b,(c,d)e1/95);",
+        ),
+        # combined with distances
+        (
+            "(a:1,b:2,(c:3,d:4)e1/95:5);",
+            {"with_distances": True, "with_support": True},
+            "(a:1.0,b:2.0,(c:3.0,d:4.0)95:5.0);",
+        ),
+        # node has no support — nothing emitted
+        ("(a,b,(c,d)e1);", {"with_support": True}, "(a,b,(c,d));"),
+    ],
+)
+def test_get_newick_with_support(
+    treestring: str, kwargs: dict[str, bool], expected: str
+):
+    tree = make_tree(treestring=treestring)
+    assert tree.get_newick(**kwargs) == expected
+
+
+def test_get_newick_with_support_integer_valued_float():
+    # float that is whole-valued should drop the trailing .0
+    tree = make_tree(treestring="(a,b,(c,d)e1);")
+    tree.get_node_matching_name("e1").support = 100.0
+    assert tree.get_newick(with_support=True) == "(a,b,(c,d)100);"
+
+
+def test_get_newick_with_support_on_tip():
+    tree = make_tree(treestring="(a,b,(c,d)e1);")
+    tree.get_node_matching_name("c").support = 80.0
+    assert tree.get_newick(with_support=True) == "(a,b,(c/80,d));"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        # root support gated by with_root_name, suppressed by default
+        ({}, "(a,b,(c,d));"),
+        # with_root_name on its own emits the support but not the root name
+        ({"with_root_name": True}, "(a,b,(c,d))50;"),
+        # with_node_names + with_root_name emits name and support
+        (
+            {"with_root_name": True, "with_node_names": True},
+            "(a,b,(c,d)e1)root/50;",
+        ),
+    ],
+)
+def test_get_newick_with_support_on_root(kwargs: dict[str, bool], expected: str):
+    tree = make_tree(treestring="(a,b,(c,d)e1);")
+    tree.support = 50.0
+    assert tree.get_newick(with_support=True, **kwargs) == expected
+
+
+@pytest.mark.parametrize("name", ["a", "b", "c", "d", "e1"])
+def test_get_newick_with_support_round_trip(name: str):
+    # with_node_names is required to round-trip internal node names
+    tree = make_tree(treestring="(a:1.0,b:2.0,(c:3.0,d:4.0)e1/95:5.0);")
+    nwk = tree.get_newick(with_distances=True, with_node_names=True, with_support=True)
+    reparsed = make_tree(treestring=nwk)
+    assert (
+        reparsed.get_node_matching_name(name).support
+        == tree.get_node_matching_name(name).support
+    )
+
+
 def test_to_dict():
     """tree produces dict"""
     tr = make_tree(treestring="(a,b,(c:0.3,d)e1/10)")


### PR DESCRIPTION
Relates to https://github.com/iqtree/piqtree/issues/446

[NEW] Adds an optional with_support: bool = False argument to
    PhyloNode.get_newick() that writes node.support values into the
    newick string. Integer-valued supports are written
    without a trailing .0.

[NEW] The cookbook gains a 'Including support values' section under
    simple_trees.rst.

## Summary by Sourcery

Add optional support-value emission to PhyloNode.get_newick output and document its usage.

New Features:
- Introduce a with_support option on PhyloNode.get_newick to include node.support values in Newick output, omitting trailing .0 for integer-valued supports.

Documentation:
- Document how to include support values in Newick output in the simple trees cookbook.

Tests:
- Add unit tests covering with_support behavior across internal nodes, tips, the root, distances, node names, and round-tripping of support values.