### PR TITLE
New feature

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -8,7 +8,7 @@ on:
     branches-ignore:
       - master
 # NOTE:
-# if changeing python versions, also update versions in
+# if changing python versions, also update versions in
 # - release.yml
 # - noxfile.py
 
@@ -52,6 +52,10 @@ jobs:
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
+        env:
+          # macOS installs the coverage-reporter via a third-party Homebrew
+          # tap; Homebrew's new tap-trust enforcement refuses it otherwise.
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         with:
           parallel: true
           github-token: ${{ secrets.github_token }}

--- a/src/cogent3/core/table.py
+++ b/src/cogent3/core/table.py
@@ -2596,7 +2596,7 @@ def make_table(
     format_name: str = "simple",
     **kwargs,
 ) -> Table:
-    """
+    """make a Table instance
 
     Parameters
     ----------
@@ -2633,7 +2633,6 @@ def make_table(
         a pandas DataFrame, supersedes header/rows
     format_name
         output format when using str(Table)
-
     """
     if any(isinstance(a, str) for a in (header, data)):
         msg = "str type invalid, if it's a path use load_table()"
@@ -2684,7 +2683,7 @@ def load_table(
     skip_inconsistent: bool = False,
     **kwargs,
 ) -> Table:
-    """
+    """return a Table instance from a file containing tabular data.
 
     Parameters
     ----------

--- a/src/cogent3/parse/phylip.py
+++ b/src/cogent3/parse/phylip.py
@@ -8,6 +8,8 @@ the line structure when ``interleaved`` is not given.
 
 import typing
 
+from scinexus.warning import deprecated_callable
+
 import cogent3
 from cogent3.parse.fasta import OptConverterType, OutTypes, minimal_converter
 from cogent3.parse.record import RecordError
@@ -116,7 +118,7 @@ def _parse_sequential(
         yield _emit(label, fragments, seq_len, converter, id_map)
 
 
-def MinimalPhylipParser(
+def iter_phylip_records(
     data: typing.Iterable[str],
     id_map: dict[str, str] | None = None,
     interleaved: bool | None = None,
@@ -178,5 +180,14 @@ def get_align_for_phylip(
     strict_mode
         when True labels occupy a fixed 10-character column
     """
-    tuples = list(MinimalPhylipParser(data, id_map, strict_mode=strict_mode))
+    tuples = list(iter_phylip_records(data, id_map, strict_mode=strict_mode))
     return cogent3.make_aligned_seqs(tuples, moltype="text")
+
+
+@deprecated_callable(
+    version="2026.9",
+    reason="function rename",
+    new="iter_phylip_records",
+)
+def MinimalPhylipParser(*args: typing.Any, **kwargs: typing.Any) -> typing.Iterator[tuple[str, OutTypes]]:  # noqa: ANN401, N802 # pragma: no cover
+    return iter_phylip_records(*args, **kwargs)

--- a/src/cogent3/parse/phylip.py
+++ b/src/cogent3/parse/phylip.py
@@ -1,126 +1,182 @@
+"""Parser for the PHYLIP sequence alignment format.
+
+Supports relaxed PHYLIP (whitespace-delimited labels of arbitrary length) by
+default and strict PHYLIP (labels in a fixed 10-character column) via
+``strict_mode=True``. Interleaved and sequential layouts are auto-detected from
+the line structure when ``interleaved`` is not given.
+"""
+
+import typing
+
 import cogent3
+from cogent3.parse.fasta import OptConverterType, OutTypes, minimal_converter
 from cogent3.parse.record import RecordError
 
+ConverterType = typing.Callable[[bytes], OutTypes]
 
-def is_blank(x) -> bool:
-    """Checks if x is blank."""
-    return not x.strip()
-
-
-def _get_header_info(line):
-    """
-    Get number of sequences and length of sequence
-    """
-    header_parts = line.split()
-    num_seqs, length = list(map(int, header_parts[:2]))
-    is_interleaved = len(header_parts) > 2
-    return num_seqs, length, is_interleaved
+_LABEL_WIDTH = 10
 
 
-def _split_line(line, id_offset):
-    """
-    First 10 chars must be blank or contain id info
-    """
-    if not line or not line.strip():
-        return None, None
-
-    # extract id and sequence
-    curr_id = line[0:id_offset].strip()
-    curr_seq = line[id_offset:].strip().replace(" ", "")
-
-    return curr_id, curr_seq
+def _parse_header(line: str) -> tuple[int, int]:
+    """Return the number of sequences and the alignment length from the header."""
+    parts = line.split()
+    return int(parts[0]), int(parts[1])
 
 
-def MinimalPhylipParser(data, id_map=None, interleaved=True):
-    """Yields successive sequences from data as (label, seq) tuples.
-
-    **Need to implement id map.
-
-    **NOTE if using phylip interleaved format, will cache entire file in
-        memory before returning sequences. If phylip file not interleaved
-        then will yield each successive sequence.
-
-    data: sequence of lines in phylip format (an open file, list, etc)
-    id_map: optional id mapping from external ids to phylip labels - not sure
-        if we're going to implement this
+def _is_labelled(line: str, strict_mode: bool) -> bool:
+    """Whether a data line carries a label rather than continuing a sequence."""
+    if strict_mode:
+        return bool(line[:_LABEL_WIDTH].strip())
+    return not line[:1].isspace()
 
 
-    returns (id, sequence) tuples
-    """
+def _split_line(line: str, strict_mode: bool) -> tuple[str | None, str]:
+    """Split a data line into its label (or None) and raw sequence fragment."""
+    if strict_mode:
+        label = line[:_LABEL_WIDTH].strip()
+        return (label or None), line[_LABEL_WIDTH:]
+    if line[:1].isspace():
+        return None, line
+    parts = line.split(None, 1)
+    return parts[0], parts[1] if len(parts) > 1 else ""
 
-    seq_cache = {}
-    interleaved_id_map = {}
-    id_offset = 10
-    curr_ct = -1
 
-    for line in data:
-        if curr_ct == -1:
-            # get header info
-            num_seqs, seq_len, interleaved = _get_header_info(line)
+def _detect_layout(lines: list[str], num_seqs: int, strict_mode: bool) -> bool:
+    """Whether the alignment is interleaved, inferred from the line structure."""
+    if num_seqs == 1:
+        return False
+    flags = [_is_labelled(line, strict_mode) for line in lines]
+    if len(flags) >= 2 and flags[0] and not flags[1]:
+        return False
+    return all(flags[:num_seqs])
 
-            if not num_seqs or not seq_len:
-                return
-            curr_ct += 1
-            continue
 
-        curr_id, curr_seq = _split_line(line, id_offset)
+def _emit(
+    label: str,
+    fragments: list[str],
+    seq_len: int,
+    converter: ConverterType,
+    id_map: dict[str, str] | None,
+) -> tuple[str, OutTypes]:
+    """Convert assembled fragments to a sequence, validating its length."""
+    seq = converter("".join(fragments).encode("utf8"))
+    if len(seq) != seq_len:
+        msg = (
+            f"Length of sequence {label!r} is not the same as in header "
+            f"Found {len(seq)}, Expected {seq_len}"
+        )
+        raise RecordError(msg)
+    if id_map is not None:
+        label = id_map.get(label, label)
+    return label, seq
 
-        # skip blank lines
-        if not curr_id and not curr_seq:
-            continue
 
-        if not interleaved:
-            if curr_id:
-                if seq_cache:
-                    yield seq_cache[0], "".join(seq_cache[1:])
-                seq_cache = [curr_id, curr_seq]
-            else:
-                seq_cache.append(curr_seq)
+def _parse_interleaved(
+    lines: list[str],
+    num_seqs: int,
+    seq_len: int,
+    strict_mode: bool,
+    converter: ConverterType,
+    id_map: dict[str, str] | None,
+) -> typing.Iterator[tuple[str, OutTypes]]:
+    """Yield (label, seq) from interleaved phylip data."""
+    labels: list[str] = []
+    fragments: list[list[str]] = []
+    for index, line in enumerate(lines):
+        if index < num_seqs:
+            label, fragment = _split_line(line, strict_mode)
+            labels.append(label or "")
+            fragments.append([fragment])
         else:
-            curr_id_ix = curr_ct % num_seqs
+            fragments[index % num_seqs].append(line)
+    for label, parts in zip(labels, fragments, strict=True):
+        yield _emit(label, parts, seq_len, converter, id_map)
 
-            if (curr_ct + 1) % num_seqs == 0:
-                id_offset = 0
 
-            if curr_id_ix not in interleaved_id_map:
-                interleaved_id_map[curr_id_ix] = curr_id
-                seq_cache[curr_id_ix] = []
+def _parse_sequential(
+    lines: list[str],
+    seq_len: int,
+    strict_mode: bool,
+    converter: ConverterType,
+    id_map: dict[str, str] | None,
+) -> typing.Iterator[tuple[str, OutTypes]]:
+    """Yield (label, seq) from sequential phylip data."""
+    label: str | None = None
+    fragments: list[str] = []
+    for line in lines:
+        this_label, fragment = _split_line(line, strict_mode)
+        if this_label is not None:
+            if label is not None:
+                yield _emit(label, fragments, seq_len, converter, id_map)
+            label = this_label
+            fragments = [fragment]
+        else:
+            fragments.append(fragment)
+    if label is not None:
+        yield _emit(label, fragments, seq_len, converter, id_map)
 
-            seq_cache[curr_id_ix].append(curr_seq)
-        curr_ct += 1
 
-    # return joined sequences if interleaved
+def MinimalPhylipParser(
+    data: typing.Iterable[str],
+    id_map: dict[str, str] | None = None,
+    interleaved: bool | None = None,
+    strict_mode: bool = False,
+    converter: OptConverterType = None,
+) -> typing.Iterator[tuple[str, OutTypes]]:
+    """Yield successive sequences from phylip data as (label, seq) tuples.
+
+    Parameters
+    ----------
+    data
+        an iterable of lines in phylip format
+    id_map
+        optional mapping from parsed labels to replacement labels
+    interleaved
+        force interleaved (True) or sequential (False) layout; when None the
+        layout is auto-detected from the line structure
+    strict_mode
+        when True labels occupy a fixed 10-character column; when False labels
+        are whitespace-delimited and may be of arbitrary length
+    converter
+        callable mapping raw sequence bytes to the yielded sequence; when None
+        uses a converter that removes whitespace and upper-cases the residues
+    """
+    lines = [line for line in data if line.strip()]
+    if not lines:
+        return
+    num_seqs, seq_len = _parse_header(lines[0])
+    data_lines = lines[1:]
+    if not num_seqs or not seq_len or not data_lines:
+        return
+    if converter is None:
+        converter = minimal_converter()
+    if interleaved is None:
+        interleaved = _detect_layout(data_lines, num_seqs, strict_mode)
     if interleaved:
-        for curr_id_ix, seq_parts in list(seq_cache.items()):
-            join_seq = "".join(seq_parts)
-
-            if len(join_seq) != seq_len:
-                raise RecordError(
-                    "Length of sequence '%s' is not the same as in header "
-                    "Found %d, Expected %d"
-                    % (interleaved_id_map[curr_id_ix], len(join_seq), seq_len),
-                )
-
-            yield interleaved_id_map[curr_id_ix], join_seq
-    # return last seq if not interleaved
-    elif seq_cache:
-        yield seq_cache[0], "".join(seq_cache[1:])
+        yield from _parse_interleaved(
+            data_lines, num_seqs, seq_len, strict_mode, converter, id_map
+        )
+    else:
+        yield from _parse_sequential(
+            data_lines, seq_len, strict_mode, converter, id_map
+        )
 
 
-def get_align_for_phylip(data, id_map=None):
+def get_align_for_phylip(
+    data: typing.Iterable[str],
+    id_map: dict[str, str] | None = None,
+    strict_mode: bool = False,
+) -> "cogent3.core.alignment.Alignment":
+    """Return an Alignment object from phylip data.
+
+    Parameters
+    ----------
+    data
+        an iterable of lines in phylip format
+    id_map
+        optional mapping from parsed labels to replacement labels
+    strict_mode
+        when True labels occupy a fixed 10-character column
     """
-    Convenience function to return aligment object from phylip data
-
-    data: sequence of lines in phylip format (an open file, list, etc)
-    id_map: optional id mapping from external ids to phylip labels - not sure
-        if we're going to implement this
-
-    returns Alignment object
-    """
-
-    mpp = MinimalPhylipParser(data, id_map)
-
-    tuples = []
-    for tup in mpp:
-        tuples.append(tup)
+    tuples = list(MinimalPhylipParser(data, id_map, strict_mode=strict_mode))
     return cogent3.make_aligned_seqs(tuples, moltype="text")

--- a/src/cogent3/parse/sequence.py
+++ b/src/cogent3/parse/sequence.py
@@ -179,6 +179,10 @@ class PhylipParser(SequenceParserBase):
         return {"phylip", "phy"}
 
     @property
+    def accepts_converter(self) -> bool:
+        return True
+
+    @property
     def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
         return LineBasedParser(phylip.MinimalPhylipParser)
 

--- a/src/cogent3/parse/sequence.py
+++ b/src/cogent3/parse/sequence.py
@@ -109,8 +109,8 @@ class LineBasedParser:
 
 
 PARSERS = {
-    "phylip": LineBasedParser(phylip.MinimalPhylipParser),
-    "phy": LineBasedParser(phylip.MinimalPhylipParser),
+    "phylip": LineBasedParser(phylip.iter_phylip_records),
+    "phy": LineBasedParser(phylip.iter_phylip_records),
     "paml": LineBasedParser(paml.PamlParser),
     "fasta": fasta.iter_fasta_records,
     "mfa": fasta.iter_fasta_records,
@@ -184,7 +184,7 @@ class PhylipParser(SequenceParserBase):
 
     @property
     def loader(self) -> typing.Callable[[SeqParserInputTypes], ParserOutputType]:
-        return LineBasedParser(phylip.MinimalPhylipParser)
+        return LineBasedParser(phylip.iter_phylip_records)
 
 
 class ClustalParser(SequenceParserBase):

--- a/tests/test_parse/test_phylip.py
+++ b/tests/test_parse/test_phylip.py
@@ -1,18 +1,57 @@
 """Unit tests for the phylip parser"""
 
-from io import StringIO
-from unittest import TestCase
+import pytest
 
+import cogent3
 from cogent3.parse.phylip import MinimalPhylipParser, get_align_for_phylip
+from cogent3.parse.record import RecordError
+from cogent3.parse.sequence import PhylipParser
+
+RELAXED_INTERLEAVED = """2 30
+Acromyrmex_echinatior_Genome         gtcgtatttg gaatttgggg
+Apis_mellifera_Genome                -gcgagttcg aaatttgggg
+
+          cttcttcttc
+          cttcttcttc
+"""
 
 
-class PhylipGenericTest(TestCase):
-    """Setup data for Phylip parsers."""
+def test_relaxed_interleaved():
+    seqs = dict(MinimalPhylipParser(RELAXED_INTERLEAVED.splitlines()))
+    assert list(seqs) == ["Acromyrmex_echinatior_Genome", "Apis_mellifera_Genome"]
+    assert seqs["Acromyrmex_echinatior_Genome"] == "GTCGTATTTGGAATTTGGGGCTTCTTCTTC"
+    assert seqs["Apis_mellifera_Genome"] == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
+    assert {len(s) for s in seqs.values()} == {30}
 
-    def setUp(self):
-        """standard files"""
-        self.big_interleaved = StringIO(
-            """10 705 I
+
+RELAXED_SEQUENTIAL = """2 30
+Acromyrmex_echinatior_Genome  gtcgtatttg
+          gaatttgggg
+          cttcttcttc
+Apis_mellifera_Genome  -gcgagttcg
+          aaatttgggg
+          cttcttcttc
+"""
+
+
+def test_relaxed_sequential():
+    seqs = dict(MinimalPhylipParser(RELAXED_SEQUENTIAL.splitlines()))
+    assert list(seqs) == ["Acromyrmex_echinatior_Genome", "Apis_mellifera_Genome"]
+    assert seqs["Acromyrmex_echinatior_Genome"] == "GTCGTATTTGGAATTTGGGGCTTCTTCTTC"
+    assert seqs["Apis_mellifera_Genome"] == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
+    assert {len(s) for s in seqs.values()} == {30}
+
+
+@pytest.mark.parametrize("data", [RELAXED_INTERLEAVED, RELAXED_SEQUENTIAL])
+def test_layout_autodetected(data):
+    expected = {
+        "Acromyrmex_echinatior_Genome": "GTCGTATTTGGAATTTGGGGCTTCTTCTTC",
+        "Apis_mellifera_Genome": "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC",
+    }
+    assert dict(MinimalPhylipParser(data.splitlines())) == expected
+
+
+BIG_INTERLEAVED = """10 705 I
 Cow       ATGGCATATCCCATACAACTAGGATTCCAAGATGCAACATCACCAATCATAGAAGAACTA
 Carp      ATGGCACACCCAACGCAACTAGGTTTCAAGGACGCGGCCATACCCGTTATAGAGGAACTT
 Chicken   ATGGCCAACCACTCCCAACTAGGCTTTCAAGACGCCTCATCCCCCATCATAGAAGAGCTC
@@ -144,11 +183,9 @@ AACTGATCAGCTTCTATAATT---------------------TAA
 AAATGATCTACCTCAATGCTT---------------------TAA
 AAATGATCTGTATCAATACTA---------------------TAA
 AACTGATCTTCATCAATACTA---GAAGCATCACTA------AGA
-        """,
-        )
+"""
 
-        self.space_interleaved = StringIO(
-            """ 5 176 I
+SPACE_INTERLEAVED = """ 5 176 I
 cox2_leita   MAFILSFWMI FLLDSVIVLL SFVCFVCVWI CALLFSTVLL VSKLNNIYCT
 cox2_crifa   MAFILSFWMI FLIDAVIVLL SFVCFVCIWI CSLFFSSFLL VSKINNVYCT
 cox2_bsalt   MSFIISFWML FLIDSLIVLL SGAIFVCIWI CSLFFLCILF ICKLDYIFCS
@@ -172,10 +209,9 @@ cox2_tborr   MLFFINQLLL LLVDTFVILE IFSLFVCVFI IVMYILFINY NIFLKNINVY
              SAIDVIHSFT LANLGIKVD? ?PGRCN
              SAVDVIHSFT ISSLGIKVEN PGRCNE
              TSIDVIHSFT ISTLGIKIDC IPGRCN
-                                                                                                                                                                """,
-        )
-        self.interleaved_little = StringIO(
-            """   6   39 I
+"""
+
+INTERLEAVED_LITTLE = """   6   39 I
 Archaeopt CGATGCTTAC CGCCGATGCT
 HesperorniCGTTACTCGT TGTCGTTACT
 BaluchitheTAATGTTAAT TGTTAATGTT
@@ -189,12 +225,9 @@ AATTGTTAAT GTTAATTGT
 CGTTGTTAAT GTTCGTTGT
 CATCATCAAA ACCCATCAT
 AATCACGGCA GCCAATCAC
-""",
-        )
-        self.empty = []
+"""
 
-        self.noninterleaved_little = StringIO(
-            """   6   20
+NONINTERLEAVED_LITTLE = """   6   20
 
 Archaeopt CGATGCTTAC CGCCGATGCT
 HesperorniCGTTACTCGT TGTCGTTACT
@@ -203,12 +236,9 @@ BaluchitheTAATGTTAAT TGTTAATGTT
 B. virginiTAATGTTCGT TGTTAATGTT
 BrontosaurCAAAACCCAT CATCAAAACC
 B.subtilisGGCAGCCAAT CACGGCAGCC
+"""
 
-""",
-        )
-
-        self.noninterleaved_big = StringIO(
-            """10  297
+NONINTERLEAVED_BIG = """10  297
 Rhesus    tgtggcacaaatactcatgccagctcattacagcatgagaac---agtttgttactcact
           aaagacagaatgaatgtagaaaaggctgaattctgtaataaaagcaaacagcctggcttg
           gcaaggagccaacataacagatggactggaagtaaggaaacatgtaatgataggcagact
@@ -224,69 +254,178 @@ Pig       tgtggcacagatactcatgccagctcgttacagcatgagaacagcagtttattactcact
           gcaaagagccaacagagcagatgggctgaaagtaagggcacatgtaatgataggcagact
           cctaacacagagaaaaaggtagttctgaatactgatctcctgtatgggagaaacgaactg
           aataagcagaaacctgcgtgctctgacagtcctagagattcccaagatgttccttgg
-""",
+"""
+
+
+def test_empty():
+    assert list(MinimalPhylipParser([])) == []
+
+
+def test_strict_interleaved_big():
+    seqs = list(MinimalPhylipParser(BIG_INTERLEAVED.splitlines(), strict_mode=True))
+    assert len(seqs) == 10
+    assert seqs[0][0] == "Cow"
+    label, seq = seqs[-1]
+    assert label == "Frog"
+    assert seq == (
+        "ATGGCACACCCATCACAATTAGGTTTTCAAGACGCAGCCTCTCCAATTATAGAAGAATTA"
+        "CTTCACTTCCACGACCATACCCTCATAGCCGTTTTTCTTATTAGTACGCTAGTTCTTTAC"
+        "ATTATTACTATTATAATAACTACTAAACTAACTAATACAAACCTAATGGACGCACAAGAG"
+        "ATCGAAATAGTGTGAACTATTATACCAGCTATTAGCCTCATCATAATTGCCCTTCCATCC"
+        "CTTCGTATCCTATATTTAATAGATGAAGTTAATGATCCACACTTAACAATTAAAGCAATC"
+        "GGCCACCAATGATACTGAAGCTACGAATATACTAACTATGAGGATCTCTCATTTGACTCT"
+        "TATATAATTCCAACTAATGACCTTACCCCTGGACAATTCCGGCTGCTAGAAGTTGATAAT"
+        "CGAATAGTAGTCCCAATAGAATCTCCAACCCGACTTTTAGTTACAGCCGAAGACGTCCTC"
+        "CACTCGTGAGCTGTACCCTCCTTGGGTGTCAAAACAGATGCAATCCCAGGACGACTTCAT"
+        "CAAACATCATTTATTGCTACTCGTCCGGGAGTATTTTACGGACAATGTTCAGAAATTTGC"
+        "GGAGCAAACCACAGCTTTATACCAATTGTAGTTGAAGCAGTACCGCTAACCGACTTTGAA"
+        "AACTGATCTTCATCAATACTA---GAAGCATCACTA------AGA"
+    )
+
+
+def test_strict_space_interleaved():
+    seqs = list(MinimalPhylipParser(SPACE_INTERLEAVED.splitlines(), strict_mode=True))
+    assert len(seqs) == 5
+    assert seqs[0][0] == "cox2_leita"
+    assert seqs[-1][0] == "cox2_tborr"
+    assert {len(seq) for _, seq in seqs} == {176}
+
+
+def test_strict_interleaved_little():
+    seqs = list(MinimalPhylipParser(INTERLEAVED_LITTLE.splitlines(), strict_mode=True))
+    assert len(seqs) == 6
+    assert seqs[1][0] == "Hesperorni"
+    assert seqs[-1][0] == "B.subtilis"
+    assert seqs[-1][1] == "GGCAGCCAATCACGGCAGCCAATCACGGCAGCCAATCAC"
+
+
+def test_strict_sequential_little():
+    seqs = list(
+        MinimalPhylipParser(NONINTERLEAVED_LITTLE.splitlines(), strict_mode=True)
+    )
+    assert len(seqs) == 6
+    assert seqs[0][0] == "Archaeopt"
+    assert seqs[-1][0] == "B.subtilis"
+    assert seqs[-1][1] == "GGCAGCCAATCACGGCAGCC"
+
+
+def test_strict_sequential_big():
+    seqs = list(MinimalPhylipParser(NONINTERLEAVED_BIG.splitlines(), strict_mode=True))
+    assert len(seqs) == 3
+    assert seqs[0][0] == "Rhesus"
+    assert seqs[-1][0] == "Pig"
+    assert seqs[-1][1] == (
+        "TGTGGCACAGATACTCATGCCAGCTCGTTACAGCATGAGAACAGCAGTTTATTACTCACT"
+        "AAAGACAGAATGAATGTAGAAAAGGCTGAATTTTGTAATAAAAGCAAGCAGCCTGTCTTA"
+        "GCAAAGAGCCAACAGAGCAGATGGGCTGAAAGTAAGGGCACATGTAATGATAGGCAGACT"
+        "CCTAACACAGAGAAAAAGGTAGTTCTGAATACTGATCTCCTGTATGGGAGAAACGAACTG"
+        "AATAAGCAGAAACCTGCGTGCTCTGACAGTCCTAGAGATTCCCAAGATGTTCCTTGG"
+    )
+
+
+def test_strict_get_align_interleaved():
+    align = get_align_for_phylip(INTERLEAVED_LITTLE.splitlines(), strict_mode=True)
+    assert str(align) == (
+        ">Archaeopt\nCGATGCTTACCGCCGATGCTTACCGCCGATGCTTACCGC\n"
+        ">Hesperorni\nCGTTACTCGTTGTCGTTACTCGTTGTCGTTACTCGTTGT\n"
+        ">Baluchithe\nTAATGTTAATTGTTAATGTTAATTGTTAATGTTAATTGT\n"
+        ">B. virgini\nTAATGTTCGTTGTTAATGTTCGTTGTTAATGTTCGTTGT\n"
+        ">Brontosaur\nCAAAACCCATCATCAAAACCCATCATCAAAACCCATCAT\n"
+        ">B.subtilis\nGGCAGCCAATCACGGCAGCCAATCACGGCAGCCAATCAC\n"
+    )
+
+
+def test_strict_get_align_sequential():
+    align = get_align_for_phylip(NONINTERLEAVED_LITTLE.splitlines(), strict_mode=True)
+    assert str(align) == (
+        ">Archaeopt\nCGATGCTTACCGCCGATGCT\n"
+        ">Hesperorni\nCGTTACTCGTTGTCGTTACT\n"
+        ">Baluchithe\nTAATGTTAATTGTTAATGTT\n"
+        ">B. virgini\nTAATGTTCGTTGTTAATGTT\n"
+        ">Brontosaur\nCAAAACCCATCATCAAAACC\n"
+        ">B.subtilis\nGGCAGCCAATCACGGCAGCC\n"
+    )
+
+
+def test_forced_interleaved_matches_autodetect():
+    data = RELAXED_INTERLEAVED.splitlines()
+    assert dict(MinimalPhylipParser(data, interleaved=True)) == dict(
+        MinimalPhylipParser(data)
+    )
+
+
+def test_forced_sequential_matches_autodetect():
+    data = RELAXED_SEQUENTIAL.splitlines()
+    assert dict(MinimalPhylipParser(data, interleaved=False)) == dict(
+        MinimalPhylipParser(data)
+    )
+
+
+def test_forced_wrong_layout_raises():
+    with pytest.raises(RecordError):
+        list(MinimalPhylipParser(RELAXED_SEQUENTIAL.splitlines(), interleaved=True))
+
+
+BAD_LENGTH = """2 40
+seq1  ACGTACGTAC
+seq2  ACGTACGTAC
+"""
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(RecordError):
+        list(MinimalPhylipParser(BAD_LENGTH.splitlines()))
+
+
+def test_header_only_yields_nothing():
+    assert list(MinimalPhylipParser(["2 30"])) == []
+
+
+def test_blank_lines_only_yields_nothing():
+    assert list(MinimalPhylipParser(["", "   ", "\t"])) == []
+
+
+def _lower_converter(data: bytes) -> str:
+    return data.decode("utf8").replace(" ", "").replace("\n", "").lower()
+
+
+def test_custom_converter_applied():
+    seqs = dict(
+        MinimalPhylipParser(
+            RELAXED_INTERLEAVED.splitlines(), converter=_lower_converter
         )
+    )
+    assert seqs["Apis_mellifera_Genome"] == "-gcgagttcgaaatttggggcttcttcttc"
 
 
-class MinimalPhylipParserTests(PhylipGenericTest):
-    """Tests of MinimalPhylipParser: returns (label, seq) tuples."""
+def test_phylip_parser_accepts_converter():
+    assert PhylipParser().accepts_converter is True
 
-    def test_empty(self):
-        """MinimalFastaParser should return empty list from 'file' w/o labels"""
-        assert list(MinimalPhylipParser(self.empty)) == []
 
-    def test_minimal_parser(self):
-        """MinimalFastaParser should read single record as (label, seq) tuple"""
-        seqs = list(MinimalPhylipParser(self.big_interleaved))
-        assert len(seqs) == 10
-        label, seq = seqs[-1]
-        assert label == "Frog"
-        assert (
-            seq
-            == "ATGGCACACCCATCACAATTAGGTTTTCAAGACGCAGCCTCTCCAATTATAGAAGAATTACTTCACTTCCACGACCATACCCTCATAGCCGTTTTTCTTATTAGTACGCTAGTTCTTTACATTATTACTATTATAATAACTACTAAACTAACTAATACAAACCTAATGGACGCACAAGAGATCGAAATAGTGTGAACTATTATACCAGCTATTAGCCTCATCATAATTGCCCTTCCATCCCTTCGTATCCTATATTTAATAGATGAAGTTAATGATCCACACTTAACAATTAAAGCAATCGGCCACCAATGATACTGAAGCTACGAATATACTAACTATGAGGATCTCTCATTTGACTCTTATATAATTCCAACTAATGACCTTACCCCTGGACAATTCCGGCTGCTAGAAGTTGATAATCGAATAGTAGTCCCAATAGAATCTCCAACCCGACTTTTAGTTACAGCCGAAGACGTCCTCCACTCGTGAGCTGTACCCTCCTTGGGTGTCAAAACAGATGCAATCCCAGGACGACTTCATCAAACATCATTTATTGCTACTCGTCCGGGAGTATTTTACGGACAATGTTCAGAAATTTGCGGAGCAAACCACAGCTTTATACCAATTGTAGTTGAAGCAGTACCGCTAACCGACTTTGAAAACTGATCTTCATCAATACTA---GAAGCATCACTA------AGA"
-        )
-        assert seqs[0][0] == "Cow"
+def test_load_aligned_seqs_relaxed(tmp_path):
+    path = tmp_path / "locus.phy"
+    path.write_text(RELAXED_INTERLEAVED)
+    aln = cogent3.load_aligned_seqs(path, moltype="dna")
+    assert aln.num_seqs == 2
+    assert set(aln.names) == {"Acromyrmex_echinatior_Genome", "Apis_mellifera_Genome"}
+    assert len(aln) == 30
+    seq = str(aln.get_gapped_seq("Apis_mellifera_Genome"))
+    assert seq == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
 
-        seqs = list(MinimalPhylipParser(self.space_interleaved))
-        assert len(seqs) == 5
-        assert seqs[0][0] == "cox2_leita"
-        assert seqs[-1][0] == "cox2_tborr"
-        assert len(seqs[0][1]) == 176
-        assert len(seqs[-1][1]) == 176
 
-        seqs = list(MinimalPhylipParser(self.interleaved_little))
-        assert len(seqs) == 6
-        assert seqs[1][0] == "Hesperorni"
-        assert seqs[-1][0] == "B.subtilis"
-        assert seqs[-1][1] == "GGCAGCCAATCACGGCAGCCAATCACGGCAGCCAATCAC"
+def test_id_map_renames_labels():
+    id_map = {"Apis_mellifera_Genome": "bee"}
+    seqs = dict(MinimalPhylipParser(RELAXED_INTERLEAVED.splitlines(), id_map=id_map))
+    assert "Apis_mellifera_Genome" not in seqs
+    assert seqs["bee"] == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
 
-        seqs = list(MinimalPhylipParser(self.noninterleaved_little))
-        assert len(seqs) == 6
-        assert seqs[0][0] == "Archaeopt"
-        assert seqs[-1][0] == "B.subtilis"
-        assert seqs[-1][-1] == "GGCAGCCAATCACGGCAGCC"
 
-        seqs = list(MinimalPhylipParser(self.noninterleaved_big))
-        assert len(seqs) == 3
-        assert seqs[0][0] == "Rhesus"
-        assert seqs[-1][0] == "Pig"
-        assert (
-            seqs[-1][1]
-            == "tgtggcacagatactcatgccagctcgttacagcatgagaacagcagtttattactcactaaagacagaatgaatgtagaaaaggctgaattttgtaataaaagcaagcagcctgtcttagcaaagagccaacagagcagatgggctgaaagtaagggcacatgtaatgataggcagactcctaacacagagaaaaaggtagttctgaatactgatctcctgtatgggagaaacgaactgaataagcagaaacctgcgtgctctgacagtcctagagattcccaagatgttccttgg"
-        )
+SINGLE_SEQUENCE = """1 20
+seq1  ACGTACGTAC
+      GTACGTACGT
+"""
 
-    def test_get_align(self):
-        """get_align_for_phylip should return Aligment object for phylip files"""
-        align = get_align_for_phylip(self.big_interleaved)
-        align = get_align_for_phylip(self.interleaved_little)
-        s = str(align)
-        assert (
-            s
-            == ">Archaeopt\nCGATGCTTACCGCCGATGCTTACCGCCGATGCTTACCGC\n>Hesperorni\nCGTTACTCGTTGTCGTTACTCGTTGTCGTTACTCGTTGT\n>Baluchithe\nTAATGTTAATTGTTAATGTTAATTGTTAATGTTAATTGT\n>B. virgini\nTAATGTTCGTTGTTAATGTTCGTTGTTAATGTTCGTTGT\n>Brontosaur\nCAAAACCCATCATCAAAACCCATCATCAAAACCCATCAT\n>B.subtilis\nGGCAGCCAATCACGGCAGCCAATCACGGCAGCCAATCAC\n"
-        )
-        align = get_align_for_phylip(self.noninterleaved_little)
-        s = str(align)
-        assert (
-            s
-            == ">Archaeopt\nCGATGCTTACCGCCGATGCT\n>Hesperorni\nCGTTACTCGTTGTCGTTACT\n>Baluchithe\nTAATGTTAATTGTTAATGTT\n>B. virgini\nTAATGTTCGTTGTTAATGTT\n>Brontosaur\nCAAAACCCATCATCAAAACC\n>B.subtilis\nGGCAGCCAATCACGGCAGCC\n"
-        )
+
+def test_single_sequence():
+    seqs = dict(MinimalPhylipParser(SINGLE_SEQUENCE.splitlines()))
+    assert seqs == {"seq1": "ACGTACGTACGTACGTACGT"}

--- a/tests/test_parse/test_phylip.py
+++ b/tests/test_parse/test_phylip.py
@@ -3,7 +3,7 @@
 import pytest
 
 import cogent3
-from cogent3.parse.phylip import MinimalPhylipParser, get_align_for_phylip
+from cogent3.parse.phylip import get_align_for_phylip, iter_phylip_records
 from cogent3.parse.record import RecordError
 from cogent3.parse.sequence import PhylipParser
 
@@ -17,7 +17,7 @@ Apis_mellifera_Genome                -gcgagttcg aaatttgggg
 
 
 def test_relaxed_interleaved():
-    seqs = dict(MinimalPhylipParser(RELAXED_INTERLEAVED.splitlines()))
+    seqs = dict(iter_phylip_records(RELAXED_INTERLEAVED.splitlines()))
     assert list(seqs) == ["Acromyrmex_echinatior_Genome", "Apis_mellifera_Genome"]
     assert seqs["Acromyrmex_echinatior_Genome"] == "GTCGTATTTGGAATTTGGGGCTTCTTCTTC"
     assert seqs["Apis_mellifera_Genome"] == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
@@ -35,7 +35,7 @@ Apis_mellifera_Genome  -gcgagttcg
 
 
 def test_relaxed_sequential():
-    seqs = dict(MinimalPhylipParser(RELAXED_SEQUENTIAL.splitlines()))
+    seqs = dict(iter_phylip_records(RELAXED_SEQUENTIAL.splitlines()))
     assert list(seqs) == ["Acromyrmex_echinatior_Genome", "Apis_mellifera_Genome"]
     assert seqs["Acromyrmex_echinatior_Genome"] == "GTCGTATTTGGAATTTGGGGCTTCTTCTTC"
     assert seqs["Apis_mellifera_Genome"] == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
@@ -48,7 +48,7 @@ def test_layout_autodetected(data):
         "Acromyrmex_echinatior_Genome": "GTCGTATTTGGAATTTGGGGCTTCTTCTTC",
         "Apis_mellifera_Genome": "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC",
     }
-    assert dict(MinimalPhylipParser(data.splitlines())) == expected
+    assert dict(iter_phylip_records(data.splitlines())) == expected
 
 
 BIG_INTERLEAVED = """10 705 I
@@ -258,11 +258,11 @@ Pig       tgtggcacagatactcatgccagctcgttacagcatgagaacagcagtttattactcact
 
 
 def test_empty():
-    assert list(MinimalPhylipParser([])) == []
+    assert list(iter_phylip_records([])) == []
 
 
 def test_strict_interleaved_big():
-    seqs = list(MinimalPhylipParser(BIG_INTERLEAVED.splitlines(), strict_mode=True))
+    seqs = list(iter_phylip_records(BIG_INTERLEAVED.splitlines(), strict_mode=True))
     assert len(seqs) == 10
     assert seqs[0][0] == "Cow"
     label, seq = seqs[-1]
@@ -284,7 +284,7 @@ def test_strict_interleaved_big():
 
 
 def test_strict_space_interleaved():
-    seqs = list(MinimalPhylipParser(SPACE_INTERLEAVED.splitlines(), strict_mode=True))
+    seqs = list(iter_phylip_records(SPACE_INTERLEAVED.splitlines(), strict_mode=True))
     assert len(seqs) == 5
     assert seqs[0][0] == "cox2_leita"
     assert seqs[-1][0] == "cox2_tborr"
@@ -292,7 +292,7 @@ def test_strict_space_interleaved():
 
 
 def test_strict_interleaved_little():
-    seqs = list(MinimalPhylipParser(INTERLEAVED_LITTLE.splitlines(), strict_mode=True))
+    seqs = list(iter_phylip_records(INTERLEAVED_LITTLE.splitlines(), strict_mode=True))
     assert len(seqs) == 6
     assert seqs[1][0] == "Hesperorni"
     assert seqs[-1][0] == "B.subtilis"
@@ -301,7 +301,7 @@ def test_strict_interleaved_little():
 
 def test_strict_sequential_little():
     seqs = list(
-        MinimalPhylipParser(NONINTERLEAVED_LITTLE.splitlines(), strict_mode=True)
+        iter_phylip_records(NONINTERLEAVED_LITTLE.splitlines(), strict_mode=True)
     )
     assert len(seqs) == 6
     assert seqs[0][0] == "Archaeopt"
@@ -310,7 +310,7 @@ def test_strict_sequential_little():
 
 
 def test_strict_sequential_big():
-    seqs = list(MinimalPhylipParser(NONINTERLEAVED_BIG.splitlines(), strict_mode=True))
+    seqs = list(iter_phylip_records(NONINTERLEAVED_BIG.splitlines(), strict_mode=True))
     assert len(seqs) == 3
     assert seqs[0][0] == "Rhesus"
     assert seqs[-1][0] == "Pig"
@@ -349,21 +349,21 @@ def test_strict_get_align_sequential():
 
 def test_forced_interleaved_matches_autodetect():
     data = RELAXED_INTERLEAVED.splitlines()
-    assert dict(MinimalPhylipParser(data, interleaved=True)) == dict(
-        MinimalPhylipParser(data)
+    assert dict(iter_phylip_records(data, interleaved=True)) == dict(
+        iter_phylip_records(data)
     )
 
 
 def test_forced_sequential_matches_autodetect():
     data = RELAXED_SEQUENTIAL.splitlines()
-    assert dict(MinimalPhylipParser(data, interleaved=False)) == dict(
-        MinimalPhylipParser(data)
+    assert dict(iter_phylip_records(data, interleaved=False)) == dict(
+        iter_phylip_records(data)
     )
 
 
 def test_forced_wrong_layout_raises():
     with pytest.raises(RecordError):
-        list(MinimalPhylipParser(RELAXED_SEQUENTIAL.splitlines(), interleaved=True))
+        list(iter_phylip_records(RELAXED_SEQUENTIAL.splitlines(), interleaved=True))
 
 
 BAD_LENGTH = """2 40
@@ -374,15 +374,15 @@ seq2  ACGTACGTAC
 
 def test_length_mismatch_raises():
     with pytest.raises(RecordError):
-        list(MinimalPhylipParser(BAD_LENGTH.splitlines()))
+        list(iter_phylip_records(BAD_LENGTH.splitlines()))
 
 
 def test_header_only_yields_nothing():
-    assert list(MinimalPhylipParser(["2 30"])) == []
+    assert list(iter_phylip_records(["2 30"])) == []
 
 
 def test_blank_lines_only_yields_nothing():
-    assert list(MinimalPhylipParser(["", "   ", "\t"])) == []
+    assert list(iter_phylip_records(["", "   ", "\t"])) == []
 
 
 def _lower_converter(data: bytes) -> str:
@@ -391,7 +391,7 @@ def _lower_converter(data: bytes) -> str:
 
 def test_custom_converter_applied():
     seqs = dict(
-        MinimalPhylipParser(
+        iter_phylip_records(
             RELAXED_INTERLEAVED.splitlines(), converter=_lower_converter
         )
     )
@@ -415,7 +415,7 @@ def test_load_aligned_seqs_relaxed(tmp_path):
 
 def test_id_map_renames_labels():
     id_map = {"Apis_mellifera_Genome": "bee"}
-    seqs = dict(MinimalPhylipParser(RELAXED_INTERLEAVED.splitlines(), id_map=id_map))
+    seqs = dict(iter_phylip_records(RELAXED_INTERLEAVED.splitlines(), id_map=id_map))
     assert "Apis_mellifera_Genome" not in seqs
     assert seqs["bee"] == "-GCGAGTTCGAAATTTGGGGCTTCTTCTTC"
 
@@ -427,5 +427,5 @@ seq1  ACGTACGTAC
 
 
 def test_single_sequence():
-    seqs = dict(MinimalPhylipParser(SINGLE_SEQUENCE.splitlines()))
+    seqs = dict(iter_phylip_records(SINGLE_SEQUENCE.splitlines()))
     assert seqs == {"seq1": "ACGTACGTACGTACGTACGT"}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a more flexible PHYLIP parser with strict and relaxed modes, update sequence parsing to use the new iterator, and extend tests and CI configuration accordingly.

New Features:
- Add iter_phylip_records with support for relaxed and strict PHYLIP formats, automatic layout detection, custom converters, and ID remapping.
- Expose PHYLIP parsing through the SequenceParser with converter support and integration into cogent3.load_aligned_seqs.

Bug Fixes:
- Validate parsed PHYLIP sequence lengths against the header and raise RecordError on mismatches, including bad layout or inconsistent lengths.
- Handle empty and header-only PHYLIP inputs without errors, yielding no records instead.

Enhancements:
- Refactor get_align_for_phylip to be built on the new PHYLIP record iterator and mark MinimalPhylipParser as a deprecated alias.
- Expand PHYLIP parser tests to cover relaxed/strict, interleaved/sequential layouts, custom converters, ID mapping, and single-sequence inputs.
- Tweak table helper docstrings for make_table and load_table for clearer documentation.

CI:
- Adjust the testing_develop workflow to set HOMEBREW_NO_REQUIRE_TAP_TRUST for Coveralls on macOS and fix a comment typo.