### PR TITLE
DEV: hardened all github actions using zizmor and pinact

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.36.2
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.36.2
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,6 +72,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.36.2
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,14 +9,20 @@ on:
     branches-ignore:
       - master
 
+permissions: {}
+
 jobs:
   linters:
     runs-on: ubuntu-latest
     if: github.repository == 'cogent3/cogent3'
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
       - name: Install dependencies
@@ -28,7 +34,7 @@ jobs:
       - name: Format code using ruff
         run: ruff check --fix-only . && ruff format .
       - name: Commit changes
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           author_name: ${{ github.actor }}
           author_email: ${{ github.actor }}@users.noreply.github.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,26 +2,31 @@ name: Release
 
 on: [workflow_dispatch]
 
+permissions: {}
+
 jobs:
   test:
     name: "Test on Python ${{ matrix.python-version }} (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: "actions/checkout@v7.0.0"
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Setup env
-      - uses: "actions/setup-python@v6.2.0"
+      - uses: "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" # v6.2.0
         with:
             python-version: "${{ matrix.python-version }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -40,17 +45,20 @@ jobs:
   docbuild:
     name: "Test the docs"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: "actions/checkout@v7.0.0"
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: "actions/setup-python@v6.2.0"
+      - uses: "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" # v6.2.0
         with:
             python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -67,13 +75,16 @@ jobs:
     name: Build wheel and sdist
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
       
@@ -86,7 +97,7 @@ jobs:
         run: python -m build --wheel --sdist
 
       - name: Upload sdist and wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: c3-wheel-sdist
           path: |
@@ -103,7 +114,7 @@ jobs:
 
     steps:
       - name: Download sdist and wheel
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: c3-wheel-sdist
           path: ./dist
@@ -123,7 +134,7 @@ jobs:
 
     steps:
       - name: Download sdist and wheel
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: c3-wheel-sdist
           path: ./dist

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -12,10 +12,14 @@ on:
 # - release.yml
 # - noxfile.py
 
+permissions: {}
+
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }} (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -23,17 +27,18 @@ jobs:
         python-version: ["3.11", "3.14"]
 
     steps:
-      - uses: "actions/checkout@v7.0.0"
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Setup env
-      - uses: "actions/setup-python@v6.2.0"
+      - uses: "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" # v6.2.0
         with:
             python-version: "${{ matrix.python-version }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -51,7 +56,7 @@ jobs:
           nox  -db uv --force-python python -s test -- $cov
 
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         env:
           # macOS installs the coverage-reporter via a third-party Homebrew
           # tap; Homebrew's new tap-trust enforcement refuses it otherwise.
@@ -65,6 +70,8 @@ jobs:
   type_check:
     name: Type Check
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -72,16 +79,17 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: "actions/setup-python@v6.2.0"
+      - uses: "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" # v6.2.0
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -97,9 +105,11 @@ jobs:
     name: "Finish Coveralls"
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true


### PR DESCRIPTION
[NEW] zizmore installed from pypi, pinact from homebrew

## Summary by Sourcery

Harden GitHub Actions workflows by tightening permissions and pinning all third-party actions to specific commit SHAs.

Build:
- Restrict default and job-level GitHub Actions permissions, including read-only contents for testing and docs workflows and write access only where commits are made.
- Pin all CI-related actions (checkout, setup-python, setup-uv, artifact upload/download, Coveralls, CodeQL, add-and-commit) to explicit commit SHAs to improve supply-chain security.