### PR TITLE
MAINT: annotate var_pos func to fix mypy error under numba 0.66

### DIFF
--- a/src/cogent3/core/alignment.py
+++ b/src/cogent3/core/alignment.py
@@ -4029,7 +4029,7 @@ class Alignment(CollectionBase[Aligned]):
         missing_index = alpha.missing_index or len(alpha)
         if include_gap_motif and include_ambiguity:
             # allow all states
-            func = None
+            func: Callable[..., npt.NDArray[numpy.bool]] | None = None
             kwargs = {}
         elif include_gap_motif and self.moltype.gapped_missing_alphabet:
             # allow canonical, gap, missing


### PR DESCRIPTION
[CHANGED] stricter Dispatcher stubs in numba 0.66 narrowed func
    from its first jitted assignment, rejecting the later
    reassignments. An explicit Callable | None annotation makes it
    version-independent.

## Summary by Sourcery

Enhancements:
- Tighten typing in variable_positions by explicitly annotating the internal dispatch function as an optional callable returning a boolean NumPy array.