### PR TITLE
TST: add explicit tests for all write methods

### DIFF
--- a/tests/test_core/test_alignment.py
+++ b/tests/test_core/test_alignment.py
@@ -2419,6 +2419,21 @@ def test_sequence_collection_write(collection_maker, tmp_path):
     assert result == ">a\nAAAA\n>b\nTTTT\n>c\nCCCC\n"
 
 
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+@pytest.mark.parametrize(
+    "collection_maker",
+    [c3_alignment.make_unaligned_seqs, c3_alignment.make_aligned_seqs],
+)
+def test_sequence_collection_write_home_dir(collection_maker, HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    data = {"a": "AAAA", "b": "TTTT", "c": "CCCC"}
+    seqs = collection_maker(data, moltype="dna")
+    seqs.write(transform(f"~/{HOME_TMP_DIR.name}/seqs.fasta"))
+    written = HOME_TMP_DIR / "seqs.fasta"
+    result = written.read_text()
+    assert result == ">a\nAAAA\n>b\nTTTT\n>c\nCCCC\n"
+
+
 @pytest.mark.parametrize(
     "mk_cls",
     [c3_alignment.make_unaligned_seqs, c3_alignment.make_aligned_seqs],

--- a/tests/test_core/test_annotation_db.py
+++ b/tests/test_core/test_annotation_db.py
@@ -1321,6 +1321,16 @@ def test_write(gb_db, tmp_path):
     close_dbs(got, gb_db)
 
 
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_write_home_dir(gb_db, HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    gb_db.write(transform(f"~/{HOME_TMP_DIR.name}/ondisk.c3gbdb"))
+    got = GenbankAnnotationDb.from_file(HOME_TMP_DIR / "ondisk.c3gbdb")
+    assert got.to_rich_dict()["tables"] == gb_db.to_rich_dict()["tables"]
+    assert isinstance(got, GenbankAnnotationDb)
+    close_dbs(got, gb_db)
+
+
 def convert_to_old_np_format(data: bytes) -> bytes:
     with io.BytesIO(data) as stream:
         return numpy.load(stream).tobytes()

--- a/tests/test_core/test_sequence.py
+++ b/tests/test_core/test_sequence.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 import re
 import typing
 from pickle import dumps
@@ -3212,6 +3213,16 @@ def test_sequence_write_json(tmp_path):
     with open(path) as fn:
         got = json.loads(fn.read())
     assert got == seq.to_rich_dict()
+
+
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_sequence_write_home_dir(HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    seq = c3_moltype.DNA.make_seq(seq="TCAGAT", name="test_seq")
+    seq.write(transform(f"~/{HOME_TMP_DIR.name}/seq.fasta"))
+    result = cogent3.load_seq(HOME_TMP_DIR / "seq.fasta", moltype="dna")
+    assert result.name == "test_seq"
+    assert str(result) == "TCAGAT"
 
 
 def test_load_seq_from_json(tmp_path):

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -2071,6 +2071,18 @@ def test_write_compressed(tmp_path):
     assert got == expect
 
 
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_write_home_dir(HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    t = load_table("data/sample.tsv")
+    t.write(transform(f"~/{HOME_TMP_DIR.name}/table.tsv"))
+    written = HOME_TMP_DIR / "table.tsv"
+    assert written.exists()
+    got = load_table(written)
+    assert got.shape == t.shape
+    assert got.header == t.header
+
+
 def test_load_table_from_json(tmp_path):
     """tests loading a Table object from json file"""
     json_path = tmp_path / "table.json"

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -298,6 +298,17 @@ def test_write_to_txt(DATA_DIR: pathlib.Path, tmp_path: pathlib.Path):
         assert got.count("(") == got.count(")") == 3
 
 
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_write_home_dir(DATA_DIR: pathlib.Path, HOME_TMP_DIR: pathlib.Path, transform):
+    # write to a "~/" home directory style path
+    tree = load_tree(filename=DATA_DIR / "brca1_5.tree")
+    tree.write(transform(f"~/{HOME_TMP_DIR.name}/brca1_5.txt"))
+    written = HOME_TMP_DIR / "brca1_5.txt"
+    assert written.exists()
+    got = written.read_text()
+    assert got.count("(") == got.count(")") == 3
+
+
 def test_multifurcating():
     """Coerces nodes to have <= n children"""
     t_str = "((a:1,b:2,c:3)d:4,(e:5,f:6,g:7)h:8,(i:9,j:10,k:11)l:12)m:14;"

--- a/tests/test_draw/test_draw_integration.py
+++ b/tests/test_draw/test_draw_integration.py
@@ -473,3 +473,14 @@ def test_colour_choice():
 def test_arrow_shapes(biotype):
     shape = make_shape(type_=biotype, coords=[(10, 20)], parent_length=20)
     assert isinstance(shape, Arrow)
+
+
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_write_home_dir(HOME_TMP_DIR, transform):
+    # write a static image to a "~/" home directory style path
+    d = Drawable(width=300, height=300)
+    d.add_trace({"type": "scatter", "x": [0, 1, 2], "y": [0, 1, 2]})
+    d.write(transform(f"~/{HOME_TMP_DIR.name}/plot.png"))
+    written = HOME_TMP_DIR / "plot.png"
+    assert written.exists()
+    assert written.stat().st_size > 0

--- a/tests/test_evolve/test_distance.py
+++ b/tests/test_evolve/test_distance.py
@@ -1,3 +1,4 @@
+import pathlib
 import warnings
 
 import numpy
@@ -831,6 +832,15 @@ def test_EstimateDistances(tmp_path, al):
 
     # excercise writing to file
     d.write(tmp_path / "junk.txt")
+
+
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_EstimateDistances_write_home_dir(al, HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    d = EstimateDistances(al, JC69())
+    d.run(show_progress=False)
+    d.write(transform(f"~/{HOME_TMP_DIR.name}/dists.txt"))
+    assert (HOME_TMP_DIR / "dists.txt").exists()
 
 
 def test_take_dists():

--- a/tests/test_phylo.py
+++ b/tests/test_phylo.py
@@ -5,6 +5,7 @@ import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
 from numpy import exp, log
 
 from cogent3 import get_model, load_aligned_seqs, load_tree, make_tree
@@ -488,6 +489,18 @@ class ConsensusTests(unittest.TestCase):
         # convert lnL into p
         eval_klass(WeightedTreeCollection([(exp(s), t) for s, t in self.scored_trees]))
         Path("sample.trees").unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_scored_tree_collection_write_home_dir(HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    scored = [(-1.0, Tree("((a,b),c,d);")), (-2.0, Tree("((a,c),b,d);"))]
+    coll = LogLikelihoodScoredTreeCollection(scored)
+    coll.write(transform(f"~/{HOME_TMP_DIR.name}/collection.trees"))
+    written = HOME_TMP_DIR / "collection.trees"
+    assert written.exists()
+    read = make_trees(str(written))
+    assert type(read) == type(coll)
 
 
 class TreeReconstructionTests(unittest.TestCase):

--- a/tests/test_util/test_dictarray.py
+++ b/tests/test_util/test_dictarray.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
@@ -513,3 +514,17 @@ def test_dictarray_from_array_names(data, names):
     assert darr.template.names == list(names)
     # indexed value correct, can be an array, or a float
     assert_allclose(darr["T"], data[0])
+
+
+@pytest.mark.parametrize("transform", [str, pathlib.Path])
+def test_write_home_dir(HOME_TMP_DIR, transform):
+    # write to a "~/" home directory style path
+    data = [[3, 7], [2, 8], [5, 5]]
+    darr = DictArrayTemplate(list("ABC"), list("ab")).wrap(data)
+    darr.write(transform(f"~/{HOME_TMP_DIR.name}/delme.tsv"))
+    written = HOME_TMP_DIR / "delme.tsv"
+    contents = [line.split() for line in written.read_text().splitlines()]
+    header = contents.pop(0)
+    assert header == ["dim-1", "dim-2", "value"]
+    got = {(k1, k2): int(v) for k1, k2, v in contents}
+    assert got == darr.to_dict(flatten=True)


### PR DESCRIPTION
[NEW] test output paths relative to homedir work

## Summary by Sourcery

Add explicit tests verifying various write methods correctly handle home-directory-style output paths.

Tests:
- Add tests ensuring sequence collections can write to paths under the user home directory syntax.
- Add DictArrayTemplate write tests for home-directory-style TSV output.
- Add tests confirming tree, scored tree collection, and distance estimation outputs can be written to home-directory paths.
- Add tests verifying sequence, table, drawable plot, and GenbankAnnotationDb objects write correctly using tilde-expanded paths.