### PR TITLE
TST: convert test_core unittest modules to pytest style

### DIFF
--- a/tests/test_core/test_features.py
+++ b/tests/test_core/test_features.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import numpy
 import pytest
 
@@ -24,24 +22,6 @@ def close_dbs(*objs):
             continue
 
         db.close()
-
-
-class FeaturesTest(TestCase):
-    """Tests of features in core"""
-
-    def setUp(self):
-        # A Sequence with a couple of exons on it.
-        self.s = DNA.make_seq(
-            seq="AAGAAGAAGACCCCCAAAAAAAAAATTTTTTTTTTAAAAAAAAAAAAA",
-            name="Orig",
-        )
-        self.exon1 = self.s.add_feature(biotype="exon", name="fred", spans=[(10, 15)])
-        self.exon2 = self.s.add_feature(biotype="exon", name="trev", spans=[(30, 40)])
-        self.nested_feature = self.s.add_feature(
-            biotype="repeat",
-            name="bob",
-            spans=[(12, 17)],
-        )
 
 
 @pytest.fixture

--- a/tests/test_core/test_info.py
+++ b/tests/test_core/test_info.py
@@ -1,149 +1,153 @@
-#!/usr/bin/env python
 """Unit tests for Info class and associated objects (DbRef, DbRefs, etc.)."""
 
 import warnings
-from unittest import TestCase
+
+import pytest
 
 from cogent3.core.info import DbRef, DbRefs, Info, _make_list
 
 
-class DbRefTests(TestCase):
-    """Tests of the DbRef object."""
-
-    def setUp(self):
-        """Define a standard DbRef object"""
-        self.data = {
-            "Accession": "xyz",
-            "Db": "abc",
-            "name": "qwe",
-            "Description": "blah",
-            "Data": list(range(20)),
-        }
-        self.db = DbRef(**self.data)
-
-    def test_init_minimal(self):
-        """DbRef minimal init should fill fields as expected"""
-        d = DbRef("abc")
-        assert d.Accession == "abc"
-        assert d.Db == ""
-        assert d.name == ""
-        assert d.Description == ""
-        assert d.Data is None
-        # empty init not allowed
-        self.assertRaises(TypeError, DbRef)
-
-    def test_init(self):
-        """DbRef init should insert correct data"""
-        for attr, val in list(self.data.items()):
-            assert getattr(self.db, attr) == val
-
-    def test_str(self):
-        """DbRef str should be the same as the accession str"""
-        assert str(self.db) == "xyz"
-        self.db.Accession = 12345
-        assert str(self.db) == "12345"
-
-    def test_int(self):
-        """DbRef int should be the same as the accession int"""
-        self.assertRaises(ValueError, int, self.db)
-        self.db.Accession = "12345"
-        assert int(self.db) == 12345
-
-    def test_cmp(self):
-        """DbRef cmp should first try numeric, then alphabetic, cmp."""
-        assert DbRef("abc") < DbRef("xyz")
-        assert DbRef("abc") == DbRef("abc")
-        assert DbRef("123") > DbRef("14")
-        assert DbRef("123") < DbRef("abc")
-        # check that it ignores other attributes
-        assert DbRef("x", "y", "z", "a", "b") == DbRef("x")
+@pytest.fixture
+def data():
+    return {
+        "Accession": "xyz",
+        "Db": "abc",
+        "name": "qwe",
+        "Description": "blah",
+        "Data": list(range(20)),
+    }
 
 
-class infoTests(TestCase):
-    """Tests of top-level functions."""
-
-    def test_make_list(self):
-        """_make_list should always return a list"""
-        assert _make_list("abc") == ["abc"]
-        assert _make_list([]) == []
-        assert _make_list(None) == [None]
-        assert _make_list({"x": "y"}) == [{"x": "y"}]
-        assert _make_list([1, 2, 3]) == [1, 2, 3]
+@pytest.fixture
+def db(data):
+    return DbRef(**data)
 
 
-class DbRefsTests(TestCase):
-    """Tests of the DbRefs class."""
-
-    def test_init_empty(self):
-        """DbRefs empty init should work as expected"""
-        assert DbRefs() == {}
-
-    def test_init_data(self):
-        """DbRefs init with data should produce expected results"""
-        d = DbRefs({"GenBank": "ab", "GO": (3, 44), "PDB": ["asdf", "ghjk"]})
-        assert d == {"GenBank": ["ab"], "GO": [3, 44], "PDB": ["asdf", "ghjk"]}
-        d.GenBank = "xyz"
-        assert d["GenBank"] == ["xyz"]
+def test_init_minimal():
+    # DbRef minimal init should fill fields as expected
+    d = DbRef("abc")
+    assert d.Accession == "abc"
+    assert d.Db == ""
+    assert d.name == ""
+    assert d.Description == ""
+    assert d.Data is None
+    # empty init not allowed
+    with pytest.raises(TypeError):
+        DbRef()
 
 
-class InfoTests(TestCase):
-    """Tests of the Info class."""
-
-    def test_init_empty(self):
-        """Info empty init should work as expected"""
-        d = Info()
-        assert len(d) == 1
-        assert "Refs" in d
-        assert d.Refs == DbRefs()
-        assert isinstance(d.Refs, DbRefs)
-
-    def test_init_data(self):
-        """Info init with data should put items in correct places"""
-        # need to check init, setting, and resetting of attributes that belong
-        # in the Info object and attributes that belong in Info.Refs. Also need
-        # to check __getitem__, __setitem__, and __contains__.
-        d = Info({"x": 3, "GO": 12345})
-        assert d.x == 3
-        assert d.GO == [12345]
-        assert d.Refs.GO == [12345]
-        try:
-            del d.Refs
-        except AttributeError:
-            pass
-        else:
-            msg = "Failed to prevent deletion of required key Refs"
-            raise Exception(msg)
-        d.GenBank = ("qaz", "wsx")
-        assert d.GenBank == ["qaz", "wsx"]
-        assert "GenBank" in d.Refs
-        assert "GenBank" in d
-        d.GenBank = "xyz"
-        assert d.GenBank == ["xyz"]
-        assert d.GenBank is d.Refs.GenBank
-        d.GO = "x"
-        assert d.GO == ["x"]
-        d.GO.append("y")
-        assert d.GO == ["x", "y"]
-        d.ZZZ = "zzz"
-        assert d.ZZZ == "zzz"
-        assert "ZZZ" not in d.Refs
-        assert "XXX" not in d
-        assert d.XXX is None
-
-    def test_identity(self):
-        """Info should get its own new Refs when created"""
-        i = Info()
-        j = Info()
-        assert i is not j
-        assert i.Refs is not j.Refs
-
-    def test_update(self):
-        """update should warn the user of overlapping keys"""
-        with warnings.catch_warnings(record=True) as w:
-            d1 = Info({"key1": "value1", "key2": "value2", "key3": "value3"})
-            d2 = Info({"key2": "value2", "key3": "value3", "key4": "value4"})
-            d1.update(d2)
-            assert len(w) == 1
+@pytest.mark.parametrize(
+    ("attr", "val"),
+    [
+        ("Accession", "xyz"),
+        ("Db", "abc"),
+        ("name", "qwe"),
+        ("Description", "blah"),
+        ("Data", list(range(20))),
+    ],
+)
+def test_init(db, attr, val):
+    # DbRef init should insert correct data
+    assert getattr(db, attr) == val
 
 
-# run the following if invoked from command-line
+def test_str(db):
+    # DbRef str should be the same as the accession str
+    assert str(db) == "xyz"
+    db.Accession = 12345
+    assert str(db) == "12345"
+
+
+def test_int(db):
+    # DbRef int should be the same as the accession int
+    with pytest.raises(ValueError):
+        int(db)
+    db.Accession = "12345"
+    assert int(db) == 12345
+
+
+def test_cmp():
+    # DbRef cmp should first try numeric, then alphabetic, cmp
+    assert DbRef("abc") < DbRef("xyz")
+    assert DbRef("abc") == DbRef("abc")
+    assert DbRef("123") > DbRef("14")
+    assert DbRef("123") < DbRef("abc")
+    # check that it ignores other attributes
+    assert DbRef("x", "y", "z", "a", "b") == DbRef("x")
+
+
+def test_make_list():
+    # _make_list should always return a list
+    assert _make_list("abc") == ["abc"]
+    assert _make_list([]) == []
+    assert _make_list(None) == [None]
+    assert _make_list({"x": "y"}) == [{"x": "y"}]
+    assert _make_list([1, 2, 3]) == [1, 2, 3]
+
+
+def test_dbrefs_init_empty():
+    # DbRefs empty init should work as expected
+    assert DbRefs() == {}
+
+
+def test_dbrefs_init_data():
+    # DbRefs init with data should produce expected results
+    d = DbRefs({"GenBank": "ab", "GO": (3, 44), "PDB": ["asdf", "ghjk"]})
+    assert d == {"GenBank": ["ab"], "GO": [3, 44], "PDB": ["asdf", "ghjk"]}
+    d.GenBank = "xyz"
+    assert d["GenBank"] == ["xyz"]
+
+
+def test_info_init_empty():
+    # Info empty init should work as expected
+    d = Info()
+    assert len(d) == 1
+    assert "Refs" in d
+    assert d.Refs == DbRefs()
+    assert isinstance(d.Refs, DbRefs)
+
+
+def test_info_init_data():
+    # Info init with data should put items in correct places
+    # need to check init, setting, and resetting of attributes that belong
+    # in the Info object and attributes that belong in Info.Refs. Also need
+    # to check __getitem__, __setitem__, and __contains__.
+    d = Info({"x": 3, "GO": 12345})
+    assert d.x == 3
+    assert d.GO == [12345]
+    assert d.Refs.GO == [12345]
+    with pytest.raises(AttributeError):
+        del d.Refs
+    d.GenBank = ("qaz", "wsx")
+    assert d.GenBank == ["qaz", "wsx"]
+    assert "GenBank" in d.Refs
+    assert "GenBank" in d
+    d.GenBank = "xyz"
+    assert d.GenBank == ["xyz"]
+    assert d.GenBank is d.Refs.GenBank
+    d.GO = "x"
+    assert d.GO == ["x"]
+    d.GO.append("y")
+    assert d.GO == ["x", "y"]
+    d.ZZZ = "zzz"
+    assert d.ZZZ == "zzz"
+    assert "ZZZ" not in d.Refs
+    assert "XXX" not in d
+    assert d.XXX is None
+
+
+def test_identity():
+    # Info should get its own new Refs when created
+    i = Info()
+    j = Info()
+    assert i is not j
+    assert i.Refs is not j.Refs
+
+
+def test_update():
+    # update should warn the user of overlapping keys
+    with warnings.catch_warnings(record=True) as w:
+        d1 = Info({"key1": "value1", "key2": "value2", "key3": "value3"})
+        d2 = Info({"key2": "value2", "key3": "value3", "key4": "value4"})
+        d1.update(d2)
+        assert len(w) == 1

--- a/tests/test_core/test_location.py
+++ b/tests/test_core/test_location.py
@@ -1,6 +1,5 @@
 import re
 from itertools import combinations
-from unittest import TestCase
 
 import numpy
 import pytest
@@ -23,257 +22,282 @@ from cogent3.core.location import (
 DNA = cogent3.get_moltype("dna")
 
 
-class SpanTests(TestCase):
-    """Tests of the Span object."""
-
-    def setUp(self):
-        """Define some standard Spans"""
-        self.empty = Span(0, 0)
-        self.full = Span(35, 30)  # will convert to (30, 35) internally
-        self.overlapping = Span(32, 36)
-        self.inside = Span(31, 32)
-        self.before = Span(25, 30)
-        self.after = Span(35, 40)
-        self.reverse = Span(30, 35, reverse=True)
-        self.spans_zero = Span(-5, 5)
-
-    def test_init(self):
-        """Span object should init with start, end, and Length"""
-        s = Span(0)
-        assert s.start == 0
-        assert s.end == 1
-        assert s.reverse is False
-        # to get an empty interval, must specify start and end explicitly
-        t = Span(0, 0)
-        assert t.start == 0
-        assert t.end == 0
-        assert t.reverse is False
-        # should be able to specify direction also
-        u = Span(5, 15, reverse=True)
-        assert u.start == 5
-        assert u.end == 15
-        assert u.reverse is True
-        # should be able to init from another span
-        v = Span(u)
-        assert v.start == 5
-        assert v.end == 15
-        assert v.reverse is True
-
-    def test_contains(self):
-        """Span object contains its start but not its end"""
-        assert 0 not in self.empty
-        assert 30 in self.full
-        assert 34 in self.full
-        assert 35 not in self.full
-        assert self.inside in self.full
-        assert self.overlapping not in self.full
-        assert 0 in self.spans_zero
-        assert -5 in self.spans_zero
-        assert 5 not in self.spans_zero
-
-    def test_overlaps(self):
-        """Span objects should be able to overlap points or spans"""
-        assert self.full.overlaps(self.overlapping)
-        assert not self.full.overlaps(self.before)
-        assert not self.before.overlaps(self.overlapping)
-        assert not self.full.overlaps(self.after)
-        assert not self.after.overlaps(self.before)
-        assert self.full.overlaps(self.inside)
-        assert self.spans_zero.overlaps(self.empty)
-        assert self.empty.overlaps(self.spans_zero)
-
-    def test_reverses(self):
-        """Span.reverses should change direction"""
-        assert not self.empty.reverse
-        self.empty.reverses()
-        assert self.empty.reverse
-        self.empty.reverses()
-        assert not self.empty.reverse
-        assert self.reverse.reverse
-        self.reverse.reverses()
-        assert not self.reverse.reverse
-
-    def test_iter(self):
-        """Span iter should loop through (integer) contents"""
-        assert list(iter(self.empty)) == []
-        assert list(iter(self.full)) == [30, 31, 32, 33, 34]
-        assert list(iter(self.spans_zero)) == [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4]
-        assert list(iter(self.inside)) == [31]
-        assert list(self.reverse) == [34, 33, 32, 31, 30]
-
-    def test_str(self):
-        """Span str should print start, stop, reverse"""
-        assert str(self.empty) == "(0,0,False)"
-        assert str(self.full) == "(30,35,False)"
-        assert str(self.reverse) == "(30,35,True)"
-
-    def test_len(self):
-        """Span len should return difference between start and end"""
-        assert len(self.empty) == 0
-        assert len(self.full) == 5
-        assert len(self.inside) == 1
-        assert len(self.spans_zero) == 10
-
-    def test_cmp(self):
-        """Span cmp should support sort by 1st/2nd index and direction"""
-        s, e, f, r, i, o = (
-            self.spans_zero,
-            self.empty,
-            self.full,
-            self.reverse,
-            self.inside,
-            self.overlapping,
-        )
-
-        n = Span(30, 36)
-
-        expected_order = [s, e, f, r, n, i, o]
-        first = expected_order[:]
-        first.sort()
-        second = [r, o, f, s, e, i, n]
-        second.sort()
-        for i, j in zip(first, second, strict=False):
-            assert i is j
-
-        for i, j in zip(first, expected_order, strict=False):
-            assert i is j
-
-    def test_sort(self):
-        """Span should support sort by 1st/2nd index and direction"""
-        s, e, _f, _r, i, _o = (
-            self.spans_zero,
-            self.empty,
-            self.full,
-            self.reverse,
-            self.inside,
-            self.overlapping,
-        )
-
-        expected_order = [s, e]
-        first = expected_order[:]
-        first.sort()
-
-        for i, j in zip(first, expected_order, strict=False):
-            assert i is j
-
-    def test_starts_before(self):
-        """Span starts_before should match hand-calculated results"""
-        e, f = self.empty, self.full
-        assert e.starts_before(f)
-        assert not f.starts_before(e)
-        assert e.starts_before(1)
-        assert e.starts_before(1000)
-        assert not e.starts_before(0)
-        assert not e.starts_before(-1)
-        assert not f.starts_before(30)
-        assert f.starts_before(31)
-        assert f.starts_before(1000)
-
-    def test_starts_after(self):
-        """Span starts_after should match hand-calculated results"""
-        e, f = self.empty, self.full
-        assert not e.starts_after(f)
-        assert f.starts_after(e)
-        assert not e.starts_after(1)
-        assert not e.starts_after(1000)
-        assert not e.starts_after(0)
-        assert e.starts_after(-1)
-        assert f.starts_after(29)
-        assert not f.starts_after(30)
-        assert not f.starts_after(31)
-        assert not f.starts_after(1000)
-
-    def test_startsAt(self):
-        """Span startsAt should return True if input matches"""
-        e, f = self.empty, self.full
-        s = Span(30, 1000)
-        assert e.starts_at(0)
-        assert f.starts_at(30)
-        assert s.starts_at(30)
-        assert f.starts_at(s)
-        assert s.starts_at(f)
-        assert not e.starts_at(f)
-        assert not e.starts_at(-1)
-        assert not e.starts_at(1)
-        assert not f.starts_at(29)
-
-    def test_startsInside(self):
-        """Span startsInside should return True if input starts inside span"""
-        e, f, i, o = self.empty, self.full, self.inside, self.overlapping
-        assert not e.starts_inside(0)
-        assert not f.starts_inside(30)
-        assert not e.starts_inside(f)
-        assert i.starts_inside(f)
-        assert not f.starts_inside(i)
-        assert o.starts_inside(f)
-        assert not o.ends_inside(i)
-
-    def test_endsBefore(self):
-        """Span endsBefore should match hand-calculated results"""
-        e, f = self.empty, self.full
-        assert e.ends_before(f)
-        assert not f.ends_before(e)
-        assert e.ends_before(1)
-        assert e.ends_before(1000)
-        assert not e.ends_before(0)
-        assert not e.ends_before(-1)
-        assert not f.ends_before(30)
-        assert not f.ends_before(31)
-        assert f.ends_before(1000)
-
-    def test_endsAfter(self):
-        """Span endsAfter should match hand-calculated results"""
-        e, f = self.empty, self.full
-        assert not e.ends_after(f)
-        assert f.ends_after(e)
-        assert not e.ends_after(1)
-        assert not e.ends_after(1000)
-        assert not e.ends_after(0)
-        assert e.ends_after(-1)
-        assert f.ends_after(29)
-        assert f.ends_after(30)
-        assert f.ends_after(34)
-        assert not f.ends_after(35)
-        assert not f.ends_after(1000)
-
-    def test_endsAt(self):
-        """Span endsAt should return True if input matches"""
-        e, f = self.empty, self.full
-        s = Span(30, 1000)
-        t = Span(-100, 35)
-        assert e.ends_at(0)
-        assert f.ends_at(35)
-        assert s.ends_at(1000)
-        assert not f.ends_at(s)
-        assert not s.ends_at(f)
-        assert f.ends_at(t)
-        assert t.ends_at(f)
-
-    def test_ends_inside(self):
-        """Span ends_inside should return True if input ends inside span"""
-        e, f, i, o = self.empty, self.full, self.inside, self.overlapping
-        assert not e.ends_inside(0)
-        assert not f.ends_inside(30)
-        assert not f.ends_inside(34)
-        assert not f.ends_inside(35)
-        assert not e.ends_inside(f)
-        assert i.ends_inside(f)
-        assert not f.ends_inside(i)
-        assert not o.ends_inside(f)
-        assert not o.ends_inside(i)
-        assert e.ends_inside(Span(-1, 1))
-        assert e.ends_inside(Span(0, 1))
-        assert not e.ends_inside(Span(-1, 0))
+@pytest.fixture
+def empty():
+    return Span(0, 0)
 
 
-class MapTests(TestCase):
-    """tests of the Map class"""
+@pytest.fixture
+def full():
+    return Span(35, 30)  # will convert to (30, 35) internally
 
-    def test_get_gap_coords(self):
-        """returns gap start and lengths"""
-        m, _ = DNA.make_seq(seq="-AC--GT-TTA--").parse_out_gaps()
-        got = m.get_gap_coordinates()
-        assert dict(got) == {0: 1, 2: 2, 4: 1, 7: 2}
+
+@pytest.fixture
+def overlapping():
+    return Span(32, 36)
+
+
+@pytest.fixture
+def inside():
+    return Span(31, 32)
+
+
+@pytest.fixture
+def before():
+    return Span(25, 30)
+
+
+@pytest.fixture
+def after():
+    return Span(35, 40)
+
+
+@pytest.fixture
+def reverse():
+    return Span(30, 35, reverse=True)
+
+
+@pytest.fixture
+def spans_zero():
+    return Span(-5, 5)
+
+
+def test_init():
+    # Span object should init with start, end, and Length
+    s = Span(0)
+    assert s.start == 0
+    assert s.end == 1
+    assert s.reverse is False
+    # to get an empty interval, must specify start and end explicitly
+    t = Span(0, 0)
+    assert t.start == 0
+    assert t.end == 0
+    assert t.reverse is False
+    # should be able to specify direction also
+    u = Span(5, 15, reverse=True)
+    assert u.start == 5
+    assert u.end == 15
+    assert u.reverse is True
+    # should be able to init from another span
+    v = Span(u)
+    assert v.start == 5
+    assert v.end == 15
+    assert v.reverse is True
+
+
+def test_contains(empty, full, overlapping, inside, spans_zero):
+    # Span object contains its start but not its end
+    assert 0 not in empty
+    assert 30 in full
+    assert 34 in full
+    assert 35 not in full
+    assert inside in full
+    assert overlapping not in full
+    assert 0 in spans_zero
+    assert -5 in spans_zero
+    assert 5 not in spans_zero
+
+
+def test_overlaps(empty, full, overlapping, inside, before, after, spans_zero):
+    # Span objects should be able to overlap points or spans
+    assert full.overlaps(overlapping)
+    assert not full.overlaps(before)
+    assert not before.overlaps(overlapping)
+    assert not full.overlaps(after)
+    assert not after.overlaps(before)
+    assert full.overlaps(inside)
+    assert spans_zero.overlaps(empty)
+    assert empty.overlaps(spans_zero)
+
+
+def test_reverses(empty, reverse):
+    # Span.reverses should change direction
+    assert not empty.reverse
+    empty.reverses()
+    assert empty.reverse
+    empty.reverses()
+    assert not empty.reverse
+    assert reverse.reverse
+    reverse.reverses()
+    assert not reverse.reverse
+
+
+def test_iter(empty, full, inside, reverse, spans_zero):
+    # Span iter should loop through (integer) contents
+    assert list(iter(empty)) == []
+    assert list(iter(full)) == [30, 31, 32, 33, 34]
+    assert list(iter(spans_zero)) == [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4]
+    assert list(iter(inside)) == [31]
+    assert list(reverse) == [34, 33, 32, 31, 30]
+
+
+def test_str(empty, full, reverse):
+    # Span str should print start, stop, reverse
+    assert str(empty) == "(0,0,False)"
+    assert str(full) == "(30,35,False)"
+    assert str(reverse) == "(30,35,True)"
+
+
+def test_len(empty, full, inside, spans_zero):
+    # Span len should return difference between start and end
+    assert len(empty) == 0
+    assert len(full) == 5
+    assert len(inside) == 1
+    assert len(spans_zero) == 10
+
+
+def test_cmp(empty, full, overlapping, inside, reverse, spans_zero):
+    # Span cmp should support sort by 1st/2nd index and direction
+    s, e, f, r, i, o = (
+        spans_zero,
+        empty,
+        full,
+        reverse,
+        inside,
+        overlapping,
+    )
+
+    n = Span(30, 36)
+
+    expected_order = [s, e, f, r, n, i, o]
+    first = expected_order[:]
+    first.sort()
+    second = [r, o, f, s, e, i, n]
+    second.sort()
+    assert all(a is b for a, b in zip(first, second, strict=False))
+    assert all(a is b for a, b in zip(first, expected_order, strict=False))
+
+
+def test_sort(empty, spans_zero):
+    # Span should support sort by 1st/2nd index and direction
+    expected_order = [spans_zero, empty]
+    first = expected_order[:]
+    first.sort()
+    assert all(a is b for a, b in zip(first, expected_order, strict=False))
+
+
+def test_starts_before(empty, full):
+    # Span starts_before should match hand-calculated results
+    e, f = empty, full
+    assert e.starts_before(f)
+    assert not f.starts_before(e)
+    assert e.starts_before(1)
+    assert e.starts_before(1000)
+    assert not e.starts_before(0)
+    assert not e.starts_before(-1)
+    assert not f.starts_before(30)
+    assert f.starts_before(31)
+    assert f.starts_before(1000)
+
+
+def test_starts_after(empty, full):
+    # Span starts_after should match hand-calculated results
+    e, f = empty, full
+    assert not e.starts_after(f)
+    assert f.starts_after(e)
+    assert not e.starts_after(1)
+    assert not e.starts_after(1000)
+    assert not e.starts_after(0)
+    assert e.starts_after(-1)
+    assert f.starts_after(29)
+    assert not f.starts_after(30)
+    assert not f.starts_after(31)
+    assert not f.starts_after(1000)
+
+
+def test_startsAt(empty, full):
+    # Span startsAt should return True if input matches
+    e, f = empty, full
+    s = Span(30, 1000)
+    assert e.starts_at(0)
+    assert f.starts_at(30)
+    assert s.starts_at(30)
+    assert f.starts_at(s)
+    assert s.starts_at(f)
+    assert not e.starts_at(f)
+    assert not e.starts_at(-1)
+    assert not e.starts_at(1)
+    assert not f.starts_at(29)
+
+
+def test_startsInside(empty, full, overlapping, inside):
+    # Span startsInside should return True if input starts inside span
+    e, f, i, o = empty, full, inside, overlapping
+    assert not e.starts_inside(0)
+    assert not f.starts_inside(30)
+    assert not e.starts_inside(f)
+    assert i.starts_inside(f)
+    assert not f.starts_inside(i)
+    assert o.starts_inside(f)
+    assert not o.ends_inside(i)
+
+
+def test_endsBefore(empty, full):
+    # Span endsBefore should match hand-calculated results
+    e, f = empty, full
+    assert e.ends_before(f)
+    assert not f.ends_before(e)
+    assert e.ends_before(1)
+    assert e.ends_before(1000)
+    assert not e.ends_before(0)
+    assert not e.ends_before(-1)
+    assert not f.ends_before(30)
+    assert not f.ends_before(31)
+    assert f.ends_before(1000)
+
+
+def test_endsAfter(empty, full):
+    # Span endsAfter should match hand-calculated results
+    e, f = empty, full
+    assert not e.ends_after(f)
+    assert f.ends_after(e)
+    assert not e.ends_after(1)
+    assert not e.ends_after(1000)
+    assert not e.ends_after(0)
+    assert e.ends_after(-1)
+    assert f.ends_after(29)
+    assert f.ends_after(30)
+    assert f.ends_after(34)
+    assert not f.ends_after(35)
+    assert not f.ends_after(1000)
+
+
+def test_endsAt(empty, full):
+    # Span endsAt should return True if input matches
+    e, f = empty, full
+    s = Span(30, 1000)
+    t = Span(-100, 35)
+    assert e.ends_at(0)
+    assert f.ends_at(35)
+    assert s.ends_at(1000)
+    assert not f.ends_at(s)
+    assert not s.ends_at(f)
+    assert f.ends_at(t)
+    assert t.ends_at(f)
+
+
+def test_ends_inside(empty, full, overlapping, inside):
+    # Span ends_inside should return True if input ends inside span
+    e, f, i, o = empty, full, inside, overlapping
+    assert not e.ends_inside(0)
+    assert not f.ends_inside(30)
+    assert not f.ends_inside(34)
+    assert not f.ends_inside(35)
+    assert not e.ends_inside(f)
+    assert i.ends_inside(f)
+    assert not f.ends_inside(i)
+    assert not o.ends_inside(f)
+    assert not o.ends_inside(i)
+    assert e.ends_inside(Span(-1, 1))
+    assert e.ends_inside(Span(0, 1))
+    assert not e.ends_inside(Span(-1, 0))
+
+
+def test_get_gap_coords():
+    # returns gap start and lengths
+    m, _ = DNA.make_seq(seq="-AC--GT-TTA--").parse_out_gaps()
+    got = m.get_gap_coordinates()
+    assert dict(got) == {0: 1, 2: 2, 4: 1, 7: 2}
 
 
 def test_span_lt_orders_by_indices():

--- a/tests/test_core/test_profile.py
+++ b/tests/test_core/test_profile.py
@@ -1,7 +1,6 @@
 """Provides tests for classes and functions in profile.py"""
 
 from collections import Counter
-from unittest import TestCase
 
 import pytest
 from numpy import array, log2, nan, vstack
@@ -13,524 +12,549 @@ from cogent3.core.profile import PSSM, MotifCountsArray, MotifFreqsArray
 DNA = cogent3.get_moltype("dna")
 
 
-class MotifCountsArrayTests(TestCase):
-    def test_construct_succeeds(self):
-        """construct from int array or list"""
-        from cogent3.maths.stats.number import CategoryCounter
+def test_counts_construct_succeeds():
+    # construct from int array or list
+    from cogent3.maths.stats.number import CategoryCounter
 
-        states = "ACGT"
-        rows = [CategoryCounter([b] * 20) for b in "ACGT"]
-        rows = [r.tolist(states) for r in rows]
-        MotifCountsArray(rows, states)
+    states = "ACGT"
+    rows = [CategoryCounter([b] * 20) for b in "ACGT"]
+    rows = [r.tolist(states) for r in rows]
+    MotifCountsArray(rows, states)
 
-        data = [[2, 4], [3, 5], [4, 8]]
-        got = MotifCountsArray(array(data), "AB")
-        assert got.array.tolist() == data
+    data = [[2, 4], [3, 5], [4, 8]]
+    got = MotifCountsArray(array(data), "AB")
+    assert got.array.tolist() == data
 
-        got = MotifCountsArray(data, "AB")
-        assert got.array.tolist() == data
-
-    def test_construct_fails(self):
-        """fails if given wrong data type or no data"""
-        # can't use a string
-        data = [["A", "A"], ["A", "A"], ["A", "A"]]
-        with pytest.raises(ValueError):
-            MotifCountsArray(data, "AB")
-
-        # or a float
-        data = [[1.1, 2.1], [0.0, 2.1], [3.0, 4.5]]
-        with pytest.raises(ValueError):
-            MotifCountsArray(data, "AB")
-        # or be empty
-        with pytest.raises(ValueError):
-            MotifCountsArray([], "AB")
-
-        with pytest.raises(ValueError):
-            MotifCountsArray([[], []], "AB")
-
-        data = [[2, 4], [3, 5], [4, 8]]
-        with pytest.raises(ValueError):
-            PSSM(data, "ACGT")
-
-    def test_str_repr(self):
-        """exercise str and repr"""
-        data = array([[2, 4], [3, 5], [4, 8]])
-        marr = MotifCountsArray(array(data), "AB")
-        str(marr)
-        repr(marr)
-
-    def test_getitem(self):
-        """slicing should return correct class"""
-        data = array([[2, 4], [3, 5], [4, 8]])
-        marr = MotifCountsArray(array(data), "AB")
-        # print(marr[[1, 2], :])
-        assert marr[0].array.tolist() == [2, 4]
-        assert marr[0, "B"] == 4
-        assert marr[0, :].array.tolist() == [2, 4]
-        assert marr[:, "A"].array.tolist() == [[2], [3], [4]]
-        assert marr[:, "A":"B"].array.tolist() == [[2], [3], [4]]
-        assert marr[1, "A"] == 3
-        marr = MotifCountsArray(array(data), "AB", row_indices=["a", "b", "c"])
-        assert marr["a"].array.tolist() == [2, 4]
-        assert marr["a", "B"] == 4
-        assert marr["a", :].array.tolist() == [2, 4]
-        assert marr[:, "A"].array.tolist() == [[2], [3], [4]]
-        assert marr[:, "A":"B"].array.tolist() == [[2], [3], [4]]
-        assert marr["b", "A"] == 3
-
-    def test_sliced_range(self):
-        """a sliced range should preserve row indices"""
-        motifs = ("A", "C", "G", "T")
-        names = ["FlyingFox", "DogFaced", "FreeTaile"]
-        data = [[316, 134, 133, 317], [321, 136, 123, 314], [331, 143, 127, 315]]
-        counts = MotifCountsArray(data, motifs, row_indices=names)
-        assert counts.keys() == names
-        subset = counts[:2]
-        assert subset.keys() == names[:2]
-
-    def test_to_dict(self):
-        """correctly converts to a dict"""
-        motifs = ["A", "C", "D"]
-        counts = [[4, 0, 0]]
-        marr = MotifCountsArray(counts, motifs)
-        assert marr.to_dict() == {0: {"A": 4, "C": 0, "D": 0}}
-
-    def test_to_freqs(self):
-        """produces a freqs array"""
-        data = array([[2, 4], [3, 5], [4, 8]])
-        marr = MotifCountsArray(array(data), "AB")
-        expect = data / vstack(data.sum(axis=1))
-        got = marr.to_freq_array()
-        assert_allclose(got.array, expect)
-
-    def test_to_freqs_1d(self):
-        """produce a freqs array from 1D counts"""
-        data = [43, 48, 114, 95]
-        total = sum(data)
-        a = MotifCountsArray([43, 48, 114, 95], motifs=("T", "C", "A", "G"))
-        f = a.to_freq_array()
-        assert_allclose(f.array, array([v / total for v in data], dtype=float))
-
-    def test_to_pssm(self):
-        """produces a PSSM array"""
-        data = array(
-            [
-                [10, 30, 50, 10],
-                [25, 25, 25, 25],
-                [5, 80, 5, 10],
-                [70, 10, 10, 10],
-                [60, 15, 5, 20],
-            ],
-        )
-        marr = MotifCountsArray(array(data), "ACGT")
-        got = marr.to_pssm()
-        expect = array(
-            [
-                [-1.322, 0.263, 1.0, -1.322],
-                [0.0, 0.0, 0.0, 0.0],
-                [-2.322, 1.678, -2.322, -1.322],
-                [1.485, -1.322, -1.322, -1.322],
-                [1.263, -0.737, -2.322, -0.322],
-            ],
-        )
-        assert_allclose(got.array, expect, atol=1e-3)
-
-    def test_to_pssm_pseudocount(self):
-        """produces a PSSM array with pseudocount"""
-        data = array(
-            [
-                [10, 30, 50, 10],
-                [25, 25, 25, 25],
-                [5, 80, 0, 10],
-                [70, 10, 10, 10],
-                [60, 15, 0, 20],
-            ],
-        )
-        marr = MotifCountsArray(array(data), "ACGT")
-        got = marr.to_pssm(pseudocount=1)
-        freqs = marr._to_freqs(pseudocount=1)
-        expect = log2(freqs / 0.25)
-        assert_allclose(got.array, expect, atol=1e-3)
-
-    def test_iter(self):
-        """iter count array traverses positions"""
-        data = [[2, 4], [3, 5], [4, 8]]
-        got = MotifCountsArray(array(data), "AB")
-        for row in got:
-            assert row.shape == (2,)
-
-    def test_take(self):
-        """take works like numpy take, supporting negation"""
-        data = array([[2, 4, 9, 2], [3, 5, 8, 0], [4, 8, 25, 13]])
-        marr = MotifCountsArray(data, ["A", "B", "C", "D"])
-        # fails if don't provide an indexable indices
-        with pytest.raises(ValueError):
-            marr.take(1, axis=1)
-
-        # indexing columns using keys
-        cols = marr.take(["A", "D"], axis=1)
-        assert_allclose(cols.array, data.take([0, 3], axis=1))
-        cols = marr.take(["A", "D"], negate=True, axis=1)
-        assert_allclose(cols.array, data.take([1, 2], axis=1))
-        # indexing columns using indexs
-        cols = marr.take([0, 3], axis=1)
-        assert_allclose(cols.array, data.take([0, 3], axis=1))
-        cols = marr.take([0, 3], negate=True, axis=1)
-        assert_allclose(cols.array, data.take([1, 2], axis=1))
-
-        marr = MotifCountsArray(data, ["A", "B", "C", "D"], row_indices=["a", "b", "c"])
-        # rows using keys
-        rows = marr.take(["a", "c"], axis=0)
-        assert_allclose(rows.array, data.take([0, 2], axis=0))
-        rows = marr.take(["a"], negate=True, axis=0)
-        assert_allclose(rows.array, data.take([1, 2], axis=0))
-        # rows using indexes
-        rows = marr.take([0, 2], axis=0)
-        assert_allclose(rows.array, data.take([0, 2], axis=0))
-        rows = marr.take([0], negate=True, axis=0)
-        assert_allclose(rows.array, data.take([1, 2], axis=0))
-
-        # 1D profile
-        marr = MotifCountsArray(data[0], ["A", "B", "C", "D"])
-        cols = marr.take([0], negate=True, axis=1)
-        assert_allclose(cols.array, data[0].take([1, 2, 3]))
+    got = MotifCountsArray(data, "AB")
+    assert got.array.tolist() == data
 
 
-class MotifFreqsArrayTests(TestCase):
-    def test_construct_succeeds(self):
-        """construct from float array or list"""
-        data = [[2 / 6, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
-        MotifFreqsArray(array(data), "AB")
-        data = [[2 / 6, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
+def test_counts_construct_fails():
+    # fails if given wrong data type or no data
+    # can't use a string
+    data = [["A", "A"], ["A", "A"], ["A", "A"]]
+    with pytest.raises(ValueError):
+        MotifCountsArray(data, "AB")
+
+    # or a float
+    data = [[1.1, 2.1], [0.0, 2.1], [3.0, 4.5]]
+    with pytest.raises(ValueError):
+        MotifCountsArray(data, "AB")
+    # or be empty
+    with pytest.raises(ValueError):
+        MotifCountsArray([], "AB")
+
+    with pytest.raises(ValueError):
+        MotifCountsArray([[], []], "AB")
+
+    data = [[2, 4], [3, 5], [4, 8]]
+    with pytest.raises(ValueError):
+        PSSM(data, "ACGT")
+
+
+def test_str_repr():
+    # exercise str and repr
+    data = array([[2, 4], [3, 5], [4, 8]])
+    marr = MotifCountsArray(array(data), "AB")
+    str(marr)
+    repr(marr)
+
+
+def test_getitem():
+    # slicing should return correct class
+    data = array([[2, 4], [3, 5], [4, 8]])
+    marr = MotifCountsArray(array(data), "AB")
+    # print(marr[[1, 2], :])
+    assert marr[0].array.tolist() == [2, 4]
+    assert marr[0, "B"] == 4
+    assert marr[0, :].array.tolist() == [2, 4]
+    assert marr[:, "A"].array.tolist() == [[2], [3], [4]]
+    assert marr[:, "A":"B"].array.tolist() == [[2], [3], [4]]
+    assert marr[1, "A"] == 3
+    marr = MotifCountsArray(array(data), "AB", row_indices=["a", "b", "c"])
+    assert marr["a"].array.tolist() == [2, 4]
+    assert marr["a", "B"] == 4
+    assert marr["a", :].array.tolist() == [2, 4]
+    assert marr[:, "A"].array.tolist() == [[2], [3], [4]]
+    assert marr[:, "A":"B"].array.tolist() == [[2], [3], [4]]
+    assert marr["b", "A"] == 3
+
+
+def test_sliced_range():
+    # a sliced range should preserve row indices
+    motifs = ("A", "C", "G", "T")
+    names = ["FlyingFox", "DogFaced", "FreeTaile"]
+    data = [[316, 134, 133, 317], [321, 136, 123, 314], [331, 143, 127, 315]]
+    counts = MotifCountsArray(data, motifs, row_indices=names)
+    assert counts.keys() == names
+    subset = counts[:2]
+    assert subset.keys() == names[:2]
+
+
+def test_to_dict():
+    # correctly converts to a dict
+    motifs = ["A", "C", "D"]
+    counts = [[4, 0, 0]]
+    marr = MotifCountsArray(counts, motifs)
+    assert marr.to_dict() == {0: {"A": 4, "C": 0, "D": 0}}
+
+
+def test_to_freqs():
+    # produces a freqs array
+    data = array([[2, 4], [3, 5], [4, 8]])
+    marr = MotifCountsArray(array(data), "AB")
+    expect = data / vstack(data.sum(axis=1))
+    got = marr.to_freq_array()
+    assert_allclose(got.array, expect)
+
+
+def test_to_freqs_1d():
+    # produce a freqs array from 1D counts
+    data = [43, 48, 114, 95]
+    total = sum(data)
+    a = MotifCountsArray([43, 48, 114, 95], motifs=("T", "C", "A", "G"))
+    f = a.to_freq_array()
+    assert_allclose(f.array, array([v / total for v in data], dtype=float))
+
+
+def test_counts_to_pssm():
+    # produces a PSSM array
+    data = array(
+        [
+            [10, 30, 50, 10],
+            [25, 25, 25, 25],
+            [5, 80, 5, 10],
+            [70, 10, 10, 10],
+            [60, 15, 5, 20],
+        ],
+    )
+    marr = MotifCountsArray(array(data), "ACGT")
+    got = marr.to_pssm()
+    expect = array(
+        [
+            [-1.322, 0.263, 1.0, -1.322],
+            [0.0, 0.0, 0.0, 0.0],
+            [-2.322, 1.678, -2.322, -1.322],
+            [1.485, -1.322, -1.322, -1.322],
+            [1.263, -0.737, -2.322, -0.322],
+        ],
+    )
+    assert_allclose(got.array, expect, atol=1e-3)
+
+
+def test_to_pssm_pseudocount():
+    # produces a PSSM array with pseudocount
+    data = array(
+        [
+            [10, 30, 50, 10],
+            [25, 25, 25, 25],
+            [5, 80, 0, 10],
+            [70, 10, 10, 10],
+            [60, 15, 0, 20],
+        ],
+    )
+    marr = MotifCountsArray(array(data), "ACGT")
+    got = marr.to_pssm(pseudocount=1)
+    freqs = marr._to_freqs(pseudocount=1)
+    expect = log2(freqs / 0.25)
+    assert_allclose(got.array, expect, atol=1e-3)
+
+
+def test_iter():
+    # iter count array traverses positions
+    data = [[2, 4], [3, 5], [4, 8]]
+    got = MotifCountsArray(array(data), "AB")
+    for row in got:
+        assert row.shape == (2,)
+
+
+def test_take():
+    # take works like numpy take, supporting negation
+    data = array([[2, 4, 9, 2], [3, 5, 8, 0], [4, 8, 25, 13]])
+    marr = MotifCountsArray(data, ["A", "B", "C", "D"])
+    # fails if don't provide an indexable indices
+    with pytest.raises(ValueError):
+        marr.take(1, axis=1)
+
+    # indexing columns using keys
+    cols = marr.take(["A", "D"], axis=1)
+    assert_allclose(cols.array, data.take([0, 3], axis=1))
+    cols = marr.take(["A", "D"], negate=True, axis=1)
+    assert_allclose(cols.array, data.take([1, 2], axis=1))
+    # indexing columns using indexs
+    cols = marr.take([0, 3], axis=1)
+    assert_allclose(cols.array, data.take([0, 3], axis=1))
+    cols = marr.take([0, 3], negate=True, axis=1)
+    assert_allclose(cols.array, data.take([1, 2], axis=1))
+
+    marr = MotifCountsArray(data, ["A", "B", "C", "D"], row_indices=["a", "b", "c"])
+    # rows using keys
+    rows = marr.take(["a", "c"], axis=0)
+    assert_allclose(rows.array, data.take([0, 2], axis=0))
+    rows = marr.take(["a"], negate=True, axis=0)
+    assert_allclose(rows.array, data.take([1, 2], axis=0))
+    # rows using indexes
+    rows = marr.take([0, 2], axis=0)
+    assert_allclose(rows.array, data.take([0, 2], axis=0))
+    rows = marr.take([0], negate=True, axis=0)
+    assert_allclose(rows.array, data.take([1, 2], axis=0))
+
+    # 1D profile
+    marr = MotifCountsArray(data[0], ["A", "B", "C", "D"])
+    cols = marr.take([0], negate=True, axis=1)
+    assert_allclose(cols.array, data[0].take([1, 2, 3]))
+
+
+def test_freqs_construct_succeeds():
+    # construct from float array or list
+    data = [[2 / 6, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
+    MotifFreqsArray(array(data), "AB")
+    data = [[2 / 6, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
+    MotifFreqsArray(data, "AB")
+
+
+def test_freqs_construct_fails():
+    # valid freqs only
+    # no negatives
+    data = [[-2 / 6, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
+    with pytest.raises(ValueError):
         MotifFreqsArray(data, "AB")
 
-    def test_construct_fails(self):
-        """valid freqs only"""
-        # no negatives
-        data = [[-2 / 6, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
-        with pytest.raises(ValueError):
-            MotifFreqsArray(data, "AB")
+    # must sum to 1 on axis=1
+    data = [[2 / 5, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
+    with pytest.raises(ValueError):
+        MotifFreqsArray(data, "AB")
 
-        # must sum to 1 on axis=1
-        data = [[2 / 5, 4 / 6], [3 / 8, 5 / 8], [4 / 12, 8 / 12]]
-        with pytest.raises(ValueError):
-            MotifFreqsArray(data, "AB")
+    data = [["A", "A"], ["A", "A"], ["A", "A"]]
+    with pytest.raises(ValueError):
+        MotifFreqsArray(data, "AB")
 
-        data = [["A", "A"], ["A", "A"], ["A", "A"]]
-        with pytest.raises(ValueError):
-            MotifFreqsArray(data, "AB")
-
-        # int's not allowed
-        data = [[2, 4], [3, 5], [4, 8]]
-        with pytest.raises(ValueError):
-            MotifFreqsArray(data, "AB")
-
-    def test_entropy_terms(self):
-        """Checks entropy_terms works correctly"""
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        got = MotifFreqsArray(array(data), "ABCD")
-        entropy_terms = got.entropy_terms()
-        expect = [[0.5, 0.5, 0.5, 0.5], [0.5, 0.5, 0, 0]]
-        assert_allclose(entropy_terms.array, expect)
-
-    def test_entropy(self):
-        """calculates entripies correctly"""
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        got = MotifFreqsArray(array(data), "ABCD")
-        entropy = got.entropy()
-        assert_allclose(entropy, [2, 1])
-
-    def test_relative_entropy_terms(self):
-        """Check that relative_entropy_terms works for different background distributions"""
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        got = MotifFreqsArray(array(data), "ABCD")
-        rel_entropy = got.relative_entropy_terms(background=None)
-        expected = [[0, 0, 0, 0], [-0.25, -0.25, -0.5, -0.5]]
-        assert_allclose(rel_entropy, expected)
-
-        background = {"A": 0.5, "B": 0.25, "C": 0.125, "D": 0.125}
-        rel_entropy = got.relative_entropy_terms(background=background)
-        expected = [[0.5, 0, -0.125, -0.125], [0, -0.25, -0.375, -0.375]]
-        assert_allclose(rel_entropy, expected)
-
-        with pytest.raises(ValueError):
-            got.relative_entropy_terms(background={"A": -0.5, "B": 1.5})
-
-        with pytest.raises(ValueError):
-            got.relative_entropy_terms(background={"A": 0.5, "B": 0.25, "C": 0.125})
-
-    def test_relative_entropy(self):
-        """calculates relative entropy correctly"""
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        got = MotifFreqsArray(array(data), "ABCD")
-        rel_entropy = got.relative_entropy(background=None)
-        assert_allclose(rel_entropy, [0, -1.5])
-
-        background = {"A": 0.5, "B": 0.25, "C": 0.125, "D": 0.125}
-        rel_entropy = got.relative_entropy(background=background)
-        expected = [0.25, -1]
-        assert_allclose(rel_entropy, expected)
-
-    def test_pairwise_jsd(self):
-        """correctly constructs pairwise JSD dict"""
-        from numpy.random import random
-
-        from cogent3.maths.measure import jsd
-
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        expect = jsd(data[0], data[1])
-        freqs = MotifFreqsArray(array(data), "ACGT")
-        got = freqs.pairwise_jsd()
-        assert_allclose(next(iter(got.values())), expect)
-
-        data = []
-        for _ in range(6):
-            freqs = random(4)
-            freqs = freqs / freqs.sum()
-            data.append(freqs)
-
-        freqs = MotifFreqsArray(array(data), "ACGT")
-        pwise = freqs.pairwise_jsd()
-        assert len(pwise) == 6 * 6 - 6
-
-    def test_pairwise_jsm(self):
-        """correctly constructs pairwise JS metric dict"""
-        from numpy.random import random
-
-        from cogent3.maths.measure import jsm
-
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        expect = jsm(data[0], data[1])
-        freqs = MotifFreqsArray(array(data), "ACGT")
-        got = freqs.pairwise_jsm()
-        assert_allclose(next(iter(got.values())), expect)
-
-        data = []
-        for _ in range(6):
-            freqs = random(4)
-            freqs = freqs / freqs.sum()
-            data.append(freqs)
-
-        freqs = MotifFreqsArray(array(data), "ACGT")
-        pwise = freqs.pairwise_jsm()
-        assert len(pwise) == 6 * 6 - 6
-
-    def test_pairwise_(self):
-        """returns None when single row"""
-        # ndim=1
-        data = [0.25, 0.25, 0.25, 0.25]
-        freqs = MotifFreqsArray(array(data), "ACGT")
-        got = freqs.pairwise_jsm()
-        assert got is None
-
-        # ndim=2
-        data = array([[0.25, 0.25, 0.25, 0.25]])
-        freqs = MotifFreqsArray(data, "ACGT")
-        got = freqs.pairwise_jsm()
-        assert got is None
-
-    def test_information(self):
-        """calculates entropies correctly"""
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        got = MotifFreqsArray(array(data), "ABCD")
-        entropy = got.information()
-        assert_allclose(entropy, [0, 1])
-
-    def test_sim_seq(self):
-        """exercising simulating a sequence"""
-        data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
-        farr = MotifFreqsArray(array(data), "ACGT")
-        pos1 = Counter()
-        pos2 = Counter()
-        num = 1000
-        for _ in range(num):
-            seq = farr.simulate_seq()
-            assert len(seq) == 2
-            pos1[seq[0]] += 1
-            pos2[seq[1]] += 1
-        assert len(pos1) == 4
-        assert len(pos2) == 2
-        assert min(pos1.values()) > 0
-        assert_allclose(pos2["C"] + pos2["A"], num)
-        assert 0 < pos2["C"] / num < 1
-
-    def test_slicing(self):
-        """slice by keys should work"""
-        counts = MotifCountsArray(
-            [[3, 2, 3, 2], [3, 2, 3, 2]],
-            ["A", "C", "G", "T"],
-            row_indices=["DogFaced", "FlyingFox"],
-        )
-        freqs = counts.to_freq_array()
-        got = freqs["FlyingFox"].to_array()
-        assert_allclose(got, [0.3, 0.2, 0.3, 0.2])
-
-    def test_to_pssm(self):
-        """construct PSSM from freqs array"""
-        data = [
-            [0.1, 0.3, 0.5, 0.1],
-            [0.25, 0.25, 0.25, 0.25],
-            [0.05, 0.8, 0.05, 0.1],
-            [0.7, 0.1, 0.1, 0.1],
-            [0.6, 0.15, 0.05, 0.2],
-        ]
-        farr = MotifFreqsArray(data, "ACTG")
-        pssm = farr.to_pssm()
-        expect = array(
-            [
-                [-1.322, 0.263, 1.0, -1.322],
-                [0.0, 0.0, 0.0, 0.0],
-                [-2.322, 1.678, -2.322, -1.322],
-                [1.485, -1.322, -1.322, -1.322],
-                [1.263, -0.737, -2.322, -0.322],
-            ],
-        )
-        assert_allclose(pssm.array, expect, atol=1e-3)
-
-    def test_logo(self):
-        """produces a Drawable with correct layout elements"""
-        data = [
-            [0.1, 0.3, 0.5, 0.1],
-            [0.25, 0.25, 0.25, 0.25],
-            [0.05, 0.8, 0.05, 0.1],
-            [0.7, 0.1, 0.1, 0.1],
-            [0.6, 0.15, 0.05, 0.2],
-        ]
-        farr = MotifFreqsArray(data, "ACTG")
-        # with defaults, has a single x/y axes and number of shapes
-        logo = farr.logo(ylim=0.5)
-        fig = logo.figure
-        assert fig.data == [{}]
-        assert len(fig.layout.xaxis) > 10
-        assert len(fig.layout.yaxis) > 10
-        assert fig.layout.yaxis.range == [0, 0.5]
-        # since the second row are equi-frequent, their information is 0 so
-        # we substract 4 shapes from that column
-        assert len(fig.layout.shapes) == farr.shape[0] * farr.shape[1] - 4
-        # wrapping across multiple rows should produce multiple axes
-        logo = farr.logo(ylim=0.5, wrap=3)
-        fig = logo.figure
-        for axis in ("axis", "axis2"):
-            assert f"x{axis}" in fig.layout
-            assert f"y{axis}" in fig.layout
-
-        # fails if vspace not in range 0-1
-        with pytest.raises(AssertionError):
-            farr.logo(vspace=20)
+    # int's not allowed
+    data = [[2, 4], [3, 5], [4, 8]]
+    with pytest.raises(ValueError):
+        MotifFreqsArray(data, "AB")
 
 
-class PSSMTests(TestCase):
-    def test_construct_succeeds(self):
-        """correctly construction from freqs"""
-        data = [
-            [0.1, 0.3, 0.5, 0.1],
-            [0.25, 0.25, 0.25, 0.25],
-            [0.05, 0.8, 0.05, 0.1],
-            [0.7, 0.1, 0.1, 0.1],
-            [0.6, 0.15, 0.05, 0.2],
-        ]
-        pssm = PSSM(data, "ACTG")
-        expect = array(
-            [
-                [-1.322, 0.263, 1.0, -1.322],
-                [0.0, 0.0, 0.0, 0.0],
-                [-2.322, 1.678, -2.322, -1.322],
-                [1.485, -1.322, -1.322, -1.322],
-                [1.263, -0.737, -2.322, -0.322],
-            ],
-        )
-        assert_allclose(pssm.array, expect, atol=1e-3)
+def test_entropy_terms():
+    # Checks entropy_terms works correctly
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    got = MotifFreqsArray(array(data), "ABCD")
+    entropy_terms = got.entropy_terms()
+    expect = [[0.5, 0.5, 0.5, 0.5], [0.5, 0.5, 0, 0]]
+    assert_allclose(entropy_terms.array, expect)
 
-    def test_construct_fails(self):
-        """construction fails for invalid input"""
 
-        # fails for entries all zero
-        data_all_zero = [
+def test_entropy():
+    # calculates entripies correctly
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    got = MotifFreqsArray(array(data), "ABCD")
+    entropy = got.entropy()
+    assert_allclose(entropy, [2, 1])
+
+
+def test_relative_entropy_terms():
+    # Check that relative_entropy_terms works for different background distributions
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    got = MotifFreqsArray(array(data), "ABCD")
+    rel_entropy = got.relative_entropy_terms(background=None)
+    expected = [[0, 0, 0, 0], [-0.25, -0.25, -0.5, -0.5]]
+    assert_allclose(rel_entropy, expected)
+
+    background = {"A": 0.5, "B": 0.25, "C": 0.125, "D": 0.125}
+    rel_entropy = got.relative_entropy_terms(background=background)
+    expected = [[0.5, 0, -0.125, -0.125], [0, -0.25, -0.375, -0.375]]
+    assert_allclose(rel_entropy, expected)
+
+    with pytest.raises(ValueError):
+        got.relative_entropy_terms(background={"A": -0.5, "B": 1.5})
+
+    with pytest.raises(ValueError):
+        got.relative_entropy_terms(background={"A": 0.5, "B": 0.25, "C": 0.125})
+
+
+def test_relative_entropy():
+    # calculates relative entropy correctly
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    got = MotifFreqsArray(array(data), "ABCD")
+    rel_entropy = got.relative_entropy(background=None)
+    assert_allclose(rel_entropy, [0, -1.5])
+
+    background = {"A": 0.5, "B": 0.25, "C": 0.125, "D": 0.125}
+    rel_entropy = got.relative_entropy(background=background)
+    expected = [0.25, -1]
+    assert_allclose(rel_entropy, expected)
+
+
+def test_pairwise_jsd():
+    # correctly constructs pairwise JSD dict
+    from numpy.random import random
+
+    from cogent3.maths.measure import jsd
+
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    expect = jsd(data[0], data[1])
+    freqs = MotifFreqsArray(array(data), "ACGT")
+    got = freqs.pairwise_jsd()
+    assert_allclose(next(iter(got.values())), expect)
+
+    data = []
+    for _ in range(6):
+        freqs = random(4)
+        freqs = freqs / freqs.sum()
+        data.append(freqs)
+
+    freqs = MotifFreqsArray(array(data), "ACGT")
+    pwise = freqs.pairwise_jsd()
+    assert len(pwise) == 6 * 6 - 6
+
+
+def test_pairwise_jsm():
+    # correctly constructs pairwise JS metric dict
+    from numpy.random import random
+
+    from cogent3.maths.measure import jsm
+
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    expect = jsm(data[0], data[1])
+    freqs = MotifFreqsArray(array(data), "ACGT")
+    got = freqs.pairwise_jsm()
+    assert_allclose(next(iter(got.values())), expect)
+
+    data = []
+    for _ in range(6):
+        freqs = random(4)
+        freqs = freqs / freqs.sum()
+        data.append(freqs)
+
+    freqs = MotifFreqsArray(array(data), "ACGT")
+    pwise = freqs.pairwise_jsm()
+    assert len(pwise) == 6 * 6 - 6
+
+
+def test_pairwise_():
+    # returns None when single row
+    # ndim=1
+    data = [0.25, 0.25, 0.25, 0.25]
+    freqs = MotifFreqsArray(array(data), "ACGT")
+    got = freqs.pairwise_jsm()
+    assert got is None
+
+    # ndim=2
+    data = array([[0.25, 0.25, 0.25, 0.25]])
+    freqs = MotifFreqsArray(data, "ACGT")
+    got = freqs.pairwise_jsm()
+    assert got is None
+
+
+def test_information():
+    # calculates entropies correctly
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    got = MotifFreqsArray(array(data), "ABCD")
+    entropy = got.information()
+    assert_allclose(entropy, [0, 1])
+
+
+def test_sim_seq():
+    # exercising simulating a sequence
+    data = [[0.25, 0.25, 0.25, 0.25], [0.5, 0.5, 0, 0]]
+    farr = MotifFreqsArray(array(data), "ACGT")
+    pos1 = Counter()
+    pos2 = Counter()
+    num = 1000
+    for _ in range(num):
+        seq = farr.simulate_seq()
+        assert len(seq) == 2
+        pos1[seq[0]] += 1
+        pos2[seq[1]] += 1
+    assert len(pos1) == 4
+    assert len(pos2) == 2
+    assert min(pos1.values()) > 0
+    assert_allclose(pos2["C"] + pos2["A"], num)
+    assert 0 < pos2["C"] / num < 1
+
+
+def test_slicing():
+    # slice by keys should work
+    counts = MotifCountsArray(
+        [[3, 2, 3, 2], [3, 2, 3, 2]],
+        ["A", "C", "G", "T"],
+        row_indices=["DogFaced", "FlyingFox"],
+    )
+    freqs = counts.to_freq_array()
+    got = freqs["FlyingFox"].to_array()
+    assert_allclose(got, [0.3, 0.2, 0.3, 0.2])
+
+
+def test_freqs_to_pssm():
+    # construct PSSM from freqs array
+    data = [
+        [0.1, 0.3, 0.5, 0.1],
+        [0.25, 0.25, 0.25, 0.25],
+        [0.05, 0.8, 0.05, 0.1],
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.15, 0.05, 0.2],
+    ]
+    farr = MotifFreqsArray(data, "ACTG")
+    pssm = farr.to_pssm()
+    expect = array(
+        [
+            [-1.322, 0.263, 1.0, -1.322],
             [0.0, 0.0, 0.0, 0.0],
+            [-2.322, 1.678, -2.322, -1.322],
+            [1.485, -1.322, -1.322, -1.322],
+            [1.263, -0.737, -2.322, -0.322],
+        ],
+    )
+    assert_allclose(pssm.array, expect, atol=1e-3)
+
+
+def test_logo():
+    # produces a Drawable with correct layout elements
+    data = [
+        [0.1, 0.3, 0.5, 0.1],
+        [0.25, 0.25, 0.25, 0.25],
+        [0.05, 0.8, 0.05, 0.1],
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.15, 0.05, 0.2],
+    ]
+    farr = MotifFreqsArray(data, "ACTG")
+    # with defaults, has a single x/y axes and number of shapes
+    logo = farr.logo(ylim=0.5)
+    fig = logo.figure
+    assert fig.data == [{}]
+    assert len(fig.layout.xaxis) > 10
+    assert len(fig.layout.yaxis) > 10
+    assert fig.layout.yaxis.range == [0, 0.5]
+    # since the second row are equi-frequent, their information is 0 so
+    # we substract 4 shapes from that column
+    assert len(fig.layout.shapes) == farr.shape[0] * farr.shape[1] - 4
+    # wrapping across multiple rows should produce multiple axes
+    logo = farr.logo(ylim=0.5, wrap=3)
+    fig = logo.figure
+    for axis in ("axis", "axis2"):
+        assert f"x{axis}" in fig.layout
+        assert f"y{axis}" in fig.layout
+
+    # fails if vspace not in range 0-1
+    with pytest.raises(AssertionError):
+        farr.logo(vspace=20)
+
+
+def test_pssm_construct_succeeds():
+    # correctly construction from freqs
+    data = [
+        [0.1, 0.3, 0.5, 0.1],
+        [0.25, 0.25, 0.25, 0.25],
+        [0.05, 0.8, 0.05, 0.1],
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.15, 0.05, 0.2],
+    ]
+    pssm = PSSM(data, "ACTG")
+    expect = array(
+        [
+            [-1.322, 0.263, 1.0, -1.322],
             [0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0],
-        ]
-        with pytest.raises(ValueError):
-            PSSM(data_all_zero, "ACTG")
+            [-2.322, 1.678, -2.322, -1.322],
+            [1.485, -1.322, -1.322, -1.322],
+            [1.263, -0.737, -2.322, -0.322],
+        ],
+    )
+    assert_allclose(pssm.array, expect, atol=1e-3)
 
-        # fails for numpy.nan
-        data_nan = [
-            [nan, -0.263, -1.0, -1.322],
-            [-2.322, -1.678, -2.322, -1.322],
-            [-1.485, -1.322, -1.322, -1.322],
-            [-1.263, -0.737, -2.322, -0.322],
-        ]
-        with pytest.raises(ValueError):
-            PSSM(data_nan, "ACTG")
 
-        # fails for entries all negative numbers
-        data = [
-            [-1.322, -0.263, -1.0, -1.322],
-            [-2.322, -1.678, -2.322, -1.322],
-            [-1.485, -1.322, -1.322, -1.322],
-            [-1.263, -0.737, -2.322, -0.322],
-        ]
-        with pytest.raises(ValueError):
-            PSSM(data, "ACTG")
+def test_pssm_construct_fails():
+    # construction fails for invalid input
 
-    def test_score_indices(self):
-        """produce correct score from indexed seq"""
-        data = [
-            [0.1, 0.3, 0.5, 0.1],
-            [0.25, 0.25, 0.25, 0.25],
-            [0.05, 0.8, 0.05, 0.1],
-            [0.7, 0.1, 0.1, 0.1],
-            [0.6, 0.15, 0.05, 0.2],
-        ]
-        pssm = PSSM(data, "ACTG")
-        indices = [3, 1, 2, 0, 2, 2, 3]
-        scores = pssm.score_indexed_seq(indices)
-        assert_allclose(scores, [-4.481, -5.703, -2.966], atol=1e-3)
+    # fails for entries all zero
+    data_all_zero = [
+        [0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0],
+    ]
+    with pytest.raises(ValueError):
+        PSSM(data_all_zero, "ACTG")
 
-        indices = [4, 1, 2, 0, 2, 2, 3]
-        scores = pssm.score_indexed_seq(indices)
-        # log2 of (0.25 * 0.05 * 0.7 * 0.05) / .25**4 = -3.158...
-        assert_allclose(scores, [-3.158, -5.703, -2.966], atol=1e-3)
+    # fails for numpy.nan
+    data_nan = [
+        [nan, -0.263, -1.0, -1.322],
+        [-2.322, -1.678, -2.322, -1.322],
+        [-1.485, -1.322, -1.322, -1.322],
+        [-1.263, -0.737, -2.322, -0.322],
+    ]
+    with pytest.raises(ValueError):
+        PSSM(data_nan, "ACTG")
 
-        # fails if sequence too short
-        with pytest.raises(ValueError):
-            pssm.score_indexed_seq(indices[:3])
+    # fails for entries all negative numbers
+    data = [
+        [-1.322, -0.263, -1.0, -1.322],
+        [-2.322, -1.678, -2.322, -1.322],
+        [-1.485, -1.322, -1.322, -1.322],
+        [-1.263, -0.737, -2.322, -0.322],
+    ]
+    with pytest.raises(ValueError):
+        PSSM(data, "ACTG")
 
-    def test_score_str(self):
-        """produce correct score from seq"""
-        data = [
-            [0.1, 0.3, 0.5, 0.1],
-            [0.25, 0.25, 0.25, 0.25],
-            [0.05, 0.8, 0.05, 0.1],
-            [0.7, 0.1, 0.1, 0.1],
-            [0.6, 0.15, 0.05, 0.2],
-        ]
-        pssm = PSSM(data, "ACTG")
-        seq = "".join("ACTG"[i] for i in [3, 1, 2, 0, 2, 2, 3])
-        scores = pssm.score_seq(seq)
-        assert_allclose(scores, [-4.481, -5.703, -2.966], atol=1e-3)
-        with pytest.raises(ValueError):
-            pssm.score_seq(seq[:3])
 
-    def test_score_seq_obj(self):
-        """produce correct score from seq"""
+def test_score_indices():
+    # produce correct score from indexed seq
+    data = [
+        [0.1, 0.3, 0.5, 0.1],
+        [0.25, 0.25, 0.25, 0.25],
+        [0.05, 0.8, 0.05, 0.1],
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.15, 0.05, 0.2],
+    ]
+    pssm = PSSM(data, "ACTG")
+    indices = [3, 1, 2, 0, 2, 2, 3]
+    scores = pssm.score_indexed_seq(indices)
+    assert_allclose(scores, [-4.481, -5.703, -2.966], atol=1e-3)
 
-        data = [
-            [0.1, 0.3, 0.5, 0.1],
-            [0.25, 0.25, 0.25, 0.25],
-            [0.05, 0.8, 0.05, 0.1],
-            [0.7, 0.1, 0.1, 0.1],
-            [0.6, 0.15, 0.05, 0.2],
-        ]
-        pssm = PSSM(data, "ACTG")
-        seq = DNA.make_seq(seq="".join("ACTG"[i] for i in [3, 1, 2, 0, 2, 2, 3]))
-        scores = pssm.score_seq(seq)
-        assert_allclose(scores, [-4.481, -5.703, -2.966], atol=1e-3)
+    indices = [4, 1, 2, 0, 2, 2, 3]
+    scores = pssm.score_indexed_seq(indices)
+    # log2 of (0.25 * 0.05 * 0.7 * 0.05) / .25**4 = -3.158...
+    assert_allclose(scores, [-3.158, -5.703, -2.966], atol=1e-3)
+
+    # fails if sequence too short
+    with pytest.raises(ValueError):
+        pssm.score_indexed_seq(indices[:3])
+
+
+def test_score_str():
+    # produce correct score from seq
+    data = [
+        [0.1, 0.3, 0.5, 0.1],
+        [0.25, 0.25, 0.25, 0.25],
+        [0.05, 0.8, 0.05, 0.1],
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.15, 0.05, 0.2],
+    ]
+    pssm = PSSM(data, "ACTG")
+    seq = "".join("ACTG"[i] for i in [3, 1, 2, 0, 2, 2, 3])
+    scores = pssm.score_seq(seq)
+    assert_allclose(scores, [-4.481, -5.703, -2.966], atol=1e-3)
+    with pytest.raises(ValueError):
+        pssm.score_seq(seq[:3])
+
+
+def test_score_seq_obj():
+    # produce correct score from seq
+
+    data = [
+        [0.1, 0.3, 0.5, 0.1],
+        [0.25, 0.25, 0.25, 0.25],
+        [0.05, 0.8, 0.05, 0.1],
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.15, 0.05, 0.2],
+    ]
+    pssm = PSSM(data, "ACTG")
+    seq = DNA.make_seq(seq="".join("ACTG"[i] for i in [3, 1, 2, 0, 2, 2, 3]))
+    scores = pssm.score_seq(seq)
+    assert_allclose(scores, [-4.481, -5.703, -2.966], atol=1e-3)
 
 
 @pytest.mark.parametrize("pseudocount", [0, 0.5, 1])
 def test_to_freqs_pseudocount(pseudocount):
-    """produces a freqs array with pseudocount"""
+    # produces a freqs array with pseudocount
     data = array([[2, 4], [3, 5], [0, 8]], dtype=int)
     zero_index = 2, 0
 

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -7,7 +7,6 @@ import pickle
 import warnings
 from collections import defaultdict
 from html.parser import HTMLParser
-from unittest import TestCase, skipIf
 
 import numpy
 import pytest
@@ -44,1772 +43,1856 @@ class TrapOutput:
         self.output = repr(data)
 
 
-class TableTests(TestCase):
-    """Tests of individual functions in table"""
+# test table 1
+t1_header = ["chrom", "stableid", "length"]
+t1_rows = [
+    ["X", "ENSG00000005893", 1353],
+    ["A", "ENSG00000019485", 1827],
+    ["A", "ENSG00000019102", 999],
+    ["X", "ENSG00000012174", 1599],
+    ["X", "ENSG00000010671", 1977],
+    ["A", "ENSG00000019186", 1554],
+    ["A", "ENSG00000019144", 4185],
+    ["X", "ENSG00000008056", 2307],
+    ["A", "ENSG00000018408", 1383],
+    ["A", "ENSG00000019169", 1698],
+]
 
-    # test table 1
-    t1_header = ["chrom", "stableid", "length"]
-    t1_rows = [
-        ["X", "ENSG00000005893", 1353],
-        ["A", "ENSG00000019485", 1827],
-        ["A", "ENSG00000019102", 999],
-        ["X", "ENSG00000012174", 1599],
-        ["X", "ENSG00000010671", 1977],
-        ["A", "ENSG00000019186", 1554],
-        ["A", "ENSG00000019144", 4185],
-        ["X", "ENSG00000008056", 2307],
-        ["A", "ENSG00000018408", 1383],
-        ["A", "ENSG00000019169", 1698],
-    ]
+# test table 2
+t2_header = ["id", "foo", "bar"]
+t2_rows = [
+    [1, "abc", 11],
+    [2, "bca", 22],
+    [3, "cab", 33],
+    [4, "abc", 44],
+    [5, "bca", 55],
+]
 
-    # test table 2
-    t2_header = ["id", "foo", "bar"]
-    t2_rows = [
-        [1, "abc", 11],
-        [2, "bca", 22],
-        [3, "cab", 33],
-        [4, "abc", 44],
-        [5, "bca", 55],
-    ]
+# test table 3
+t3_header = ["id", "foo", "bar"]
+t3_rows = [[6, "abc", 66], [7, "bca", 77]]
 
-    # test table 3
-    t3_header = ["id", "foo", "bar"]
-    t3_rows = [[6, "abc", 66], [7, "bca", 77]]
+# test table 4
+t4_header = ["id", "foo", "bar"]
+t4_rows = [[8, "abc", 88], [9, "bca", 99]]
 
-    # test table 4
-    t4_header = ["id", "foo", "bar"]
-    t4_rows = [[8, "abc", 88], [9, "bca", 99]]
+# test table 5
+t5_header = ["a", "b", "c", "d"]
+t5_rows = [[1, 1, 1, 1], [2, 0, 1, 1], [1, 3, 2, 2]]
 
-    # test table 5
-    t5_header = ["a", "b", "c", "d"]
-    t5_rows = [[1, 1, 1, 1], [2, 0, 1, 1], [1, 3, 2, 2]]
+# test table 6
+t6_header = ["id", "foo", "bar"]
+t6_rows = [["60", " | ", "666"], ["70", "bca", "777"]]
 
-    # test table 6
-    t6_header = ["id", "foo", "bar"]
-    t6_rows = [["60", " | ", "666"], ["70", "bca", "777"]]
+# test table 7
+t7_header = ["chrom", "gene", "stat"]
+t7_rows = [
+    ["X", "ENSG00000005893", 0.1353],
+    ["A", "ENSG00000019485", 1827.558],
+    ["A", "ENSG00000019102", 999.125],
+]
 
-    # test table 7
-    t7_header = ["chrom", "gene", "stat"]
-    t7_rows = [
-        ["X", "ENSG00000005893", 0.1353],
-        ["A", "ENSG00000019485", 1827.558],
-        ["A", "ENSG00000019102", 999.125],
-    ]
+t8_header = ["edge.name", "edge.parent", "length", "x", "y", "z"]
+t8_rows = [
+    ["Human", "edge.0", 4.0, 1.0, 3.0, 6.0],
+    ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
+]
 
-    t8_header = ["edge.name", "edge.parent", "length", "x", "y", "z"]
-    t8_rows = [
-        ["Human", "edge.0", 4.0, 1.0, 3.0, 6.0],
-        ["NineBande", "root", 4.0, 1.0, 3.0, 6.0],
-    ]
 
-    def test_input_containers(self):
-        """should not fail on defaultdict"""
-        raw = {"a": [1, 2, 3], "b": [3, 4, 6]}
-        data = defaultdict(list)
-        data.update(raw)
-        t = Table(data=data)
-        assert t.shape == (3, 2)
+def test_input_containers():
+    # should not fail on defaultdict
+    raw = {"a": [1, 2, 3], "b": [3, 4, 6]}
+    data = defaultdict(list)
+    data.update(raw)
+    t = Table(data=data)
+    assert t.shape == (3, 2)
 
-    def test_keys_are_str(self):
-        """all column headers converted to str"""
-        t = Table(header=["col 1", 2], data=[[0, 1]])
-        assert t.header == ("col 1", "2")
 
-    def test_no_index_name(self):
-        """assigning None has no effect"""
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        t.index_name = None
-        assert t.index_name is None
+def test_keys_are_str():
+    # all column headers converted to str
+    t = Table(header=["col 1", 2], data=[[0, 1]])
+    assert t.header == ("col 1", "2")
 
-    def test_index_name(self):
-        """correctly assigns"""
-        t = Table(header=self.t3_header, data=self.t3_rows, index_name="foo")
-        assert t.index_name == "foo"
-        # fails if not an existing column
-        with pytest.raises(ValueError):
-            t.index_name = "missing"
 
-        data = t.columns.to_dict()
-        # correctly handled when provided on construction
-        with pytest.raises(ValueError):
-            t = Table(data=data, index_name="missing")
+def test_no_index_name():
+    # assigning None has no effect
+    t = Table(header=t5_header, data=t5_rows)
+    t.index_name = None
+    assert t.index_name is None
 
-        t = Table(data=data, index_name="foo")
-        assert t.index_name == "foo"
 
-        # correctly reset when assigned None
-        t.index_name = None
-        assert t.index_name is None
-        assert t.columns.index_name is None
-        assert t._template is None
+def test_index_name():
+    # correctly assigns
+    t = Table(header=t3_header, data=t3_rows, index_name="foo")
+    assert t.index_name == "foo"
+    # fails if not an existing column
+    with pytest.raises(ValueError):
+        t.index_name = "missing"
 
-        # ... prior to providing columns
-        t = Table(index_name="foo")
-        for c, v in data.items():
-            t.columns[c] = v
-        assert t.index_name == "foo"
-        t = Table(index_name="missing")
-        for c, v in data.items():
-            t.columns[c] = v
+    data = t.columns.to_dict()
+    # correctly handled when provided on construction
+    with pytest.raises(ValueError):
+        t = Table(data=data, index_name="missing")
 
-        with pytest.raises(ValueError):
-            t.index_name
+    t = Table(data=data, index_name="foo")
+    assert t.index_name == "foo"
 
-    def test_table_data_int_keys(self):
-        """correctly construct table from dict with int's as keys"""
-        head = ["", 0, 1]
-        data = {0: [2, 2], 1: [2, 2], "": [0, 1]}
-        t = Table(head, data=data)
-        assert_equal(t.array.tolist(), [[0, 2, 2], [1, 2, 2]])
+    # correctly reset when assigned None
+    t.index_name = None
+    assert t.index_name is None
+    assert t.columns.index_name is None
+    assert t._template is None
 
-    def test_table_with_empty_string_index(self):
-        """handle an index of empty string"""
-        d = {
-            "": ["Chimpanzee", "Galago", "Gorilla"],
-            "Chimpanzee": [0.0, 0.19, 0.005],
-            "Galago": [0.19, 0.0, 0.19],
-        }
-        table = make_table(data=d, index_name="")
-        val = table["Galago", "Chimpanzee"]
-        assert val == 0.19
+    # ... prior to providing columns
+    t = Table(index_name="foo")
+    for c, v in data.items():
+        t.columns[c] = v
+    assert t.index_name == "foo"
+    t = Table(index_name="missing")
+    for c, v in data.items():
+        t.columns[c] = v
 
-    def test_column_repr_str(self):
-        """repr and str of Columns"""
-        t = Table(header=list("abcdefg"), data=[[0, 1.1, 2, 3, 4, 5.5, 6.0]])
-        r = repr(t.columns)
-        s = str(t.columns)
-        assert isinstance(r, str)
-        assert r == s
+    with pytest.raises(ValueError):
+        t.index_name
 
-    def test_slicing_columns(self):
-        """works using names, ints, bool array"""
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        n = t.columns["b":"d"]
-        assert_equal(n, [[1, 0, 3], [1, 1, 2]])
-        n = t.columns[1:3]
-        assert_equal(n, [[1, 0, 3], [1, 1, 2]])
-        indices = numpy.array([False, True, True, False])
-        n = t.columns[indices]
-        assert_equal(n, [[1, 0, 3], [1, 1, 2]])
 
-    def test_indexing_columns(self):
-        """works using names or ints"""
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        n = t.columns["b"]
-        assert_equal(n, [1, 0, 3])
-        n = t.columns[1]
-        assert_equal(n, [1, 0, 3])
+def test_table_data_int_keys():
+    # correctly construct table from dict with int's as keys
+    head = ["", 0, 1]
+    data = {0: [2, 2], 1: [2, 2], "": [0, 1]}
+    t = Table(head, data=data)
+    assert_equal(t.array.tolist(), [[0, 2, 2], [1, 2, 2]])
 
-    def test_indexing_rows(self):
-        """works using names or ints"""
-        t = Table(header=self.t7_header, data=self.t7_rows, index_name="gene")
-        got = t["ENSG00000019485", "chrom"]
-        assert got == "A"
 
-    def test_immutability_cells(self):
-        """table cells are immutable"""
-        t = Table(header=self.t7_header, data=self.t7_rows, index_name="gene")
-        with pytest.raises(TypeError):
-            t["ENSG00000019485", "chrom"] = "D"
+def test_table_with_empty_string_index():
+    # handle an index of empty string
+    d = {
+        "": ["Chimpanzee", "Galago", "Gorilla"],
+        "Chimpanzee": [0.0, 0.19, 0.005],
+        "Galago": [0.19, 0.0, 0.19],
+    }
+    table = make_table(data=d, index_name="")
+    val = table["Galago", "Chimpanzee"]
+    assert val == 0.19
 
-        # even via column instance
-        with pytest.raises(ValueError):
-            t.columns["chrom"]["ENSG00000019485"] = "D"
 
-    def test_slicing_table(self):
-        """works using column names, ints, bool array"""
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        n = t[:, "b":"d"]
-        assert n.columns.order == ("b", "c")
-        assert_equal(n.array, [[1, 1], [0, 1], [3, 2]])
-        # using numpy bool array
-        rows = numpy.array([True, False, True])
-        n = t[rows]
-        assert n.shape == (2, 4)
-        assert_equal(n.columns["a"], [1, 1])
-        rows = numpy.array([True, False, True])
-        columns = numpy.array([True, False, False, True])
-        n = t[rows, columns]
-        assert_equal(n.header, numpy.array(t.header)[columns])
-        assert n.shape == (2, 2)
+def test_column_repr_str():
+    # repr and str of Columns
+    t = Table(header=list("abcdefg"), data=[[0, 1.1, 2, 3, 4, 5.5, 6.0]])
+    r = repr(t.columns)
+    s = str(t.columns)
+    assert isinstance(r, str)
+    assert r == s
 
-        # column formatting copied on slice
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        t.format_column("c", "%.2e")
-        n = t[:, 1:]
-        assert n._column_templates == t._column_templates
 
-    def test_slicing_using_numpy_indexing(self):
-        """support numpy advanced indexing"""
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        indices = t.columns["b"] != 0
-        got = t[indices]
-        expect = t.array[[0, 2], :]
-        assert_equal(got.array, expect)
-        got = t[indices, [True, False, True, True]]
-        expect = expect[:, [0, 2, 3]]
-        assert_equal(got.array, expect)
+def test_slicing_columns():
+    # works using names, ints, bool array
+    t = Table(header=t5_header, data=t5_rows)
+    n = t.columns["b":"d"]
+    assert_equal(n, [[1, 0, 3], [1, 1, 2]])
+    n = t.columns[1:3]
+    assert_equal(n, [[1, 0, 3], [1, 1, 2]])
+    indices = numpy.array([False, True, True, False])
+    n = t.columns[indices]
+    assert_equal(n, [[1, 0, 3], [1, 1, 2]])
 
-        # using numpy arrays for rows and columns
-        got_np = t[indices, numpy.array([True, False, True, True])]
-        assert_equal(got_np.array, got.array)
 
-    def test_slicing_with_index(self):
-        """different slice types work when index_name defined"""
-        # slicing by int works with index_name too
-        t = Table(header=self.t8_header, data=self.t8_rows, index_name="edge.name")
-        got = t[[1]]
+def test_indexing_columns():
+    # works using names or ints
+    t = Table(header=t5_header, data=t5_rows)
+    n = t.columns["b"]
+    assert_equal(n, [1, 0, 3])
+    n = t.columns[1]
+    assert_equal(n, [1, 0, 3])
+
+
+def test_indexing_rows():
+    # works using names or ints
+    t = Table(header=t7_header, data=t7_rows, index_name="gene")
+    got = t["ENSG00000019485", "chrom"]
+    assert got == "A"
+
+
+def test_immutability_cells():
+    # table cells are immutable
+    t = Table(header=t7_header, data=t7_rows, index_name="gene")
+    with pytest.raises(TypeError):
+        t["ENSG00000019485", "chrom"] = "D"
+
+    # even via column instance
+    with pytest.raises(ValueError):
+        t.columns["chrom"]["ENSG00000019485"] = "D"
+
+
+def test_slicing_table():
+    # works using column names, ints, bool array
+    t = Table(header=t5_header, data=t5_rows)
+    n = t[:, "b":"d"]
+    assert n.columns.order == ("b", "c")
+    assert_equal(n.array, [[1, 1], [0, 1], [3, 2]])
+    # using numpy bool array
+    rows = numpy.array([True, False, True])
+    n = t[rows]
+    assert n.shape == (2, 4)
+    assert_equal(n.columns["a"], [1, 1])
+    rows = numpy.array([True, False, True])
+    columns = numpy.array([True, False, False, True])
+    n = t[rows, columns]
+    assert_equal(n.header, numpy.array(t.header)[columns])
+    assert n.shape == (2, 2)
+
+    # column formatting copied on slice
+    t = Table(header=t5_header, data=t5_rows)
+    t.format_column("c", "%.2e")
+    n = t[:, 1:]
+    assert n._column_templates == t._column_templates
+
+
+def test_slicing_using_numpy_indexing():
+    # support numpy advanced indexing
+    t = Table(header=t5_header, data=t5_rows)
+    indices = t.columns["b"] != 0
+    got = t[indices]
+    expect = t.array[[0, 2], :]
+    assert_equal(got.array, expect)
+    got = t[indices, [True, False, True, True]]
+    expect = expect[:, [0, 2, 3]]
+    assert_equal(got.array, expect)
+
+    # using numpy arrays for rows and columns
+    got_np = t[indices, numpy.array([True, False, True, True])]
+    assert_equal(got_np.array, got.array)
+
+
+def test_slicing_with_index():
+    # different slice types work when index_name defined
+    # slicing by int works with index_name too
+    t = Table(header=t8_header, data=t8_rows, index_name="edge.name")
+    got = t[[1]]
+    assert got.columns["edge.name"] == "NineBande"
+    assert got.shape == (1, t.shape[1])
+    for v, dtype in [(1, None), (1, object), ("NineBande", "U")]:
+        got = t[numpy.array([v], dtype=dtype)]
         assert got.columns["edge.name"] == "NineBande"
         assert got.shape == (1, t.shape[1])
-        for v, dtype in [(1, None), (1, object), ("NineBande", "U")]:
-            got = t[numpy.array([v], dtype=dtype)]
-            assert got.columns["edge.name"] == "NineBande"
-            assert got.shape == (1, t.shape[1])
 
-        # works if, for some reason, the index_name column has floats
-        t = Table(header=self.t7_header, data=self.t7_rows, index_name="stat")
-        got = t[[1827.5580]]
-        assert got.shape == (1, t.shape[1])
-        got = t[numpy.array([1827.5580])]
-        assert got.shape == (1, t.shape[1])
+    # works if, for some reason, the index_name column has floats
+    t = Table(header=t7_header, data=t7_rows, index_name="stat")
+    got = t[[1827.5580]]
+    assert got.shape == (1, t.shape[1])
+    got = t[numpy.array([1827.5580])]
+    assert got.shape == (1, t.shape[1])
 
-    def test_specifying_space(self):
-        """controls spacing in simple format"""
-        space = "        "
-        t4 = Table(header=self.t1_header, data=self.t1_rows)
-        orig = len(str(t4).splitlines()[1])
-        t4 = Table(header=self.t1_header, data=self.t1_rows, space=space)
-        got1 = len(str(t4).splitlines()[1])
-        assert got1 > orig
-        # repr is same
-        got2 = len(repr(t4).splitlines()[1])
-        assert got1 == got2
 
-    def test_construct_from_dict2d(self):
-        """construction from a 2D dict"""
-        data = {
-            "edge.parent": {
-                "NineBande": "root",
-                "edge.1": "root",
-                "DogFaced": "root",
-                "Human": "edge.0",
-                "edge.0": "edge.1",
-                "Mouse": "edge.1",
-                "HowlerMon": "edge.0",
-            },
-            "x": {
-                "NineBande": 1.0,
-                "edge.1": 1.0,
-                "DogFaced": 1.0,
-                "Human": 1.0,
-                "edge.0": 1.0,
-                "Mouse": 1.0,
-                "HowlerMon": 1.0,
-            },
-        }
-        t = Table(data=data)
-        assert t.shape == (len(data["x"]), len(data))
+def test_specifying_space():
+    # controls spacing in simple format
+    space = "        "
+    t4 = Table(header=t1_header, data=t1_rows)
+    orig = len(str(t4).splitlines()[1])
+    t4 = Table(header=t1_header, data=t1_rows, space=space)
+    got1 = len(str(t4).splitlines()[1])
+    assert got1 > orig
+    # repr is same
+    got2 = len(repr(t4).splitlines()[1])
+    assert got1 == got2
 
-    def test_wrapping_tables_index_1row(self):
-        """correctly wraps table to <= maximum width"""
-        index = "A/C"
-        h = ["A/C", "A/G", "A/T", "C/A"]
-        rows = [[0.0425, 0.1424, 0.0226, 0.0391]]
-        t = Table(header=h, data=rows, max_width=30, index_name=index)
-        wrapped = str(t)
-        # index_name column occurs twice for these conditions
-        for c in h:
-            expect = 2 if c == index else 1
-            assert wrapped.count(c) == expect
 
-    def test_wrapping_tables_index_multirow(self):
-        """correctly wraps table to <= maximum width"""
-        # multi-row table
-        d2D = {
-            "edge.parent": {
-                "NineBande": "root",
-                "Human": "edge.0",
-            },
-            "x": {
-                "NineBande": 1.0,
-                "Human": 1.0,
-            },
-            "length": {
-                "NineBande": 4.0,
-                "Human": 4.0,
-            },
-            "y": {
-                "NineBande": 3.0,
-                "Human": 3.0,
-            },
-            "z": {
-                "NineBande": 6.0,
-                "Human": 6.0,
-            },
-            "edge.name": {
-                "Human": "Human",
-                "NineBande": "NineBande",
-            },
-        }
-        row_order = list(d2D["edge.name"])
-        t = Table(
-            ["edge.name", "edge.parent", "length", "x", "y", "z"],
-            d2D,
-            row_order=row_order,
-            space=8,
-            max_width=50,
-            index_name="edge.name",
-            title="My title",
-            legend="legend: this is a nonsense example.",
-        )
-        wrapped = str(t)
-        for line in wrapped.splitlines():
-            len(line)
+def test_construct_from_dict2d():
+    # construction from a 2D dict
+    data = {
+        "edge.parent": {
+            "NineBande": "root",
+            "edge.1": "root",
+            "DogFaced": "root",
+            "Human": "edge.0",
+            "edge.0": "edge.1",
+            "Mouse": "edge.1",
+            "HowlerMon": "edge.0",
+        },
+        "x": {
+            "NineBande": 1.0,
+            "edge.1": 1.0,
+            "DogFaced": 1.0,
+            "Human": 1.0,
+            "edge.0": 1.0,
+            "Mouse": 1.0,
+            "HowlerMon": 1.0,
+        },
+    }
+    t = Table(data=data)
+    assert t.shape == (len(data["x"]), len(data))
 
-    def test_wrapping_tables(self):
-        """correctly wraps table to <= maximum width"""
-        h = ["A/C", "A/G", "A/T", "C/A"]
-        rows = [[0.0425, 0.1424, 0.0226, 0.0391]]
-        t = Table(header=h, data=rows, max_width=30)
-        wrapped = str(t)
-        # index_name column occurs twice for these conditions
-        for c in h:
-            assert wrapped.count(c) == 1
 
-        # multi-row table
-        data = {
-            "edge.parent": {
-                "NineBande": "root",
-                "edge.1": "root",
-            },
-            "x": {
-                "NineBande": 1.0,
-                "edge.1": 1.0,
-            },
-            "length": {
-                "NineBande": 4.0,
-                "edge.1": 4.0,
-            },
-            "y": {
-                "NineBande": 3.0,
-                "edge.1": 3.0,
-            },
-            "z": {
-                "NineBande": 6.0,
-                "edge.1": 6.0,
-            },
-        }
-        t = Table(data=data, max_width=30)
-        wrapped = str(t)
-        for c in data:
-            assert wrapped.count(c) == 1
+def test_wrapping_tables_index_1row():
+    # correctly wraps table to <= maximum width
+    index = "A/C"
+    h = ["A/C", "A/G", "A/T", "C/A"]
+    rows = [[0.0425, 0.1424, 0.0226, 0.0391]]
+    t = Table(header=h, data=rows, max_width=30, index_name=index)
+    wrapped = str(t)
+    # index_name column occurs twice for these conditions
+    for c in h:
+        expect = 2 if c == index else 1
+        assert wrapped.count(c) == expect
 
-    def test_format_array(self):
-        """correctly format array data"""
-        f = (2.53, 12.426, 9.9, 7.382e-08)
-        # with default format_spec
-        g, l, w = formatted_array(numpy.array(f), "LR", precision=2)
-        assert l.endswith("LR")
-        for e in g:
-            v = e.split(".")
-            assert len(v[-1]) == 2, v
-        # handles bool
-        g, l, w = formatted_array(numpy.array([True, False, True]), "LR", precision=2)
-        assert g[0].strip() == "True"
-        # title is always right aligned
-        _, l, _ = formatted_array(numpy.array(f), "LR", format_spec=">.1f")
-        assert l.endswith("LR")
-        _, l, _ = formatted_array(numpy.array(f), "LR", format_spec="<.1f")
-        assert l.startswith("LR")
 
-        # using format_spec with right alignment character
-        g, l, w = formatted_array(numpy.array(f), "   blah", format_spec=">.1f")
-        for e in g:
-            # padded with spaces
-            assert e.startswith(" "), e
-            assert not e.endswith(" "), e
+def test_wrapping_tables_index_multirow():
+    # correctly wraps table to <= maximum width
+    # multi-row table
+    d2D = {
+        "edge.parent": {
+            "NineBande": "root",
+            "Human": "edge.0",
+        },
+        "x": {
+            "NineBande": 1.0,
+            "Human": 1.0,
+        },
+        "length": {
+            "NineBande": 4.0,
+            "Human": 4.0,
+        },
+        "y": {
+            "NineBande": 3.0,
+            "Human": 3.0,
+        },
+        "z": {
+            "NineBande": 6.0,
+            "Human": 6.0,
+        },
+        "edge.name": {
+            "Human": "Human",
+            "NineBande": "NineBande",
+        },
+    }
+    row_order = list(d2D["edge.name"])
+    t = Table(
+        ["edge.name", "edge.parent", "length", "x", "y", "z"],
+        d2D,
+        row_order=row_order,
+        space=8,
+        max_width=50,
+        index_name="edge.name",
+        title="My title",
+        legend="legend: this is a nonsense example.",
+    )
+    wrapped = str(t)
+    for line in wrapped.splitlines():
+        len(line)
 
-        # using format_spec with left alignment character
-        g, l, w = formatted_array(numpy.array(f), "    blah", format_spec="<.1f")
-        for e in g:
-            # padded with spaces
-            assert e.endswith(" "), e
-            assert not e.startswith(" "), e
 
-        # using format_spec with center alignment character
-        g, l, w = formatted_array(numpy.array(f), "    blah", format_spec="^.1f")
-        for e in g:
-            # padded with spaces
-            assert e.endswith(" "), e
-            assert e.startswith(" "), e
+def test_wrapping_tables():
+    # correctly wraps table to <= maximum width
+    h = ["A/C", "A/G", "A/T", "C/A"]
+    rows = [[0.0425, 0.1424, 0.0226, 0.0391]]
+    t = Table(header=h, data=rows, max_width=30)
+    wrapped = str(t)
+    # index_name column occurs twice for these conditions
+    for c in h:
+        assert wrapped.count(c) == 1
 
-        g, _, _ = formatted_array(numpy.array(f), "blah", format_spec=".4f")
-        for e in g:
-            v = e.split(".")
-            assert len(v[-1]) == 4, v
+    # multi-row table
+    data = {
+        "edge.parent": {
+            "NineBande": "root",
+            "edge.1": "root",
+        },
+        "x": {
+            "NineBande": 1.0,
+            "edge.1": 1.0,
+        },
+        "length": {
+            "NineBande": 4.0,
+            "edge.1": 4.0,
+        },
+        "y": {
+            "NineBande": 3.0,
+            "edge.1": 3.0,
+        },
+        "z": {
+            "NineBande": 6.0,
+            "edge.1": 6.0,
+        },
+    }
+    t = Table(data=data, max_width=30)
+    wrapped = str(t)
+    for c in data:
+        assert wrapped.count(c) == 1
 
-        # cope with C-style format strings
-        g, _, _ = formatted_array(numpy.array(f), "blah", format_spec="%.4f")
-        for e in g:
-            v = e.split(".")
-            assert len(v[-1]) == 4, v
 
-        # handle a formatter function
-        def formatcol(value):
-            return f"{value:.2f}" if isinstance(value, float) else str(value)
+def test_format_array():
+    # correctly format array data
+    f = (2.53, 12.426, 9.9, 7.382e-08)
+    # with default format_spec
+    g, l, w = formatted_array(numpy.array(f), "LR", precision=2)
+    assert l.endswith("LR")
+    for e in g:
+        v = e.split(".")
+        assert len(v[-1]) == 2, v
+    # handles bool
+    g, l, w = formatted_array(numpy.array([True, False, True]), "LR", precision=2)
+    assert g[0].strip() == "True"
+    # title is always right aligned
+    _, l, _ = formatted_array(numpy.array(f), "LR", format_spec=">.1f")
+    assert l.endswith("LR")
+    _, l, _ = formatted_array(numpy.array(f), "LR", format_spec="<.1f")
+    assert l.startswith("LR")
 
-        o = [3, "abc", 3.456789]
-        g, _, _ = formatted_array(
-            numpy.array(o, dtype="O"),
-            "blah",
-            format_spec=formatcol,
-        )
-        assert g[0] == "   3", g[0]
-        assert g[1] == " abc", g[1]
-        assert g[2] == "3.46", g
+    # using format_spec with right alignment character
+    g, l, w = formatted_array(numpy.array(f), "   blah", format_spec=">.1f")
+    for e in g:
+        # padded with spaces
+        assert e.startswith(" "), e
+        assert not e.endswith(" "), e
 
-        # don't pad
-        g, l, w = formatted_array(numpy.array(f), "    blah", format_spec="<.1f")
-        g, l, w = formatted_array(
-            numpy.array(f),
-            "    blah",
-            format_spec="<.1f",
-            pad=False,
-        )
-        assert l == "blah"
-        for v in g:
-            assert " " not in v
+    # using format_spec with left alignment character
+    g, l, w = formatted_array(numpy.array(f), "    blah", format_spec="<.1f")
+    for e in g:
+        # padded with spaces
+        assert e.endswith(" "), e
+        assert not e.startswith(" "), e
 
-        # use the align argument, 'c'
-        g, l, w = formatted_array(
+    # using format_spec with center alignment character
+    g, l, w = formatted_array(numpy.array(f), "    blah", format_spec="^.1f")
+    for e in g:
+        # padded with spaces
+        assert e.endswith(" "), e
+        assert e.startswith(" "), e
+
+    g, _, _ = formatted_array(numpy.array(f), "blah", format_spec=".4f")
+    for e in g:
+        v = e.split(".")
+        assert len(v[-1]) == 4, v
+
+    # cope with C-style format strings
+    g, _, _ = formatted_array(numpy.array(f), "blah", format_spec="%.4f")
+    for e in g:
+        v = e.split(".")
+        assert len(v[-1]) == 4, v
+
+    # handle a formatter function
+    def formatcol(value):
+        return f"{value:.2f}" if isinstance(value, float) else str(value)
+
+    o = [3, "abc", 3.456789]
+    g, _, _ = formatted_array(
+        numpy.array(o, dtype="O"),
+        "blah",
+        format_spec=formatcol,
+    )
+    assert g[0] == "   3", g[0]
+    assert g[1] == " abc", g[1]
+    assert g[2] == "3.46", g
+
+    # don't pad
+    g, l, w = formatted_array(numpy.array(f), "    blah", format_spec="<.1f")
+    g, l, w = formatted_array(
+        numpy.array(f),
+        "    blah",
+        format_spec="<.1f",
+        pad=False,
+    )
+    assert l == "blah"
+    for v in g:
+        assert " " not in v
+
+    # use the align argument, 'c'
+    g, l, w = formatted_array(
+        numpy.array(f),
+        "  blah  ",
+        precision=1,
+        pad=True,
+        align="c",
+    )
+    for v in g:
+        assert v.startswith(" ")
+        assert v.endswith(" ")
+
+    # use the align argument, 'l'
+    g, l, w = formatted_array(
+        numpy.array(f),
+        "  blah  ",
+        precision=1,
+        pad=True,
+        align="l",
+    )
+    for v in g:
+        assert not v.startswith(" ")
+        assert v.endswith(" ")
+
+    # use the align argument, 'r'
+    col_title = "  blah  "
+    g, l, w = formatted_array(
+        numpy.array(f),
+        col_title,
+        precision=1,
+        pad=True,
+        align="r",
+    )
+    for v in g:
+        assert v.startswith(" ")
+        assert not v.endswith(" ")
+
+    assert w == len(col_title)
+
+    # raises error if align invalid value
+    with pytest.raises(ValueError):
+        formatted_array(
             numpy.array(f),
             "  blah  ",
             precision=1,
             pad=True,
-            align="c",
+            align="blah",
         )
-        for v in g:
-            assert v.startswith(" ")
-            assert v.endswith(" ")
 
-        # use the align argument, 'l'
-        g, l, w = formatted_array(
-            numpy.array(f),
-            "  blah  ",
-            precision=1,
-            pad=True,
-            align="l",
-        )
-        for v in g:
-            assert not v.startswith(" ")
-            assert v.endswith(" ")
 
-        # use the align argument, 'r'
-        col_title = "  blah  "
-        g, l, w = formatted_array(
-            numpy.array(f),
-            col_title,
-            precision=1,
-            pad=True,
-            align="r",
-        )
-        for v in g:
-            assert v.startswith(" ")
-            assert not v.endswith(" ")
+def test_get_continuation_tables_headers():
+    # correctly identify the columns for subtables
+    cols_widths = [("", 10), ("b", 5), ("c", 3), ("d", 14), ("e", 15)]
+    got = get_continuation_tables_headers(cols_widths)
+    # no subtables, returns list of lists
+    expect = [[c for c, _ in cols_widths]]
+    assert got == expect
+    # fails if any column has a width < max_width
+    with pytest.raises(ValueError):
+        get_continuation_tables_headers(cols_widths, max_width=5)
 
-        assert w == len(col_title)
+    # or if the sum of the index_name width and column is > max_width
+    with pytest.raises(ValueError):
+        get_continuation_tables_headers(cols_widths, index_name="", max_width=24)
 
-        # raises error if align invalid value
-        with pytest.raises(ValueError):
-            formatted_array(
-                numpy.array(f),
-                "  blah  ",
-                precision=1,
-                pad=True,
-                align="blah",
-            )
+    got = get_continuation_tables_headers(cols_widths, max_width=25)
+    expect = [["", "b", "c"], ["d"], ["e"]]
+    assert got == expect
 
-    def test_get_continuation_tables_headers(self):
-        """correctly identify the columns for subtables"""
-        cols_widths = [("", 10), ("b", 5), ("c", 3), ("d", 14), ("e", 15)]
-        got = get_continuation_tables_headers(cols_widths)
-        # no subtables, returns list of lists
-        expect = [[c for c, _ in cols_widths]]
-        assert got == expect
-        # fails if any column has a width < max_width
-        with pytest.raises(ValueError):
-            get_continuation_tables_headers(cols_widths, max_width=5)
+    # with an index_name column
+    got = get_continuation_tables_headers(cols_widths, index_name="", max_width=27)
+    expect = [["", "b", "c"], ["", "d"], ["", "e"]]
+    assert got == expect
 
-        # or if the sum of the index_name width and column is > max_width
-        with pytest.raises(ValueError):
-            get_continuation_tables_headers(cols_widths, index_name="", max_width=24)
+    cols_widths = [("a", 10), ("b", 5), ("c", 3), ("d", 14), ("e", 15)]
+    got = get_continuation_tables_headers(cols_widths, index_name="a", max_width=27)
+    expect = [["a", "b", "c"], ["a", "d"], ["a", "e"]]
+    assert got == expect
 
-        got = get_continuation_tables_headers(cols_widths, max_width=25)
-        expect = [["", "b", "c"], ["d"], ["e"]]
-        assert got == expect
+    # space has an affect
+    got = get_continuation_tables_headers(cols_widths, max_width=25, space=4)
+    expect = [["a", "b"], ["c", "d"], ["e"]]
+    assert got == expect
 
-        # with an index_name column
-        got = get_continuation_tables_headers(cols_widths, index_name="", max_width=27)
-        expect = [["", "b", "c"], ["", "d"], ["", "e"]]
-        assert got == expect
 
-        cols_widths = [("a", 10), ("b", 5), ("c", 3), ("d", 14), ("e", 15)]
-        got = get_continuation_tables_headers(cols_widths, index_name="a", max_width=27)
-        expect = [["a", "b", "c"], ["a", "d"], ["a", "e"]]
-        assert got == expect
+def test_cast_to_array():
+    # correctly cast to numpy array
+    b = (True, False, True)
+    a = cast_to_array(b)
+    assert "bool" in a.dtype.name
+    assert a.tolist() == list(b)
+    s = (
+        "NP_003077_hs_mm_rn_dna",
+        "NP_004893_hs_mm_rn_dna",
+        "NP_005079_hs_mm_rn_dna",
+        "NP_005500_hs_mm_rn_dna",
+        "NP_055852_hs_mm_rn_dna",
+    )
+    a = cast_to_array(s)
+    assert "str" in a.dtype.name
+    assert a.tolist() == list(s)
 
-        # space has an affect
-        got = get_continuation_tables_headers(cols_widths, max_width=25, space=4)
-        expect = [["a", "b"], ["c", "d"], ["e"]]
-        assert got == expect
+    f = (2.53, 12.426, 9.9, 7.382e-08)
+    a = cast_to_array(f)
+    assert "float" in a.dtype.name, a.dtype.name
+    assert a.tolist() == list(f)
 
-    def test_cast_to_array(self):
-        """correctly cast to numpy array"""
-        b = (True, False, True)
-        a = cast_to_array(b)
-        assert "bool" in a.dtype.name
-        assert a.tolist() == list(b)
-        s = (
+    d = [3, 4, 5]
+    a = cast_to_array(d)
+    assert "int" in a.dtype.name, a.dtype.name
+    assert a.tolist() == list(d)
+
+    o = [3, "abc", 3.4]
+    a = cast_to_array(o)
+    assert "object" in a.dtype.name, a.dtype.name
+    assert a.tolist() == list(o)
+
+
+def test_make_table():
+    # makes a table
+    data = {
+        "edge.parent": {
+            "NineBande": "root",
+            "edge.1": "root",
+            "DogFaced": "root",
+            "Human": "edge.0",
+        },
+        "x": {
+            "NineBande": 1.0,
+            "edge.1": 1.0,
+            "DogFaced": 1.0,
+            "Human": 1.0,
+        },
+        "length": {
+            "NineBande": 4.0,
+            "edge.1": 4.0,
+            "DogFaced": 4.0,
+            "Human": 4.0,
+        },
+        "y": {
+            "NineBande": 3.0,
+            "edge.1": 3.0,
+            "DogFaced": 3.0,
+            "Human": 3.0,
+        },
+        "z": {
+            "NineBande": 6.0,
+            "edge.1": 6.0,
+            "DogFaced": 6.0,
+            "Human": 6.0,
+        },
+        "edge.names": {
+            "NineBande": "NineBande",
+            "edge.1": "edge.1",
+            "DogFaced": "DogFaced",
+            "Human": "Human",
+        },
+    }
+    t = make_table(data=data)
+    assert t.shape == (4, 6)
+    # if index_name column not specified
+    with pytest.raises(IndexError):
+        _ = t["Human", "edge.parent"]
+
+    # use an index_name
+    t = make_table(data=data, index_name="edge.names")
+    # index_name col is the first one, and the data can be indexed
+    assert t.columns.order[0] == "edge.names"
+    assert t["Human", "edge.parent"] == "edge.0"
+
+    # providing path raises TypeError
+    with pytest.raises(TypeError):
+        make_table("some_path.tsv")
+
+    with pytest.raises(TypeError):
+        make_table(header="some_path.tsv")
+
+    with pytest.raises(TypeError):
+        make_table(data="some_path.tsv")
+
+
+def test_modify_title_legend():
+    # reflected in persistent attrs
+    rows = (
+        ("NP_003077_hs_mm_rn_dna", "Con", 2.5386013224378985),
+        ("NP_004893_hs_mm_rn_dna", "Con", 0.12135142635634111e06),
+    )
+    t = Table(["Gene", "Type", "LR"], rows)
+    t.title = "a new one"
+    assert t._get_persistent_attrs()["title"] == "a new one"
+    t.legend = "a new 2"
+    assert t._get_persistent_attrs()["legend"] == "a new 2"
+
+
+def test_dunder_repr_eq_str():
+    # dunder str and repr methods should produce same
+    rows = (
+        ("NP_003077_hs_mm_rn_dna", "Con", 2.5386013224378985),
+        ("NP_004893_hs_mm_rn_dna", "Con", 0.12135142635634111e06),
+    )
+    t = Table(["Gene", "Type", "LR"], rows)
+    t.format_column("LR", "%.4e")
+    s = str(t)
+    r = repr(t)
+    assert r.startswith(s)
+
+
+@pytest.mark.skipif(DataFrame is None, reason="pandas not installed")
+def test_make_table_from_dataframe():
+    # makes a table from a pandas data frame
+    df = DataFrame(data=[[0, 1], [3, 7]], columns=["a", "b"])
+    t = make_table(data_frame=df)
+    assert_equal(t.columns["a"], [0, 3])
+    assert_equal(t.columns["b"], [1, 7])
+    with pytest.raises(TypeError):
+        make_table(data_frame="abcde")
+
+
+def test_appended():
+    # test the table appended method
+    t2 = Table(header=t2_header, data=t2_rows)
+    t3 = Table(header=t3_header, data=t3_rows)
+    t4 = Table(header=t4_header, data=t4_rows)
+
+    append_0 = t2.appended("foo2", [], title="self")
+    assert append_0.shape[0] == t2.shape[0]
+    # test the title feature
+    assert append_0.title == "self"
+
+    append_1 = t2.appended("foo2", [t3])
+    assert append_1.shape[0] == t2.shape[0] + t3.shape[0]
+    # test the new_column feature
+    assert append_1.shape[1] == 4
+    assert append_1.header[0] == "foo2"
+
+    append_2 = t2.appended("foo2", [t3, t4])
+    assert append_2.shape[0] == t2.shape[0] + t3.shape[0] + t4.shape[0]
+
+    append_3 = t2.appended("", [t3, t4])
+    assert append_3.shape[0] == t2.shape[0] + t3.shape[0] + t4.shape[0]
+    assert append_3.shape[1] == t2.shape[1] + 1
+
+
+def test_appended_mixed_dtypes():
+    # handles table columns with different dtypes
+    t1 = Table(header=["a", "b"], data={"a": [1], "b": ["s"]})
+    t2 = Table(header=["a", "b"], data={"a": [1.2], "b": [4]})
+    appended = t1.appended(None, t2)
+    assert "float" in appended.columns["a"].dtype.name
+    assert "object" in appended.columns["b"].dtype.name
+
+
+def test_count():
+    # test the table count method
+    t1 = Table(header=t1_header, data=t1_rows)
+    assert t1.count('chrom == "X"') == 4
+    assert t1.count('stableid.endswith("6")') == 2
+    assert t1.count("length % 2 == 0") == 2
+    assert t1.count('chrom == "Y"') == 0
+    assert t1.count('length % 2 == 0 and chrom == "A"') == 2
+    assert t1.count('length % 2 == 0 or chrom == "X"') == 6
+
+    t2 = Table(header=t2_header, data=t2_rows)
+    assert t2.count('foo == "abc"') == 2
+    assert t2.count('foo == "cab"') == 1
+    assert t2.count("bar % 2 == 0") == 2
+    assert t2.count("id == 0") == 0
+
+
+def test_count_empty():
+    # empty table count method returns 0
+    t1 = Table(header=t1_header)
+    assert t1.count('chrom == "X"') == 0
+    assert t1.count(lambda x: x == "X", columns="chrom") == 0
+
+
+def test_count_unique():
+    # correctly computes unique values
+    data = {
+        "Project_Code": [
+            "Ovary-AdenoCA",
+            "Liver-HCC",
+            "Panc-AdenoCA",
+            "Panc-AdenoCA",
+        ],
+        "Donor_ID": ["DO46416", "DO45049", "DO51493", "DO32860"],
+        "Variant_Classification": ["IGR", "Intron", "Intron", "Intron"],
+    }
+    table = make_table(data=data)
+    co = table.count_unique(["Project_Code", "Variant_Classification"])
+    assert co["Panc-AdenoCA", "Intron"] == 2
+    assert co["Liver-HCC", "IGR"] == 0
+    co = table.count_unique("Variant_Classification")
+    assert co["Intron"] == 3
+    assert co["IGR"] == 1
+
+
+def test_distinct_values():
+    # test the table distinct_values method
+    t1 = Table(header=t1_header, data=t1_rows)
+    assert len(t1.distinct_values("chrom")) == 2
+    assert len(t1.distinct_values("stableid")) == 10
+    assert len(t1.distinct_values("length")) == 10
+
+    t2 = Table(header=t2_header, data=t2_rows)
+    assert len(t2.distinct_values("id")) == 5
+    assert len(t2.distinct_values("foo")) == 3
+    assert len(t2.distinct_values("bar")) == 5
+    d = t2.distinct_values("foo")
+    assert d == {"cab", "bca", "abc"}
+
+
+def test_filtered():
+    # test the table filtered method
+    t1 = Table(header=t1_header, data=t1_rows)
+    assert t1.filtered('chrom == "X"').shape[0] == 4
+    assert t1.filtered('stableid.endswith("6")').shape[0] == 2
+    assert t1.filtered("length % 2 == 0").shape[0] == 2
+    assert t1.filtered('chrom == "Y"').shape[0] == 0
+    assert t1.filtered('length % 2 == 0 and chrom == "A"').shape[0] == 2
+    assert t1.filtered('length % 2 == 0 or chrom == "X"').shape[0] == 6
+
+    t2 = Table(header=t2_header, data=t2_rows)
+    assert t2.filtered('foo == "abc"').shape[0] == 2
+    assert t2.filtered('foo == "cab"').shape[0] == 1
+    assert t2.filtered("bar % 2 == 0").shape[0] == 2
+    assert t2.filtered("id == 0").shape[0] == 0
+
+
+def test_filtered_empty():
+    # test the table filtered method
+    t1 = Table(header=t1_header)
+    assert t1.shape[0] == 0
+    got = t1.filtered('chrom == "X"')
+    assert got.shape[0] == 0
+    got = t1.filtered(lambda x: x == "X", columns="chrom")
+    assert got.shape[0] == 0
+
+
+def test_filtered_by_column():
+    # test the table filtered_by_column method
+    t1 = Table(header=t1_header, data=t1_rows)
+    t2 = Table(header=t2_header, data=t2_rows)
+
+    def is_numeric(values):
+        try:
+            sum(values)
+        except TypeError:
+            return False
+        return True
+
+    assert t1.filtered_by_column(is_numeric).shape[1] == 1
+    assert t2.filtered_by_column(is_numeric).shape[1] == 2
+
+
+def test_get_columns():
+    # test the table get_columns method
+    t1 = Table(header=t1_header, data=t1_rows)
+    assert t1.get_columns("chrom").shape[0] == t1.shape[0]
+    assert t1.get_columns("chrom").shape[1] == 1
+
+    assert t1.get_columns(["chrom", "length"]).shape[0] == t1.shape[0]
+    assert t1.get_columns(["chrom", "length"]).shape[1] == 2
+    # if index_name, includes that in return
+    t1 = Table(header=t1_header, data=t1_rows, index_name="stableid")
+    r = t1.get_columns(["length"])
+    assert r.header == ("stableid", "length")
+    # if index_name, unless excluded
+    r = t1.get_columns(["length"], with_index=False)
+    assert r.index_name is None
+
+
+def test_joined():
+    # test the table joined method
+    t2 = Table(header=t2_header, data=t2_rows)
+    t3 = Table(header=t3_header, data=t3_rows)
+    # inner join with defaults
+    got = t2.joined(t3)
+    assert got.shape[0] == 0
+
+    # inner join test
+    assert t2.joined(t3, columns_self="foo", columns_other="foo").shape[0] == 4
+    # merged 'foo' column, so (6-1) columns in join
+    assert t2.joined(t3, columns_self="foo", columns_other="foo").shape[1] == 5
+    # non-inner join test (cartesian product of rows)
+    got = t2.joined(t3, inner_join=False)
+    assert got.shape[0] == t2.shape[0] * t3.shape[0]
+    assert t2.joined(t3, inner_join=False).shape[1] == t2.shape[1] + t3.shape[1]
+
+    got = t2.cross_join(t3)
+    assert got.shape[0] == t2.shape[0] * t3.shape[0]
+    assert t2.joined(t3, inner_join=False).shape[1] == t2.shape[1] + t3.shape[1]
+
+
+def test_joined_diff_indexing():
+    # join handles different indexing
+    a = Table(
+        header=["index", "col2", "col3"],
+        data=[[1, 2, 3], [2, 3, 1], [2, 6, 5]],
+        title="A",
+    )
+    b = Table(
+        header=["index", "col2", "col3"],
+        data=[[1, 2, 3], [2, 2, 1], [3, 6, 3]],
+        title="B",
+    )
+    # index by int
+    j1 = a.joined(b, [0, 2])
+    # index by column names
+    j2 = a.joined(b, ["index", "col3"])
+    assert j1.header == j2.header
+    assert str(j1) == str(j2)
+
+
+def test_normalized():
+    # test the table normalized method
+    t5 = Table(header=t5_header, data=t5_rows)
+    assert t5.normalized().to_list(t5.header) == [
+        [0.25, 0.25, 0.25, 0.25],
+        [0.5, 0.0, 0.25, 0.25],
+        [0.125, 0.375, 0.25, 0.25],
+    ]
+    assert t5.normalized(by_row=False).to_list(t5.header) == [
+        [0.25, 0.25, 0.25, 0.25],
+        [0.5, 0.0, 0.25, 0.25],
+        [0.25, 0.75, 0.5, 0.5],
+    ]
+
+
+def test_sorted():
+    # test the table sorted method
+    t1 = Table(header=t1_header, data=t1_rows)
+    got = t1.sorted("length")
+    assert got.to_list("length") == [
+        999,
+        1353,
+        1383,
+        1554,
+        1599,
+        1698,
+        1827,
+        1977,
+        2307,
+        4185,
+    ]
+
+    t5 = Table(header=t5_header, data=t5_rows)
+    assert t5.sorted("b").to_list("b") == [0, 1, 3]
+    assert t5.sorted().to_list("a") == [1, 1, 2]
+    assert t5.sorted(reverse="a").to_list("a") == [2, 1, 1]
+
+    table = Table(
+        data={
+            "chrom": ("X", "A", "A", "X", "X", "A", "A", "X", "A", "A"),
+            "stableid": (
+                "ENSG00000005893",
+                "ENSG00000019485",
+                "ENSG00000019102",
+                "ENSG00000012174",
+                "ENSG00000010671",
+                "ENSG00000019186",
+                "ENSG00000019144",
+                "ENSG00000008056",
+                "ENSG00000018408",
+                "ENSG00000019169",
+            ),
+            "length": [1353, 1827, 999, 1599, 1977, 1554, 4185, 2307, 1383, 1698],
+        },
+    )
+
+    table = table.sorted(columns=["chrom", "stableid"])
+    last_index = len(table) - 1
+    assert table[0, "stableid"] == "ENSG00000018408"
+    assert table[last_index, "stableid"] == "ENSG00000012174"
+
+    table = table.sorted(reverse="stableid")
+    assert table[0, "stableid"] == "ENSG00000019485"
+    assert table[last_index, "stableid"] == "ENSG00000005893"
+
+    table = table.sorted(reverse="chrom", columns="length")
+    assert table[0, "stableid"] == "ENSG00000019102"
+    assert table[last_index, "stableid"] == "ENSG00000019144"
+
+    # providing reversed argument name raises TypeError
+    with pytest.raises(TypeError):
+        table.sorted(reversed="chrom")
+
+
+def test_summed():
+    # test the table summed method
+    t5 = Table(header=t5_header, data=t5_rows)
+    assert t5.summed() == [4, 4, 4, 4]
+    assert t5.summed(col_sum=False) == [4, 4, 8]
+    t2 = Table(header=t2_header, data=t2_rows)
+    assert t2.summed(indices=2) == 165
+
+    mix = Table(header=["A", "B"], data=[[0, ""], [1, 2], [3, 4]])
+
+    assert mix.summed("B", strict=False) == 6
+    assert mix.summed(0, col_sum=False, strict=False) == 0
+    assert mix.summed(1, col_sum=False) == 3
+    assert mix.summed(strict=False) == [4, 6]
+    assert mix.summed(col_sum=False, strict=False) == [0, 3, 7]
+    with pytest.raises(TypeError):
+        _ = mix.summed(strict=True)
+
+
+def test_to_list():
+    # test the table to_list method
+    t3 = Table(header=t3_header, data=t3_rows)
+    assert t3.to_list("id") == [6, 7]
+    assert t3.to_list("foo") == ["abc", "bca"]
+
+
+def test_to_list_column_order():
+    # column order of input reflected in result
+    t3 = Table(header=t3_header, data=t3_rows)
+    rev_order = ["id", "foo", "bar"]
+    rev_order.reverse()
+    result = t3.to_list(rev_order)
+    assert result[0] == list(reversed(t3_rows[0][:]))
+
+
+def test_to_dict():
+    # cast to 2D dict
+    Table(header=t7_header, data=t7_rows, digits=1)
+
+
+def test_transposed():
+    # test the table transposed method
+    t1 = Table(header=t1_header, data=t1_rows)
+    # note the transpose has one less row
+    got = t1.transposed("", select_as_header="stableid")
+    assert got.shape[0] == t1.shape[1] - 1
+    # note the transpose has an extra column
+    assert got.shape[1] == t1.shape[0] + 1
+    # specifying a column without unique values not supported
+    with pytest.raises(ValueError):
+        _ = t1.transposed("", select_as_header="chrom")
+
+
+def test_transposed_numeric():
+    # table transposed with numeric header converted to str's
+    t = Table(header=t2_header, data=t2_rows)
+    # note the transpose has one less row
+    got = t.transposed("", select_as_header="bar")
+    assert got.shape[0] == t.shape[1] - 1
+    # note the transpose has an extra column
+    assert got.shape[1] == t.shape[0] + 1
+    assert got.header == ("", "11", "22", "33", "44", "55")
+    str(got)  # this should not fail!
+
+
+def test_transposed_forgets_index():
+    # transposed table defaults to no row index_name
+    data = {
+        "": [0, 1, 2, 3, 4, 5, 6],
+        "T": [2, 10, 1, 6, 1, 5, 0],
+        "C": [0, 0, 0, 0, 0, 0, 1],
+        "A": [8, 0, 9, 4, 9, 4, 4],
+        "G": [0, 0, 0, 0, 0, 1, 5],
+    }
+    t = Table(header=["", "T", "C", "A", "G"], data=data, index_name="")
+    tr = t.transposed("Base", select_as_header="")
+    assert tr.index_name is None
+
+    # but you can set a new one
+    tr = t.transposed("Base", select_as_header="", index_name="Base")
+    assert tr.index_name == "Base"
+    assert tr["G", "5"] == 1
+
+
+def test_del_column():
+    # correctly removes the column
+    t = Table(header=t5_header, data=t5_rows)
+    columns = list(t.columns)
+    expect = tuple(columns[1:])
+    del t.columns[columns[0]]
+    assert t.columns.order == expect
+
+
+def test_take_columns():
+    # correctly takes columns
+    t = Table(header=t4_header, data=t4_rows)
+    columns = list(t.columns)
+    expect = tuple(columns[1:])
+    n = t.columns.take_columns(expect)
+    assert n.order == expect
+    n = t.columns.take_columns(columns[0])
+    assert n.order == (columns[0],)
+    n = t.columns.take_columns(1)
+    assert n.order == (columns[1],)
+
+
+def test_with_new_column():
+    # test the table with_new_column method
+    t5 = Table(header=t5_header, data=t5_rows)
+    t5_row_sum = t5.with_new_column("sum", sum, t5.header)
+    assert t5_row_sum.get_columns("sum").to_list() == [4, 4, 8]
+    # now using a string expression
+    t8 = Table(header=t8_header, data=t8_rows, index_name="edge.name")
+    n = t8.with_new_column("YZ", callback="y+z")
+    assert_equal(n.columns["YZ"], [9.0, 9.0])
+    # if the new column alreayb exists, the new table has the newest column
+    n2 = t8.with_new_column("YZ", callback="y*z")
+    assert_equal(n2.columns["YZ"], [18.0, 18.0])
+    assert id(n) != id(n2)
+    # bu the column arrays that have not changed should be equal
+    for c in n.columns:
+        if c == "YZ":
+            assert id(n.columns[c]) != id(n2.columns[c])
+        else:
+            assert id(n.columns[c]) == id(n2.columns[c])
+
+
+def test_with_new_header():
+    # test the table with_new_header method
+    t2 = Table(header=t2_header, data=t2_rows)
+    t2 = t2.with_new_header("id", "no")
+    assert t2.header[0] == "no"
+    t2 = t2.with_new_header("foo", "moo")
+    assert t2.header[1] == "moo"
+    t2 = t2.with_new_header("moo", "foo")
+    assert t2.header[1] == "foo"
+
+
+def test_formatted_mutable():
+    # returns a mutable object
+    # required by formatting functions
+    t = Table(t1_header, t1_rows)
+    fmt = t._formatted()
+    fmt[0][0] = "24"
+    assert fmt[0][0] == "24"
+
+
+def test_formatted_precision():
+    # applies numerical precision
+    # required by formatting functions
+    t = Table(t7_header, t7_rows, digits=1)
+    fmt = t._formatted()
+    # last column should have single place after decimal
+    for l in fmt[1:]:
+        decimal = l[-1].strip().split(".")[-1]
+        assert len(decimal) == 1, l[-1]
+
+
+def test_str_empty():
+    # empty table returns empty str
+    table = make_table()
+    assert str(table) == ""
+
+
+def test_repr_empty():
+    # empty table returns empty str
+    table = make_table()
+    got = repr(table)
+    assert got == "0 rows x 0 columns"
+
+
+def test_str_zero_rows():
+    # table with no rows returns column heads
+    table = make_table(header=["a"])
+    assert str(table) == "=\na\n-\n-"
+
+
+def test_str_object_col():
+    # str works when a column has complex object
+    # data has tuples in an array
+    data = {
+        "key": numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
+        "count": [1, 3, 2],
+    }
+    t = Table(data=data)
+    got = str(t)
+    assert len(got.splitlines()) == 7
+
+
+def test_str_md_format():
+    # str() produces markdown table
+    md_table = make_table(
+        header=["a", "b"],
+        data=[["val1", "val2"], ["has | symbol", "val4"]],
+    )
+    md = md_table.to_string(format_name="md")
+    assert "has \\| symbol" in md
+
+
+def test_str_tex_format():
+    # str() produces latex tabular table
+    tex_table = make_table(
+        header=["a", "b"],
+        data=[["val1", "val2"], ["val3", "val4"]],
+    )
+    tex = tex_table.to_string(format_name="tex", justify="cr")
+    assert tex_table.to_string(format_name="tex", justify="cr") == tex_table.to_latex(
+        justify="cr",
+    )
+    assert tex.splitlines()[2] == "\\begin{tabular}{ c r }"
+    assert "caption" not in tex
+    # with a title
+    tex_table = make_table(
+        header=["a", "b"],
+        data=[["val1", "val2"], ["val3", "val4"]],
+        title="a title",
+    )
+    tex = tex_table.to_string(format_name="tex")
+    tex = tex.splitlines()
+    assert tex[-2] == "\\caption{a title}"
+
+    tex = tex_table.to_string(format_name="tex", label="tab:first")
+    tex = tex.splitlines()
+    assert tex[-3] == "\\caption{a title}"
+    assert tex[-2] == "\\label{tab:first}"
+
+    # with a legend, no title
+    tex_table = make_table(
+        header=["a", "b"],
+        data=[["val1", "val2"], ["val3", "val4"]],
+        legend="a legend",
+    )
+    tex = tex_table.to_string(format_name="tex")
+    tex = tex.splitlines()
+    # because it's treated as a title by default
+    assert tex[-2] == "\\caption{a legend}"
+    # unless you say not to
+    tex = tex_table.to_string(format_name="tex", concat_title_legend=False)
+    tex = tex.splitlines()
+    assert tex[-2] == "\\caption*{a legend}"
+    tex_table = make_table(
+        header=["a", "b"],
+        data=[["val1", "val2"], ["val3", "val4"]],
+        title="a title.",
+        legend="a legend",
+    )
+    tex = tex_table.to_string(format_name="tex")
+    tex = tex.splitlines()
+    assert tex[-2] == "\\caption{a title. a legend}"
+    tex = tex_table.to_string(format_name="tex", concat_title_legend=False)
+    tex = tex.splitlines()
+    assert tex[2] == "\\caption{a title.}"
+    assert tex[-2] == "\\caption*{a legend}"
+    tex = tex_table.to_string(
+        format_name="tex",
+        concat_title_legend=False,
+        label="table",
+    )
+    tex = tex.splitlines()
+    assert tex[2] == "\\caption{a title.}"
+    assert tex[3] == "\\label{table}"
+
+
+def test_to_html():
+    # generates html table within c3table div
+    # with no index_name, or title, or legend
+    import re
+
+    t = Table(header=t8_header, data=t8_rows)
+    got = t.to_html()
+    # make sure tags are matched
+    for tag in ("div", "style", "table", "thead"):
+        assert len(re.findall(f"<[/]*{tag}.*>", got)) == 2
+
+    # 2 data rows plus the header row, each with an open and close tag
+    assert len(re.findall("<[/]*tr>", got)) == 6
+    # 2 columns should be left aligned, 4 right aligned
+    # adding 1 for the CSS style definition
+    assert got.count("c3col_left") == 4 + 1
+    assert got.count("c3col_right") == 8 + 1
+    assert got.count("cell_title") == 1  # CSS defn only
+    num_spans = got.count("span")
+    num_caption = got.count("caption")
+
+    t = Table(header=t8_header, data=t8_rows, title="a title")
+    got = t.to_html()
+    assert got.count("cell_title") == 2
+    # number of spans increases by 2 to enclose the title
+    assert got.count("span") == num_spans + 2
+    assert got.count("caption") == num_caption + 2
+    # no <br> element
+    assert "<br>" not in got
+
+    t = Table(header=t8_header, data=t8_rows, legend="a legend")
+    got = t.to_html()
+    assert got.count("cell_title") == 1
+    # cell_legend not actually defined in CSS yet
+    assert got.count("cell_legend") == 1
+    # number of spans increases by 2 to enclose the title
+    assert got.count("span") == num_spans + 2
+    assert got.count("caption") == num_caption + 2
+    # no <br> element
+    assert "<br>" not in got
+
+    t = Table(
+        header=t8_header,
+        data=t8_rows,
+        title="a title",
+        legend="a legend",
+    )
+    got = t.to_html()
+    assert got.count("cell_title") == 2
+    # cell_legend not actually defined in CSS yet
+    assert got.count("cell_legend") == 1
+    assert got.count("caption") == num_caption + 2
+    # has <br> element
+    assert "<br>" in got
+
+
+def test_invalid_format():
+    # should raise value error
+    t = make_table(t2_header, data=t2_rows)
+    with pytest.raises(ValueError):
+        t.format = "blah"
+
+
+def test_phylip():
+    # generates phylip format
+    rows = [
+        ["a", "", 0.088337278874079342, 0.18848582712597683, 0.44084000179091454],
+        ["c", 0.088337278874079342, "", 0.088337278874079342, 0.44083999937417828],
+        ["b", 0.18848582712597683, 0.088337278874079342, "", 0.44084000179090932],
+        ["e", 0.44084000179091454, 0.44083999937417828, 0.44084000179090932, ""],
+    ]
+    header = ["seq1/2", "a", "c", "b", "e"]
+    dist = Table(header=header, data=rows, index_name="seq1/2")
+    r = dist.to_string(format_name="phylip")
+    r = r.splitlines()
+    assert r[0].strip() == "4"
+    for line in r[1:]:
+        line = line.split()
+        assert line[0] in dist.header
+        assert line[-1][-1].isdigit()
+
+    line = r[1].split()
+    assert line[1] == "0.0000", line
+
+
+def test_load_table_invalid_type():
+    # raises TypeError if filename invalid type
+    with pytest.raises(TypeError):
+        load_table({"a": [0, 1]})
+
+
+def test_make_table_white_space_in_column():
+    # strips white space from column headers
+    # matching header and data keys
+    t = make_table(header=[" a"], data={" a": [0, 2]}, sep="\t")
+    assert t.columns["a"].tolist() == [0, 2]
+    assert isinstance(t.to_string(), str)
+
+    # data key has a space
+    t = make_table(data={" a": [0, 2]}, sep="\t")
+    assert t.columns["a"].tolist() == [0, 2]
+    assert isinstance(t.to_string(), str)
+
+
+def test_load_table_limit():
+    # limit argument to function works
+    t = load_table("data/sample.tsv", limit=2)
+    assert t.shape[0] == 2
+
+
+def test_load_table_returns_static_columns():
+    # for static data, load_table gives same dtypes for static_columns_type=True/False
+    t = load_table("data/sample.tsv", sep="\t", static_column_types=False)
+    is_false = {t.columns[c].dtype.name for c in t.columns}
+    t = load_table("data/sample.tsv", sep="\t", static_column_types=True)
+    is_true = {t.columns[c].dtype.name for c in t.columns}
+    assert is_true == is_false
+
+
+def test_grid_table_format():
+    # test the table grid_table_format method
+    from cogent3.format.table import grid_table_format
+
+    formatted_grid = grid_table_format(
+        t6_header,
+        t6_rows,
+        title="Test",
+        legend="Units",
+    )
+    assert len(formatted_grid.split("\n")) == len(t6_rows) * 2 + 7
+
+    formatted_grid = grid_table_format(
+        t6_header,
+        t6_rows,
+        title="Really Long Title",
+        legend="Extra Long Legend",
+    )
+    assert len(formatted_grid.split("\n")) == len(t6_rows) * 2 + 7 + 2
+
+
+def test_to_markdown():
+    # Exercising the table markdown method
+    table = make_table(t6_header, t6_rows, format_name="md")
+    markdown_table = table.to_markdown(justify="crl")
+    markdown_list = markdown_table.split("\n")
+    assert markdown_list[2].count("|") == 5
+    # the pipe symbol should have been escaped
+    assert markdown_list[2].count("\\|") == 1
+
+    with pytest.raises(ValueError):
+        _ = table.to_markdown(justify="cr1")
+
+
+def test_to_csv():
+    # successfully create csv formatted string
+    table = Table(
+        header=t3_header,
+        data=t3_rows,
+        title="A title",
+        legend="A legend",
+    )
+    sv = table.to_csv()
+    expect = ["id,foo,bar", "6,abc,66", "7,bca,77"]
+    assert sv.splitlines() == expect
+    sv = table.to_csv(with_title=True)
+    assert sv.splitlines() == ["A title", *expect]
+    sv = table.to_csv(with_legend=True)
+    assert sv.splitlines() == [*expect, "A legend"]
+    sv = table.to_csv(with_title=True, with_legend=True)
+    assert sv.splitlines() == ["A title", *expect, "A legend"]
+
+
+def test_to_tsv():
+    # successfully create csv formatted string
+    table = Table(
+        header=t3_header,
+        data=t3_rows,
+        title="A title",
+        legend="A legend",
+    )
+
+    sv = table.to_tsv()
+    expect = ["id\tfoo\tbar", "6\tabc\t66", "7\tbca\t77"]
+    assert sv.splitlines() == expect
+    sv = table.to_tsv(with_title=True)
+    assert sv.splitlines() == ["A title", *expect]
+    sv = table.to_tsv(with_legend=True)
+    assert sv.splitlines() == [*expect, "A legend"]
+    sv = table.to_tsv(with_title=True, with_legend=True)
+    assert sv.splitlines() == ["A title", *expect, "A legend"]
+
+
+def test_to_delim():
+    # successfully create separated format with arbitrary character
+    table = Table(
+        header=t3_header,
+        data=t3_rows,
+    )
+    sv = table.to_string(sep=";")
+    expect = ["id;foo;bar", "6;abc;66", "7;bca;77"]
+    assert sv.splitlines() == expect
+
+
+def test_to_rst_grid():
+    # generates a rst grid table
+    table = Table(header=["a", "b"], data=[[1, 2]], title="A title")
+    got = table.to_rst(csv_table=False).splitlines()
+    assert table.title in got[1]
+    assert set(got[0]) == {"-", "+"}
+    assert set(got[4]) == {"=", "+"}
+
+
+def test_to_rst_csv():
+    # generates a rst csv-table
+    table = Table(
+        header=["a", "b"],
+        data=[[1, 2]],
+        title="A title",
+        legend="A legend",
+    )
+    got = table.to_rst(csv_table=True)
+    assert got.splitlines() == [
+        ".. csv-table:: A title A legend",
+        '    :header: "a", "b"',
+        "",
+        "    1, 2",
+    ]
+    # try without a title/legend
+    table = Table(header=["a", "b"], data=[[1, 2]])
+    got = table.to_rst(csv_table=True)
+    assert got.splitlines() == [
+        ".. csv-table::",
+        '    :header: "a", "b"',
+        "",
+        "    1, 2",
+    ]
+
+
+def test_get_repr_():
+    # handles single column case
+    t = make_table(t2_header, data=t2_rows)
+    t = t[:, 0]
+    # the next line was previously failing
+    t._get_repr_()
+
+    table = Table(header=["a", "b"], data=[[1, 2]])
+    table, _, unset_columns = table._get_repr_()
+    assert table.shape == (1, 2)
+    assert unset_columns is None
+
+    table = make_table(header=["a", "b"])
+    table.columns["a"] = ["a"]
+    table, _, unset_columns = table._get_repr_()
+    assert table.shape == (1, 1)
+    assert "b" in unset_columns
+
+
+def test_repr_html_():
+    # should produce html
+    # no index_name
+    t = Table(header=t8_header, data=t8_rows)
+    _ = t._repr_html_()
+
+    # with an index_name
+    t = Table(header=t8_header, data=t8_rows, index_name="edge.name")
+    got = t._repr_html_()
+    # and the index_name column should contain "index_name" css class
+    assert got.count("index") == t.shape[0] + 1  # add 1 for CSS style sheet
+
+    # data has tuples in an array
+    data = {
+        "key": numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
+        "count": [1, 3, 2],
+    }
+    t = Table(data=data)
+    _ = t._repr_html_()
+
+    # some columns without data
+    table = make_table(header=["a", "b"])
+    table.columns["a"] = ["a"]
+    _ = t._repr_html_()
+
+    # single column with a single value should not fail
+    table = make_table(data={"kappa": [3.2]}, title="a title")
+    _ = table._repr_html_()
+
+    # set head and tail, introduces ellipsis row class
+    table = make_table(data={"A": list("abcdefghijk"), "B": list(range(11))})
+    table.set_repr_policy(head=8, tail=1)
+    got = table._repr_html_().splitlines()
+    num_rows = 0
+    for l in got:
+        if "<tr>" in l:
+            num_rows += 1
+            if "ellipsis" in l:
+                break
+
+    # header row plus 8 head rows plus the ellipsis row
+    assert num_rows == 10
+
+
+def test_array():
+    # should produce array
+    # data has tuples in an array
+    data = {
+        "key": numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
+        "count": [1, 3, 2],
+    }
+    expect = [list(v) for v in zip(data["key"][:], data["count"], strict=False)]
+    t = Table(data=data)
+    arr = t.array
+    assert_equal(arr.tolist(), expect)
+
+
+def test_separator_format():
+    # testing separator_format with title and legend, and contents that match the separator
+    from cogent3.format.table import separator_format
+
+    with pytest.raises(RuntimeError):
+        _ = separator_format(t6_header, t6_rows)
+    separated_table = separator_format(
+        t6_header,
+        t6_rows,
+        sep=" | ",
+        title="Test",
+        legend="Units",
+    )
+    assert len(separated_table.split("\n")) == len(t6_rows) + 3
+
+
+def test_separator_format_writer():
+    # exercising separator_format_writer
+    from cogent3.format.table import separator_formatter
+
+    t3 = Table(header=t3_header, data=t3_rows)
+    comma_sep = t3.to_string(sep=",").splitlines()
+    writer = separator_formatter(sep=" | ")
+    formatted = list(writer([l.split(",") for l in comma_sep], has_header=True))
+    expected_format = ["id | foo | bar", "6 | abc | 66", "7 | bca | 77"]
+    assert formatted == expected_format
+
+
+def test_set_repr_policy():
+    # exercising setting repr policy
+    t = Table(header=t2_header, data=t2_rows)
+    t.set_repr_policy(random=2)
+    r = repr(t)
+    assert isinstance(r, str)
+    r, _, _ = t._get_repr_()
+    assert r.shape[0] == 2
+    t.set_repr_policy(head=1)
+    r, _, _ = t._get_repr_()
+    assert r.shape[0] == 1
+    t.set_repr_policy(tail=3)
+    r, _, _ = t._get_repr_()
+    assert r.shape[0] == 3
+    t.set_repr_policy(show_shape=False)
+    r = repr(t)
+    assert f"\n{t.shape[0]:,} rows x {t.shape[1]:,} columns" not in r
+    r = t._repr_html_()
+    assert f"\n{t.shape[0]:,} rows x {t.shape[1]:,} columns" not in r
+
+
+def test_head():
+    # returns the head of the table!
+    from cogent3.core import table
+
+    display = table.display
+    head = TrapOutput()
+    table.display = head
+    t = Table(header=t1_header, data=t1_rows)
+    t.head(nrows=3)
+    assert head.data.shape[0] == 3
+    assert len(head.output.splitlines()) == 9
+    assert head.data.to_list() == t1_rows[:3]
+    # tests when number of rows < default
+    t = make_table(data={"a": ["a"], "b": ["b"]})
+    t.head()
+    assert head.data.shape[0] == 1
+    assert len(head.output.splitlines()) == 7
+    assert head.data.to_list() == [["a", "b"]]
+    table.display = display
+
+
+def test_tail():
+    # returns the tail of the table!
+    from cogent3.core import table
+
+    display = table.display
+    tail = TrapOutput()
+    table.display = tail
+    t = Table(header=t1_header, data=t1_rows)
+    t.tail(nrows=3)
+    assert tail.data.shape[0] == 3
+    assert len(tail.output.splitlines()) == 9
+    assert [int(v) for v in tail.data[:, -1].to_list()] == [r[-1] for r in t1_rows[-3:]]
+    # tests when number of rows < default
+    t = make_table(data={"a": ["a"], "b": ["b"]})
+    t.tail()
+    assert tail.data.shape[0] == 1
+    assert len(tail.output.splitlines()) == 7
+    assert tail.data.to_list() == [["a", "b"]]
+    table.display = display
+
+
+@pytest.mark.skipif(DataFrame is None, reason="pandas not installed")
+def test_to_pandas():
+    # produces a dataframe
+    t = Table(header=t1_header, data=t1_rows)
+    df = t.to_pandas()
+    assert isinstance(df, DataFrame)
+    data = df.to_numpy()
+    assert data.tolist() == t1_rows
+
+
+def test_load_table():
+    # exercising load table
+    path = os.path.dirname(os.path.dirname(__file__))
+    path = os.path.join(path, "data/sample.tsv")
+    table = load_table(path)
+    assert table.shape == (10, 3)
+
+
+def test_cast_str_to_numerical():
+    # correctly converts a series of strings to numeric values
+    d = arange(4, step=0.1)
+    r = cast_str_to_numeric(d)
+    assert_equal(d, r)
+
+    with warnings.catch_warnings():
+        # we know that converting to real loses imaginary
+        warnings.filterwarnings("ignore", category=ComplexWarning)
+        for d_type in [numpy.int64, numpy.complex128, numpy.float64]:
+            d = d.astype(d_type)
+            r = cast_str_to_numeric(d)
+            assert isinstance(r[0], type(d[0]))
+
+    d = d.astype(str)
+    r = cast_str_to_numeric(d)
+    assert isinstance(r[0], numpy.float64)
+    d = numpy.array(d, dtype="U")
+    r = cast_str_to_numeric(d)
+    assert isinstance(r[0], numpy.float64)
+    d = numpy.array(d, dtype="S")
+    r = cast_str_to_numeric(d)
+    assert isinstance(r[0], numpy.float64)
+
+
+def test_cast_str_to_array():
+    # handle processing string series
+    d = [".123|.345", "123"]
+    r = cast_str_to_array(d, static_type=True)
+    assert "str" in r.dtype.name
+    r = cast_str_to_array(d, static_type=False)
+    assert r.dtype.name == "object"
+    d = [".123|.345", "123", "()"]
+    r = cast_str_to_array(d, static_type=False)
+    assert r[-1] == ()
+
+
+def test_filtering_parser():
+    # filters rows
+    expect = []
+    for r in t1_rows:
+        row = [str(e) for e in r]
+        expect.append(row)
+
+    t = make_table(t1_header, data=t1_rows)
+    lines = t.to_csv().splitlines()
+    # no limit set
+    reader = FilteringParser(
+        row_condition=lambda x: x[0] == "A",
+        with_header=True,
+        sep=",",
+    )
+    got = list(reader(lines))
+    assert got[0] == t1_header
+    assert got[1:] == [r for r in expect if r[0] == "A"]
+
+    # limit set
+    reader = FilteringParser(
+        lambda x: x[0] == "A",
+        with_header=True,
+        sep=",",
+        limit=2,
+    )
+    got = list(reader(lines))
+    assert got[0] == t1_header
+    assert got[1:] == [r for r in expect if r[0] == "A"][:2]
+
+    # negate
+    reader = FilteringParser(
+        lambda x: x[0] == "A",
+        negate=True,
+        with_header=True,
+        sep=",",
+    )
+    got = list(reader(lines))
+    assert got[0] == t1_header
+    assert got[1:] == [r for r in expect if r[0] == "X"]
+
+    # parser works with load_table
+    path = TEST_ROOT / "data" / "sample.tsv"
+    reader = FilteringParser(lambda x: x[0] == "A", with_header=True, sep="\t")
+    table = load_table(path, reader=reader)
+    assert list(table.header) == t1_header
+    assert table.array.tolist() == [r for r in t1_rows if r[0] == "A"]
+
+    # parser works if called on path as Path
+    reader = FilteringParser(lambda x: x[0] == "A", with_header=True, sep="\t")
+    got = list(reader(path))
+    assert len(got) == 7
+
+    # parser works if called on path as str
+    got = list(reader(str(path)))
+    assert len(got) == 7
+
+    # parser works with no conditions
+    reader = FilteringParser(with_header=True, sep="\t")
+    t = load_table(path, reader=reader)
+    assert t.shape == (10, 3)
+
+
+def test_filtering_parser_filter_columns():
+    # filters columns
+    path = TEST_ROOT / "data" / "sample.tsv"
+    # specified by int
+    reader = FilteringParser(columns=0, with_header=True, sep="\t")
+    got = load_table(path, reader=reader)
+    assert got.shape == (10, 1)
+
+    # specified by str
+    reader = FilteringParser(columns="length", with_header=True, sep="\t")
+    got = load_table(path, reader=reader)
+    assert got.shape == (10, 1)
+
+    # specified by index_name
+    reader = FilteringParser(columns=[0, 2], with_header=True, sep="\t")
+    got = load_table(path, reader=reader)
+    assert got.shape == (10, 2)
+
+    # specified by name
+    reader = FilteringParser(
+        columns=["chrom", "length"],
+        with_header=True,
+        sep="\t",
+    )
+    got2 = load_table(path, reader=reader)
+    assert got2.shape == (10, 2)
+    assert_equal(got.array, got2.array)
+
+    # raises value error if column name doesn't exist
+    reader = FilteringParser(columns=["blah", "length"], with_header=True, sep="\t")
+    with pytest.raises(ValueError):
+        _ = load_table(path, reader=reader)
+
+    # raises IndexError if column index_name doesn't exist
+    reader = FilteringParser(columns=[0, 10], with_header=True, sep="\t")
+    with pytest.raises(IndexError):
+        _ = load_table(path, reader=reader)
+
+    # raises ValueError if names given and with_header is False
+    with pytest.raises(ValueError):
+        _ = FilteringParser(columns=["blah"], with_header=False)
+
+
+def test_set_column_format():
+    # fails if invalid format spec provided
+    data = {
+        "Gene": [
             "NP_003077_hs_mm_rn_dna",
             "NP_004893_hs_mm_rn_dna",
             "NP_005079_hs_mm_rn_dna",
             "NP_005500_hs_mm_rn_dna",
             "NP_055852_hs_mm_rn_dna",
-        )
-        a = cast_to_array(s)
-        assert "str" in a.dtype.name
-        assert a.tolist() == list(s)
-
-        f = (2.53, 12.426, 9.9, 7.382e-08)
-        a = cast_to_array(f)
-        assert "float" in a.dtype.name, a.dtype.name
-        assert a.tolist() == list(f)
-
-        d = [3, 4, 5]
-        a = cast_to_array(d)
-        assert "int" in a.dtype.name, a.dtype.name
-        assert a.tolist() == list(d)
-
-        o = [3, "abc", 3.4]
-        a = cast_to_array(o)
-        assert "object" in a.dtype.name, a.dtype.name
-        assert a.tolist() == list(o)
-
-    def test_make_table(self):
-        """makes a table"""
-        data = {
-            "edge.parent": {
-                "NineBande": "root",
-                "edge.1": "root",
-                "DogFaced": "root",
-                "Human": "edge.0",
-            },
-            "x": {
-                "NineBande": 1.0,
-                "edge.1": 1.0,
-                "DogFaced": 1.0,
-                "Human": 1.0,
-            },
-            "length": {
-                "NineBande": 4.0,
-                "edge.1": 4.0,
-                "DogFaced": 4.0,
-                "Human": 4.0,
-            },
-            "y": {
-                "NineBande": 3.0,
-                "edge.1": 3.0,
-                "DogFaced": 3.0,
-                "Human": 3.0,
-            },
-            "z": {
-                "NineBande": 6.0,
-                "edge.1": 6.0,
-                "DogFaced": 6.0,
-                "Human": 6.0,
-            },
-            "edge.names": {
-                "NineBande": "NineBande",
-                "edge.1": "edge.1",
-                "DogFaced": "DogFaced",
-                "Human": "Human",
-            },
-        }
-        t = make_table(data=data)
-        assert t.shape == (4, 6)
-        # if index_name column not specified
-        with pytest.raises(IndexError):
-            _ = t["Human", "edge.parent"]
-
-        # use an index_name
-        t = make_table(data=data, index_name="edge.names")
-        # index_name col is the first one, and the data can be indexed
-        assert t.columns.order[0] == "edge.names"
-        assert t["Human", "edge.parent"] == "edge.0"
-
-        # providing path raises TypeError
-        with pytest.raises(TypeError):
-            make_table("some_path.tsv")
-
-        with pytest.raises(TypeError):
-            make_table(header="some_path.tsv")
-
-        with pytest.raises(TypeError):
-            make_table(data="some_path.tsv")
-
-    def test_modify_title_legend(self):
-        """reflected in persistent attrs"""
-        rows = (
-            ("NP_003077_hs_mm_rn_dna", "Con", 2.5386013224378985),
-            ("NP_004893_hs_mm_rn_dna", "Con", 0.12135142635634111e06),
-        )
-        t = Table(["Gene", "Type", "LR"], rows)
-        t.title = "a new one"
-        assert t._get_persistent_attrs()["title"] == "a new one"
-        t.legend = "a new 2"
-        assert t._get_persistent_attrs()["legend"] == "a new 2"
-
-    def test_dunder_repr_eq_str(self):
-        """dunder str and repr methods should produce same"""
-        rows = (
-            ("NP_003077_hs_mm_rn_dna", "Con", 2.5386013224378985),
-            ("NP_004893_hs_mm_rn_dna", "Con", 0.12135142635634111e06),
-        )
-        t = Table(["Gene", "Type", "LR"], rows)
-        t.format_column("LR", "%.4e")
-        s = str(t)
-        r = repr(t)
-        assert r.startswith(s)
-
-    @skipIf(DataFrame is None, "pandas not installed")
-    def test_make_table_from_dataframe(self):
-        """makes a table from a pandas data frame"""
-        df = DataFrame(data=[[0, 1], [3, 7]], columns=["a", "b"])
-        t = make_table(data_frame=df)
-        assert_equal(t.columns["a"], [0, 3])
-        assert_equal(t.columns["b"], [1, 7])
-        with pytest.raises(TypeError):
-            make_table(data_frame="abcde")
-
-    def test_appended(self):
-        """test the table appended method"""
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        t3 = Table(header=self.t3_header, data=self.t3_rows)
-        t4 = Table(header=self.t4_header, data=self.t4_rows)
-
-        append_0 = t2.appended("foo2", [], title="self")
-        assert append_0.shape[0] == t2.shape[0]
-        # test the title feature
-        assert append_0.title == "self"
-
-        append_1 = t2.appended("foo2", [t3])
-        assert append_1.shape[0] == t2.shape[0] + t3.shape[0]
-        # test the new_column feature
-        assert append_1.shape[1] == 4
-        assert append_1.header[0] == "foo2"
-
-        append_2 = t2.appended("foo2", [t3, t4])
-        assert append_2.shape[0] == t2.shape[0] + t3.shape[0] + t4.shape[0]
-
-        append_3 = t2.appended("", [t3, t4])
-        assert append_3.shape[0] == t2.shape[0] + t3.shape[0] + t4.shape[0]
-        assert append_3.shape[1] == t2.shape[1] + 1
-
-    def test_appended_mixed_dtypes(self):
-        """handles table columns with different dtypes"""
-        t1 = Table(header=["a", "b"], data={"a": [1], "b": ["s"]})
-        t2 = Table(header=["a", "b"], data={"a": [1.2], "b": [4]})
-        appended = t1.appended(None, t2)
-        assert "float" in appended.columns["a"].dtype.name
-        assert "object" in appended.columns["b"].dtype.name
-
-    def test_count(self):
-        """test the table count method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        assert t1.count('chrom == "X"') == 4
-        assert t1.count('stableid.endswith("6")') == 2
-        assert t1.count("length % 2 == 0") == 2
-        assert t1.count('chrom == "Y"') == 0
-        assert t1.count('length % 2 == 0 and chrom == "A"') == 2
-        assert t1.count('length % 2 == 0 or chrom == "X"') == 6
-
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        assert t2.count('foo == "abc"') == 2
-        assert t2.count('foo == "cab"') == 1
-        assert t2.count("bar % 2 == 0") == 2
-        assert t2.count("id == 0") == 0
-
-    def test_count_empty(self):
-        """empty table count method returns 0"""
-        t1 = Table(header=self.t1_header)
-        assert t1.count('chrom == "X"') == 0
-        assert t1.count(lambda x: x == "X", columns="chrom") == 0
-
-    def test_count_unique(self):
-        """correctly computes unique values"""
-        data = {
-            "Project_Code": [
-                "Ovary-AdenoCA",
-                "Liver-HCC",
-                "Panc-AdenoCA",
-                "Panc-AdenoCA",
-            ],
-            "Donor_ID": ["DO46416", "DO45049", "DO51493", "DO32860"],
-            "Variant_Classification": ["IGR", "Intron", "Intron", "Intron"],
-        }
-        table = make_table(data=data)
-        co = table.count_unique(["Project_Code", "Variant_Classification"])
-        assert co["Panc-AdenoCA", "Intron"] == 2
-        assert co["Liver-HCC", "IGR"] == 0
-        co = table.count_unique("Variant_Classification")
-        assert co["Intron"] == 3
-        assert co["IGR"] == 1
-
-    def test_distinct_values(self):
-        """test the table distinct_values method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        assert len(t1.distinct_values("chrom")) == 2
-        assert len(t1.distinct_values("stableid")) == 10
-        assert len(t1.distinct_values("length")) == 10
-
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        assert len(t2.distinct_values("id")) == 5
-        assert len(t2.distinct_values("foo")) == 3
-        assert len(t2.distinct_values("bar")) == 5
-        d = t2.distinct_values("foo")
-        assert d == {"cab", "bca", "abc"}
-
-    def test_filtered(self):
-        """test the table filtered method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        assert t1.filtered('chrom == "X"').shape[0] == 4
-        assert t1.filtered('stableid.endswith("6")').shape[0] == 2
-        assert t1.filtered("length % 2 == 0").shape[0] == 2
-        assert t1.filtered('chrom == "Y"').shape[0] == 0
-        assert t1.filtered('length % 2 == 0 and chrom == "A"').shape[0] == 2
-        assert t1.filtered('length % 2 == 0 or chrom == "X"').shape[0] == 6
-
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        assert t2.filtered('foo == "abc"').shape[0] == 2
-        assert t2.filtered('foo == "cab"').shape[0] == 1
-        assert t2.filtered("bar % 2 == 0").shape[0] == 2
-        assert t2.filtered("id == 0").shape[0] == 0
-
-    def test_filtered_empty(self):
-        """test the table filtered method"""
-        t1 = Table(header=self.t1_header)
-        assert t1.shape[0] == 0
-        got = t1.filtered('chrom == "X"')
-        assert got.shape[0] == 0
-        got = t1.filtered(lambda x: x == "X", columns="chrom")
-        assert got.shape[0] == 0
-
-    def test_filtered_by_column(self):
-        """test the table filtered_by_column method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-
-        def is_numeric(values):
-            try:
-                sum(values)
-            except TypeError:
-                return False
-            return True
-
-        assert t1.filtered_by_column(is_numeric).shape[1] == 1
-        assert t2.filtered_by_column(is_numeric).shape[1] == 2
-
-    def test_get_columns(self):
-        """test the table get_columns method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        assert t1.get_columns("chrom").shape[0] == t1.shape[0]
-        assert t1.get_columns("chrom").shape[1] == 1
-
-        assert t1.get_columns(["chrom", "length"]).shape[0] == t1.shape[0]
-        assert t1.get_columns(["chrom", "length"]).shape[1] == 2
-        # if index_name, includes that in return
-        t1 = Table(header=self.t1_header, data=self.t1_rows, index_name="stableid")
-        r = t1.get_columns(["length"])
-        assert r.header == ("stableid", "length")
-        # if index_name, unless excluded
-        r = t1.get_columns(["length"], with_index=False)
-        assert r.index_name is None
-
-    def test_joined(self):
-        """test the table joined method"""
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        t3 = Table(header=self.t3_header, data=self.t3_rows)
-        # inner join with defaults
-        got = t2.joined(t3)
-        assert got.shape[0] == 0
-
-        # inner join test
-        assert t2.joined(t3, columns_self="foo", columns_other="foo").shape[0] == 4
-        # merged 'foo' column, so (6-1) columns in join
-        assert t2.joined(t3, columns_self="foo", columns_other="foo").shape[1] == 5
-        # non-inner join test (cartesian product of rows)
-        got = t2.joined(t3, inner_join=False)
-        assert got.shape[0] == t2.shape[0] * t3.shape[0]
-        assert t2.joined(t3, inner_join=False).shape[1] == t2.shape[1] + t3.shape[1]
-
-        got = t2.cross_join(t3)
-        assert got.shape[0] == t2.shape[0] * t3.shape[0]
-        assert t2.joined(t3, inner_join=False).shape[1] == t2.shape[1] + t3.shape[1]
-
-    def test_joined_diff_indexing(self):
-        """join handles different indexing"""
-        a = Table(
-            header=["index", "col2", "col3"],
-            data=[[1, 2, 3], [2, 3, 1], [2, 6, 5]],
-            title="A",
-        )
-        b = Table(
-            header=["index", "col2", "col3"],
-            data=[[1, 2, 3], [2, 2, 1], [3, 6, 3]],
-            title="B",
-        )
-        # index by int
-        j1 = a.joined(b, [0, 2])
-        # index by column names
-        j2 = a.joined(b, ["index", "col3"])
-        assert j1.header == j2.header
-        assert str(j1) == str(j2)
-
-    def test_normalized(self):
-        """test the table normalized method"""
-        t5 = Table(header=self.t5_header, data=self.t5_rows)
-        assert t5.normalized().to_list(t5.header) == [
-            [0.25, 0.25, 0.25, 0.25],
-            [0.5, 0.0, 0.25, 0.25],
-            [0.125, 0.375, 0.25, 0.25],
-        ]
-        assert t5.normalized(by_row=False).to_list(t5.header) == [
-            [0.25, 0.25, 0.25, 0.25],
-            [0.5, 0.0, 0.25, 0.25],
-            [0.25, 0.75, 0.5, 0.5],
-        ]
-
-    def test_sorted(self):
-        """test the table sorted method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        got = t1.sorted("length")
-        assert got.to_list("length") == [
-            999,
-            1353,
-            1383,
-            1554,
-            1599,
-            1698,
-            1827,
-            1977,
-            2307,
-            4185,
-        ]
-
-        t5 = Table(header=self.t5_header, data=self.t5_rows)
-        assert t5.sorted("b").to_list("b") == [0, 1, 3]
-        assert t5.sorted().to_list("a") == [1, 1, 2]
-        assert t5.sorted(reverse="a").to_list("a") == [2, 1, 1]
-
-        table = Table(
-            data={
-                "chrom": ("X", "A", "A", "X", "X", "A", "A", "X", "A", "A"),
-                "stableid": (
-                    "ENSG00000005893",
-                    "ENSG00000019485",
-                    "ENSG00000019102",
-                    "ENSG00000012174",
-                    "ENSG00000010671",
-                    "ENSG00000019186",
-                    "ENSG00000019144",
-                    "ENSG00000008056",
-                    "ENSG00000018408",
-                    "ENSG00000019169",
-                ),
-                "length": [1353, 1827, 999, 1599, 1977, 1554, 4185, 2307, 1383, 1698],
-            },
-        )
-
-        table = table.sorted(columns=["chrom", "stableid"])
-        last_index = len(table) - 1
-        assert table[0, "stableid"] == "ENSG00000018408"
-        assert table[last_index, "stableid"] == "ENSG00000012174"
-
-        table = table.sorted(reverse="stableid")
-        assert table[0, "stableid"] == "ENSG00000019485"
-        assert table[last_index, "stableid"] == "ENSG00000005893"
-
-        table = table.sorted(reverse="chrom", columns="length")
-        assert table[0, "stableid"] == "ENSG00000019102"
-        assert table[last_index, "stableid"] == "ENSG00000019144"
-
-        # providing reversed argument name raises TypeError
-        with pytest.raises(TypeError):
-            table.sorted(reversed="chrom")
-
-    def test_summed(self):
-        """test the table summed method"""
-        t5 = Table(header=self.t5_header, data=self.t5_rows)
-        assert t5.summed() == [4, 4, 4, 4]
-        assert t5.summed(col_sum=False) == [4, 4, 8]
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        assert t2.summed(indices=2) == 165
-
-        mix = Table(header=["A", "B"], data=[[0, ""], [1, 2], [3, 4]])
-
-        assert mix.summed("B", strict=False) == 6
-        assert mix.summed(0, col_sum=False, strict=False) == 0
-        assert mix.summed(1, col_sum=False) == 3
-        assert mix.summed(strict=False) == [4, 6]
-        assert mix.summed(col_sum=False, strict=False) == [0, 3, 7]
-        with pytest.raises(TypeError):
-            _ = mix.summed(strict=True)
-
-    def test_to_list(self):
-        """test the table to_list method"""
-        t3 = Table(header=self.t3_header, data=self.t3_rows)
-        assert t3.to_list("id") == [6, 7]
-        assert t3.to_list("foo") == ["abc", "bca"]
-
-    def test_to_list_column_order(self):
-        """column order of input reflected in result"""
-        t3 = Table(header=self.t3_header, data=self.t3_rows)
-        rev_order = ["id", "foo", "bar"]
-        rev_order.reverse()
-        result = t3.to_list(rev_order)
-        assert result[0] == list(reversed(self.t3_rows[0][:]))
-
-    def test_to_dict(self):
-        """cast to 2D dict"""
-        Table(header=self.t7_header, data=self.t7_rows, digits=1)
-
-    def test_transposed(self):
-        """test the table transposed method"""
-        t1 = Table(header=self.t1_header, data=self.t1_rows)
-        # note the transpose has one less row
-        got = t1.transposed("", select_as_header="stableid")
-        assert got.shape[0] == t1.shape[1] - 1
-        # note the transpose has an extra column
-        assert got.shape[1] == t1.shape[0] + 1
-        # specifying a column without unique values not supported
-        with pytest.raises(ValueError):
-            _ = t1.transposed("", select_as_header="chrom")
-
-    def test_transposed_numeric(self):
-        """table transposed with numeric header converted to str's"""
-        t = Table(header=self.t2_header, data=self.t2_rows)
-        # note the transpose has one less row
-        got = t.transposed("", select_as_header="bar")
-        assert got.shape[0] == t.shape[1] - 1
-        # note the transpose has an extra column
-        assert got.shape[1] == t.shape[0] + 1
-        assert got.header == ("", "11", "22", "33", "44", "55")
-        str(got)  # this should not fail!
-
-    def test_transposed_forgets_index(self):
-        """transposed table defaults to no row index_name"""
-        data = {
-            "": [0, 1, 2, 3, 4, 5, 6],
-            "T": [2, 10, 1, 6, 1, 5, 0],
-            "C": [0, 0, 0, 0, 0, 0, 1],
-            "A": [8, 0, 9, 4, 9, 4, 4],
-            "G": [0, 0, 0, 0, 0, 1, 5],
-        }
-        t = Table(header=["", "T", "C", "A", "G"], data=data, index_name="")
-        tr = t.transposed("Base", select_as_header="")
-        assert tr.index_name is None
-
-        # but you can set a new one
-        tr = t.transposed("Base", select_as_header="", index_name="Base")
-        assert tr.index_name == "Base"
-        assert tr["G", "5"] == 1
-
-    def test_del_column(self):
-        """correctly removes the column"""
-        t = Table(header=self.t5_header, data=self.t5_rows)
-        columns = list(t.columns)
-        expect = tuple(columns[1:])
-        del t.columns[columns[0]]
-        assert t.columns.order == expect
-
-    def test_take_columns(self):
-        """correctly takes columns"""
-        t = Table(header=self.t4_header, data=self.t4_rows)
-        columns = list(t.columns)
-        expect = tuple(columns[1:])
-        n = t.columns.take_columns(expect)
-        assert n.order == expect
-        n = t.columns.take_columns(columns[0])
-        assert n.order == (columns[0],)
-        n = t.columns.take_columns(1)
-        assert n.order == (columns[1],)
-
-    def test_with_new_column(self):
-        """test the table with_new_column method"""
-        t5 = Table(header=self.t5_header, data=self.t5_rows)
-        t5_row_sum = t5.with_new_column("sum", sum, t5.header)
-        assert t5_row_sum.get_columns("sum").to_list() == [4, 4, 8]
-        # now using a string expression
-        t8 = Table(header=self.t8_header, data=self.t8_rows, index_name="edge.name")
-        n = t8.with_new_column("YZ", callback="y+z")
-        assert_equal(n.columns["YZ"], [9.0, 9.0])
-        # if the new column alreayb exists, the new table has the newest column
-        n2 = t8.with_new_column("YZ", callback="y*z")
-        assert_equal(n2.columns["YZ"], [18.0, 18.0])
-        assert id(n) != id(n2)
-        # bu the column arrays that have not changed should be equal
-        for c in n.columns:
-            if c == "YZ":
-                assert id(n.columns[c]) != id(n2.columns[c])
-            else:
-                assert id(n.columns[c]) == id(n2.columns[c])
-
-    def test_with_new_header(self):
-        """test the table with_new_header method"""
-        t2 = Table(header=self.t2_header, data=self.t2_rows)
-        t2 = t2.with_new_header("id", "no")
-        assert t2.header[0] == "no"
-        t2 = t2.with_new_header("foo", "moo")
-        assert t2.header[1] == "moo"
-        t2 = t2.with_new_header("moo", "foo")
-        assert t2.header[1] == "foo"
-
-    def test_formatted_mutable(self):
-        """returns a mutable object"""
-        # required by formatting functions
-        t = Table(self.t1_header, self.t1_rows)
-        fmt = t._formatted()
-        fmt[0][0] = "24"
-        assert fmt[0][0] == "24"
-
-    def test_formatted_precision(self):
-        """applies numerical precision"""
-        # required by formatting functions
-        t = Table(self.t7_header, self.t7_rows, digits=1)
-        fmt = t._formatted()
-        # last column should have single place after decimal
-        for l in fmt[1:]:
-            decimal = l[-1].strip().split(".")[-1]
-            assert len(decimal) == 1, l[-1]
-
-    def test_str_empty(self):
-        """empty table returns empty str"""
-        table = make_table()
-        assert str(table) == ""
-
-    def test_repr_empty(self):
-        """empty table returns empty str"""
-        table = make_table()
-        got = repr(table)
-        assert got == "0 rows x 0 columns"
-
-    def test_str_zero_rows(self):
-        """table with no rows returns column heads"""
-        table = make_table(header=["a"])
-        assert str(table) == "=\na\n-\n-"
-
-    def test_str_object_col(self):
-        """str works when a column has complex object"""
-        # data has tuples in an array
-        data = {
-            "key": numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
-            "count": [1, 3, 2],
-        }
-        t = Table(data=data)
-        got = str(t)
-        assert len(got.splitlines()) == 7
-
-    def test_str_md_format(self):
-        """str() produces markdown table"""
-        md_table = make_table(
-            header=["a", "b"],
-            data=[["val1", "val2"], ["has | symbol", "val4"]],
-        )
-        md = md_table.to_string(format_name="md")
-        assert "has \\| symbol" in md
-
-    def test_str_tex_format(self):
-        """str() produces latex tabular table"""
-        tex_table = make_table(
-            header=["a", "b"],
-            data=[["val1", "val2"], ["val3", "val4"]],
-        )
-        tex = tex_table.to_string(format_name="tex", justify="cr")
-        assert tex_table.to_string(
-            format_name="tex", justify="cr"
-        ) == tex_table.to_latex(
-            justify="cr",
-        )
-        assert tex.splitlines()[2] == "\\begin{tabular}{ c r }"
-        assert "caption" not in tex
-        # with a title
-        tex_table = make_table(
-            header=["a", "b"],
-            data=[["val1", "val2"], ["val3", "val4"]],
-            title="a title",
-        )
-        tex = tex_table.to_string(format_name="tex")
-        tex = tex.splitlines()
-        assert tex[-2] == "\\caption{a title}"
-
-        tex = tex_table.to_string(format_name="tex", label="tab:first")
-        tex = tex.splitlines()
-        assert tex[-3] == "\\caption{a title}"
-        assert tex[-2] == "\\label{tab:first}"
-
-        # with a legend, no title
-        tex_table = make_table(
-            header=["a", "b"],
-            data=[["val1", "val2"], ["val3", "val4"]],
-            legend="a legend",
-        )
-        tex = tex_table.to_string(format_name="tex")
-        tex = tex.splitlines()
-        # because it's treated as a title by default
-        assert tex[-2] == "\\caption{a legend}"
-        # unless you say not to
-        tex = tex_table.to_string(format_name="tex", concat_title_legend=False)
-        tex = tex.splitlines()
-        assert tex[-2] == "\\caption*{a legend}"
-        tex_table = make_table(
-            header=["a", "b"],
-            data=[["val1", "val2"], ["val3", "val4"]],
-            title="a title.",
-            legend="a legend",
-        )
-        tex = tex_table.to_string(format_name="tex")
-        tex = tex.splitlines()
-        assert tex[-2] == "\\caption{a title. a legend}"
-        tex = tex_table.to_string(format_name="tex", concat_title_legend=False)
-        tex = tex.splitlines()
-        assert tex[2] == "\\caption{a title.}"
-        assert tex[-2] == "\\caption*{a legend}"
-        tex = tex_table.to_string(
-            format_name="tex",
-            concat_title_legend=False,
-            label="table",
-        )
-        tex = tex.splitlines()
-        assert tex[2] == "\\caption{a title.}"
-        assert tex[3] == "\\label{table}"
-
-    def test_to_html(self):
-        """generates html table within c3table div"""
-        # with no index_name, or title, or legend
-        import re
-
-        t = Table(header=self.t8_header, data=self.t8_rows)
-        got = t.to_html()
-        # make sure tags are matched
-        for tag in ("div", "style", "table", "thead"):
-            assert len(re.findall(f"<[/]*{tag}.*>", got)) == 2
-
-        # 2 data rows plus the header row, each with an open and close tag
-        assert len(re.findall("<[/]*tr>", got)) == 6
-        # 2 columns should be left aligned, 4 right aligned
-        # adding 1 for the CSS style definition
-        assert got.count("c3col_left") == 4 + 1
-        assert got.count("c3col_right") == 8 + 1
-        assert got.count("cell_title") == 1  # CSS defn only
-        num_spans = got.count("span")
-        num_caption = got.count("caption")
-
-        t = Table(header=self.t8_header, data=self.t8_rows, title="a title")
-        got = t.to_html()
-        assert got.count("cell_title") == 2
-        # number of spans increases by 2 to enclose the title
-        assert got.count("span") == num_spans + 2
-        assert got.count("caption") == num_caption + 2
-        # no <br> element
-        assert "<br>" not in got
-
-        t = Table(header=self.t8_header, data=self.t8_rows, legend="a legend")
-        got = t.to_html()
-        assert got.count("cell_title") == 1
-        # cell_legend not actually defined in CSS yet
-        assert got.count("cell_legend") == 1
-        # number of spans increases by 2 to enclose the title
-        assert got.count("span") == num_spans + 2
-        assert got.count("caption") == num_caption + 2
-        # no <br> element
-        assert "<br>" not in got
-
-        t = Table(
-            header=self.t8_header,
-            data=self.t8_rows,
-            title="a title",
-            legend="a legend",
-        )
-        got = t.to_html()
-        assert got.count("cell_title") == 2
-        # cell_legend not actually defined in CSS yet
-        assert got.count("cell_legend") == 1
-        assert got.count("caption") == num_caption + 2
-        # has <br> element
-        assert "<br>" in got
-
-    def test_invalid_format(self):
-        """should raise value error"""
-        t = make_table(self.t2_header, data=self.t2_rows)
-        with pytest.raises(ValueError):
-            t.format = "blah"
-
-    def test_phylip(self):
-        """generates phylip format"""
-        rows = [
-            ["a", "", 0.088337278874079342, 0.18848582712597683, 0.44084000179091454],
-            ["c", 0.088337278874079342, "", 0.088337278874079342, 0.44083999937417828],
-            ["b", 0.18848582712597683, 0.088337278874079342, "", 0.44084000179090932],
-            ["e", 0.44084000179091454, 0.44083999937417828, 0.44084000179090932, ""],
-        ]
-        header = ["seq1/2", "a", "c", "b", "e"]
-        dist = Table(header=header, data=rows, index_name="seq1/2")
-        r = dist.to_string(format_name="phylip")
-        r = r.splitlines()
-        assert r[0].strip() == "4"
-        for line in r[1:]:
-            line = line.split()
-            assert line[0] in dist.header
-            assert line[-1][-1].isdigit()
-
-        line = r[1].split()
-        assert line[1] == "0.0000", line
-
-    def test_load_table_invalid_type(self):
-        """raises TypeError if filename invalid type"""
-        with pytest.raises(TypeError):
-            load_table({"a": [0, 1]})
-
-    def test_make_table_white_space_in_column(self):
-        """strips white space from column headers"""
-        # matching header and data keys
-        t = make_table(header=[" a"], data={" a": [0, 2]}, sep="\t")
-        assert t.columns["a"].tolist() == [0, 2]
-        assert isinstance(t.to_string(), str)
-
-        # data key has a space
-        t = make_table(data={" a": [0, 2]}, sep="\t")
-        assert t.columns["a"].tolist() == [0, 2]
-        assert isinstance(t.to_string(), str)
-
-    def test_load_table_limit(self):
-        """limit argument to function works"""
-        t = load_table("data/sample.tsv", limit=2)
-        assert t.shape[0] == 2
-
-    def test_load_table_returns_static_columns(self):
-        """for static data, load_table gives same dtypes for static_columns_type=True/False"""
-        t = load_table("data/sample.tsv", sep="\t", static_column_types=False)
-        is_false = {t.columns[c].dtype.name for c in t.columns}
-        t = load_table("data/sample.tsv", sep="\t", static_column_types=True)
-        is_true = {t.columns[c].dtype.name for c in t.columns}
-        assert is_true == is_false
-
-    def test_grid_table_format(self):
-        """test the table grid_table_format method"""
-        from cogent3.format.table import grid_table_format
-
-        formatted_grid = grid_table_format(
-            self.t6_header,
-            self.t6_rows,
-            title="Test",
-            legend="Units",
-        )
-        assert len(formatted_grid.split("\n")) == len(self.t6_rows) * 2 + 7
-
-        formatted_grid = grid_table_format(
-            self.t6_header,
-            self.t6_rows,
-            title="Really Long Title",
-            legend="Extra Long Legend",
-        )
-        assert len(formatted_grid.split("\n")) == len(self.t6_rows) * 2 + 7 + 2
-
-    def test_to_markdown(self):
-        """Exercising the table markdown method"""
-        table = make_table(self.t6_header, self.t6_rows, format_name="md")
-        markdown_table = table.to_markdown(justify="crl")
-        markdown_list = markdown_table.split("\n")
-        assert markdown_list[2].count("|") == 5
-        # the pipe symbol should have been escaped
-        assert markdown_list[2].count("\\|") == 1
-
-        with pytest.raises(ValueError):
-            _ = table.to_markdown(justify="cr1")
-
-    def test_to_csv(self):
-        """successfully create csv formatted string"""
-        table = Table(
-            header=self.t3_header,
-            data=self.t3_rows,
-            title="A title",
-            legend="A legend",
-        )
-        sv = table.to_csv()
-        expect = ["id,foo,bar", "6,abc,66", "7,bca,77"]
-        assert sv.splitlines() == expect
-        sv = table.to_csv(with_title=True)
-        assert sv.splitlines() == ["A title", *expect]
-        sv = table.to_csv(with_legend=True)
-        assert sv.splitlines() == [*expect, "A legend"]
-        sv = table.to_csv(with_title=True, with_legend=True)
-        assert sv.splitlines() == ["A title", *expect, "A legend"]
-
-    def test_to_tsv(self):
-        """successfully create csv formatted string"""
-        table = Table(
-            header=self.t3_header,
-            data=self.t3_rows,
-            title="A title",
-            legend="A legend",
-        )
-
-        sv = table.to_tsv()
-        expect = ["id\tfoo\tbar", "6\tabc\t66", "7\tbca\t77"]
-        assert sv.splitlines() == expect
-        sv = table.to_tsv(with_title=True)
-        assert sv.splitlines() == ["A title", *expect]
-        sv = table.to_tsv(with_legend=True)
-        assert sv.splitlines() == [*expect, "A legend"]
-        sv = table.to_tsv(with_title=True, with_legend=True)
-        assert sv.splitlines() == ["A title", *expect, "A legend"]
-
-    def test_to_delim(self):
-        """successfully create separated format with arbitrary character"""
-        table = Table(
-            header=self.t3_header,
-            data=self.t3_rows,
-        )
-        sv = table.to_string(sep=";")
-        expect = ["id;foo;bar", "6;abc;66", "7;bca;77"]
-        assert sv.splitlines() == expect
-
-    def test_to_rst_grid(self):
-        """generates a rst grid table"""
-        table = Table(header=["a", "b"], data=[[1, 2]], title="A title")
-        got = table.to_rst(csv_table=False).splitlines()
-        assert table.title in got[1]
-        assert set(got[0]) == {"-", "+"}
-        assert set(got[4]) == {"=", "+"}
-
-    def test_to_rst_csv(self):
-        """generates a rst csv-table"""
-        table = Table(
-            header=["a", "b"],
-            data=[[1, 2]],
-            title="A title",
-            legend="A legend",
-        )
-        got = table.to_rst(csv_table=True)
-        assert got.splitlines() == [
-            ".. csv-table:: A title A legend",
-            '    :header: "a", "b"',
-            "",
-            "    1, 2",
-        ]
-        # try without a title/legend
-        table = Table(header=["a", "b"], data=[[1, 2]])
-        got = table.to_rst(csv_table=True)
-        assert got.splitlines() == [
-            ".. csv-table::",
-            '    :header: "a", "b"',
-            "",
-            "    1, 2",
-        ]
-
-    def test_get_repr_(self):
-        """handles single column case"""
-        t = make_table(self.t2_header, data=self.t2_rows)
-        t = t[:, 0]
-        # the next line was previously failing
-        t._get_repr_()
-
-        table = Table(header=["a", "b"], data=[[1, 2]])
-        table, _, unset_columns = table._get_repr_()
-        assert table.shape == (1, 2)
-        assert unset_columns is None
-
-        table = make_table(header=["a", "b"])
-        table.columns["a"] = ["a"]
-        table, _, unset_columns = table._get_repr_()
-        assert table.shape == (1, 1)
-        assert "b" in unset_columns
-
-    def test_repr_html_(self):
-        """should produce html"""
-        # no index_name
-        t = Table(header=self.t8_header, data=self.t8_rows)
-        _ = t._repr_html_()
-
-        # with an index_name
-        t = Table(header=self.t8_header, data=self.t8_rows, index_name="edge.name")
-        got = t._repr_html_()
-        # and the index_name column should contain "index_name" css class
-        assert got.count("index") == t.shape[0] + 1  # add 1 for CSS style sheet
-
-        # data has tuples in an array
-        data = {
-            "key": numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
-            "count": [1, 3, 2],
-        }
-        t = Table(data=data)
-        _ = t._repr_html_()
-
-        # some columns without data
-        table = make_table(header=["a", "b"])
-        table.columns["a"] = ["a"]
-        _ = t._repr_html_()
-
-        # single column with a single value should not fail
-        table = make_table(data={"kappa": [3.2]}, title="a title")
-        _ = table._repr_html_()
-
-        # set head and tail, introduces ellipsis row class
-        table = make_table(data={"A": list("abcdefghijk"), "B": list(range(11))})
-        table.set_repr_policy(head=8, tail=1)
-        got = table._repr_html_().splitlines()
-        num_rows = 0
-        for l in got:
-            if "<tr>" in l:
-                num_rows += 1
-                if "ellipsis" in l:
-                    break
-
-        # header row plus 8 head rows plus the ellipsis row
-        assert num_rows == 10
-
-    def test_array(self):
-        """should produce array"""
-        # data has tuples in an array
-        data = {
-            "key": numpy.array([("a", "c"), ("b", "c"), ("a", "d")], dtype="O"),
-            "count": [1, 3, 2],
-        }
-        expect = [list(v) for v in zip(data["key"][:], data["count"], strict=False)]
-        t = Table(data=data)
-        arr = t.array
-        assert_equal(arr.tolist(), expect)
-
-    def test_separator_format(self):
-        """testing separator_format with title and legend, and contents that match the separator"""
-        from cogent3.format.table import separator_format
-
-        with pytest.raises(RuntimeError):
-            _ = separator_format(self.t6_header, self.t6_rows)
-        separated_table = separator_format(
-            self.t6_header,
-            self.t6_rows,
-            sep=" | ",
-            title="Test",
-            legend="Units",
-        )
-        assert len(separated_table.split("\n")) == len(self.t6_rows) + 3
-
-    def test_separator_format_writer(self):
-        """exercising separator_format_writer"""
-        from cogent3.format.table import separator_formatter
-
-        t3 = Table(header=self.t3_header, data=self.t3_rows)
-        comma_sep = t3.to_string(sep=",").splitlines()
-        writer = separator_formatter(sep=" | ")
-        formatted = list(writer([l.split(",") for l in comma_sep], has_header=True))
-        expected_format = ["id | foo | bar", "6 | abc | 66", "7 | bca | 77"]
-        assert formatted == expected_format
-
-    def test_set_repr_policy(self):
-        """exercising setting repr policy"""
-        t = Table(header=self.t2_header, data=self.t2_rows)
-        t.set_repr_policy(random=2)
-        r = repr(t)
-        assert isinstance(r, str)
-        r, _, _ = t._get_repr_()
-        assert r.shape[0] == 2
-        t.set_repr_policy(head=1)
-        r, _, _ = t._get_repr_()
-        assert r.shape[0] == 1
-        t.set_repr_policy(tail=3)
-        r, _, _ = t._get_repr_()
-        assert r.shape[0] == 3
-        t.set_repr_policy(show_shape=False)
-        r = repr(t)
-        assert f"\n{t.shape[0]:,} rows x {t.shape[1]:,} columns" not in r
-        r = t._repr_html_()
-        assert f"\n{t.shape[0]:,} rows x {t.shape[1]:,} columns" not in r
-
-    def test_head(self):
-        """returns the head of the table!"""
-        from cogent3.core import table
-
-        display = table.display
-        head = TrapOutput()
-        table.display = head
-        t = Table(header=self.t1_header, data=self.t1_rows)
-        t.head(nrows=3)
-        assert head.data.shape[0] == 3
-        assert len(head.output.splitlines()) == 9
-        assert head.data.to_list() == self.t1_rows[:3]
-        # tests when number of rows < default
-        t = make_table(data={"a": ["a"], "b": ["b"]})
-        t.head()
-        assert head.data.shape[0] == 1
-        assert len(head.output.splitlines()) == 7
-        assert head.data.to_list() == [["a", "b"]]
-        table.display = display
-
-    def test_tail(self):
-        """returns the tail of the table!"""
-        from cogent3.core import table
-
-        display = table.display
-        tail = TrapOutput()
-        table.display = tail
-        t = Table(header=self.t1_header, data=self.t1_rows)
-        t.tail(nrows=3)
-        assert tail.data.shape[0] == 3
-        assert len(tail.output.splitlines()) == 9
-        assert [int(v) for v in tail.data[:, -1].to_list()] == [
-            r[-1] for r in self.t1_rows[-3:]
-        ]
-        # tests when number of rows < default
-        t = make_table(data={"a": ["a"], "b": ["b"]})
-        t.tail()
-        assert tail.data.shape[0] == 1
-        assert len(tail.output.splitlines()) == 7
-        assert tail.data.to_list() == [["a", "b"]]
-        table.display = display
-
-    @skipIf(DataFrame is None, "pandas not installed")
-    def test_to_pandas(self):
-        """produces a dataframe"""
-        t = Table(header=self.t1_header, data=self.t1_rows)
-        df = t.to_pandas()
-        assert isinstance(df, DataFrame)
-        data = df.to_numpy()
-        assert data.tolist() == self.t1_rows
-
-    def test_load_table(self):
-        """exercising load table"""
-        path = os.path.dirname(os.path.dirname(__file__))
-        path = os.path.join(path, "data/sample.tsv")
-        table = load_table(path)
-        assert table.shape == (10, 3)
-
-    def test_cast_str_to_numerical(self):
-        """correctly converts a series of strings to numeric values"""
-        d = arange(4, step=0.1)
-        r = cast_str_to_numeric(d)
-        assert_equal(d, r)
-
-        with warnings.catch_warnings():
-            # we know that converting to real loses imaginary
-            warnings.filterwarnings("ignore", category=ComplexWarning)
-            for d_type in [numpy.int64, numpy.complex128, numpy.float64]:
-                d = d.astype(d_type)
-                r = cast_str_to_numeric(d)
-                assert isinstance(r[0], type(d[0]))
-
-        d = d.astype(str)
-        r = cast_str_to_numeric(d)
-        assert isinstance(r[0], numpy.float64)
-        d = numpy.array(d, dtype="U")
-        r = cast_str_to_numeric(d)
-        assert isinstance(r[0], numpy.float64)
-        d = numpy.array(d, dtype="S")
-        r = cast_str_to_numeric(d)
-        assert isinstance(r[0], numpy.float64)
-
-    def test_cast_str_to_array(self):
-        """handle processing string series"""
-        d = [".123|.345", "123"]
-        r = cast_str_to_array(d, static_type=True)
-        assert "str" in r.dtype.name
-        r = cast_str_to_array(d, static_type=False)
-        assert r.dtype.name == "object"
-        d = [".123|.345", "123", "()"]
-        r = cast_str_to_array(d, static_type=False)
-        assert r[-1] == ()
-
-    def test_filtering_parser(self):
-        """filters rows"""
-        expect = []
-        for r in self.t1_rows:
-            row = [str(e) for e in r]
-            expect.append(row)
-
-        t = make_table(self.t1_header, data=self.t1_rows)
-        lines = t.to_csv().splitlines()
-        # no limit set
-        reader = FilteringParser(
-            row_condition=lambda x: x[0] == "A",
-            with_header=True,
-            sep=",",
-        )
-        got = list(reader(lines))
-        assert got[0] == self.t1_header
-        assert got[1:] == [r for r in expect if r[0] == "A"]
-
-        # limit set
-        reader = FilteringParser(
-            lambda x: x[0] == "A",
-            with_header=True,
-            sep=",",
-            limit=2,
-        )
-        got = list(reader(lines))
-        assert got[0] == self.t1_header
-        assert got[1:] == [r for r in expect if r[0] == "A"][:2]
-
-        # negate
-        reader = FilteringParser(
-            lambda x: x[0] == "A",
-            negate=True,
-            with_header=True,
-            sep=",",
-        )
-        got = list(reader(lines))
-        assert got[0] == self.t1_header
-        assert got[1:] == [r for r in expect if r[0] == "X"]
-
-        # parser works with load_table
-        path = TEST_ROOT / "data" / "sample.tsv"
-        reader = FilteringParser(lambda x: x[0] == "A", with_header=True, sep="\t")
-        table = load_table(path, reader=reader)
-        assert list(table.header) == self.t1_header
-        assert table.array.tolist() == [r for r in self.t1_rows if r[0] == "A"]
-
-        # parser works if called on path as Path
-        reader = FilteringParser(lambda x: x[0] == "A", with_header=True, sep="\t")
-        got = list(reader(path))
-        assert len(got) == 7
-
-        # parser works if called on path as str
-        got = list(reader(str(path)))
-        assert len(got) == 7
-
-        # parser works with no conditions
-        reader = FilteringParser(with_header=True, sep="\t")
-        t = load_table(path, reader=reader)
-        assert t.shape == (10, 3)
-
-    def test_filtering_parser_filter_columns(self):
-        """filters columns"""
-        path = TEST_ROOT / "data" / "sample.tsv"
-        # specified by int
-        reader = FilteringParser(columns=0, with_header=True, sep="\t")
-        got = load_table(path, reader=reader)
-        assert got.shape == (10, 1)
-
-        # specified by str
-        reader = FilteringParser(columns="length", with_header=True, sep="\t")
-        got = load_table(path, reader=reader)
-        assert got.shape == (10, 1)
-
-        # specified by index_name
-        reader = FilteringParser(columns=[0, 2], with_header=True, sep="\t")
-        got = load_table(path, reader=reader)
-        assert got.shape == (10, 2)
-
-        # specified by name
-        reader = FilteringParser(
-            columns=["chrom", "length"],
-            with_header=True,
-            sep="\t",
-        )
-        got2 = load_table(path, reader=reader)
-        assert got2.shape == (10, 2)
-        assert_equal(got.array, got2.array)
-
-        # raises value error if column name doesn't exist
-        reader = FilteringParser(columns=["blah", "length"], with_header=True, sep="\t")
-        with pytest.raises(ValueError):
-            _ = load_table(path, reader=reader)
-
-        # raises IndexError if column index_name doesn't exist
-        reader = FilteringParser(columns=[0, 10], with_header=True, sep="\t")
-        with pytest.raises(IndexError):
-            _ = load_table(path, reader=reader)
-
-        # raises ValueError if names given and with_header is False
-        with pytest.raises(ValueError):
-            _ = FilteringParser(columns=["blah"], with_header=False)
-
-    def test_set_column_format(self):
-        """fails if invalid format spec provided"""
-        data = {
-            "Gene": [
-                "NP_003077_hs_mm_rn_dna",
-                "NP_004893_hs_mm_rn_dna",
-                "NP_005079_hs_mm_rn_dna",
-                "NP_005500_hs_mm_rn_dna",
-                "NP_055852_hs_mm_rn_dna",
-            ],
-            "Type": ["Con", "Con", "Con", "Con", "Con"],
-            "LR": [
-                2.5386013224378985,
-                121351.42635634111,
-                9516594.978886133,
-                7.382703020266491e-08,
-                10933217.708952725,
-            ],
-        }
-        t = make_table(data=data)
-        with pytest.raises(ValueError):
-            t.format_column("LR", ".4e")
-
-    def test_table_format(self):
-        """table formating function doesn't fail with different input values"""
-        from cogent3.format.table import formatted_cells
-
-        data = [[230, "acdef", None], [6, "cc", 1.9876]]
-        head = ["one", "two", "three"]
-        _ = formatted_cells(data, header=head)
-        data = [[230, "acdef", 1.3], [6, "cc", numpy.array([1.9876, 2.34])]]
-        _ = formatted_cells(data, header=head)
-
-    def test_to_categorical(self):
-        """correctly construct contingency table"""
-        data = {"Ts": [31, 58], "Tv": [36, 138], "": ["syn", "nsyn"]}
-        table = make_table(header=["", "Ts", "Tv"], data=data)
-        with pytest.raises(ValueError):
-            # did not set an index_name
-            table.to_categorical(columns=["Ts", "Tv"])
-
-        got = table.to_categorical(columns=["Ts", "Tv"], index_name="")
-        assert_equal(got.observed, table[:, 1:].array)
-
-        got = table.to_categorical(["Ts"])
-        mean = got.observed.array.mean()
-        expected = numpy.array([[mean], [mean]])
-        assert_equal(got.expected, expected)
-
-        # works if index_name included
-        got = table.to_categorical(columns=["Ts", "Tv", ""])
-        assert_equal(got.observed, table[:, 1:].array)
-
-        # works if no columns specified
-        got = table.to_categorical()
-        assert_equal(got.observed, table[:, 1:].array)
-
-        data = {
-            "": numpy.array(["syn", "nsyn"], dtype=object),
-            "Ts": numpy.array([31, 58], dtype=object),
-            "Tv": numpy.array([36, 138], dtype=object),
-        }
-
-        table = make_table(header=["", "Ts", "Tv"], data=data, index_name="")
-        with pytest.raises(TypeError):
-            table.to_categorical(columns=["Ts", "Tv"])
-
-    def test_is_html_markup(self):
-        """format function confirms correctly specified html"""
-        assert is_html_markup("<table>blah</table>")
-        assert is_html_markup("<table>blah<table>blah</table></table>")
-        assert is_html_markup("<i>blah</i><sub>blah</sub>")
-        assert is_html_markup("<i>blah</i>\n<sub>blah</sub>")
-        assert not is_html_markup("<table>blah</tabl>")
-        assert not is_html_markup("<table>")
-        assert not is_html_markup("blah < blah")
-        assert not is_html_markup("blah > blah")
+        ],
+        "Type": ["Con", "Con", "Con", "Con", "Con"],
+        "LR": [
+            2.5386013224378985,
+            121351.42635634111,
+            9516594.978886133,
+            7.382703020266491e-08,
+            10933217.708952725,
+        ],
+    }
+    t = make_table(data=data)
+    with pytest.raises(ValueError):
+        t.format_column("LR", ".4e")
+
+
+def test_table_format():
+    # table formating function doesn't fail with different input values
+    from cogent3.format.table import formatted_cells
+
+    data = [[230, "acdef", None], [6, "cc", 1.9876]]
+    head = ["one", "two", "three"]
+    _ = formatted_cells(data, header=head)
+    data = [[230, "acdef", 1.3], [6, "cc", numpy.array([1.9876, 2.34])]]
+    _ = formatted_cells(data, header=head)
+
+
+def test_to_categorical():
+    # correctly construct contingency table
+    data = {"Ts": [31, 58], "Tv": [36, 138], "": ["syn", "nsyn"]}
+    table = make_table(header=["", "Ts", "Tv"], data=data)
+    with pytest.raises(ValueError):
+        # did not set an index_name
+        table.to_categorical(columns=["Ts", "Tv"])
+
+    got = table.to_categorical(columns=["Ts", "Tv"], index_name="")
+    assert_equal(got.observed, table[:, 1:].array)
+
+    got = table.to_categorical(["Ts"])
+    mean = got.observed.array.mean()
+    expected = numpy.array([[mean], [mean]])
+    assert_equal(got.expected, expected)
+
+    # works if index_name included
+    got = table.to_categorical(columns=["Ts", "Tv", ""])
+    assert_equal(got.observed, table[:, 1:].array)
+
+    # works if no columns specified
+    got = table.to_categorical()
+    assert_equal(got.observed, table[:, 1:].array)
+
+    data = {
+        "": numpy.array(["syn", "nsyn"], dtype=object),
+        "Ts": numpy.array([31, 58], dtype=object),
+        "Tv": numpy.array([36, 138], dtype=object),
+    }
+
+    table = make_table(header=["", "Ts", "Tv"], data=data, index_name="")
+    with pytest.raises(TypeError):
+        table.to_categorical(columns=["Ts", "Tv"])
+
+
+def test_is_html_markup():
+    # format function confirms correctly specified html
+    assert is_html_markup("<table>blah</table>")
+    assert is_html_markup("<table>blah<table>blah</table></table>")
+    assert is_html_markup("<i>blah</i><sub>blah</sub>")
+    assert is_html_markup("<i>blah</i>\n<sub>blah</sub>")
+    assert not is_html_markup("<table>blah</tabl>")
+    assert not is_html_markup("<table>")
+    assert not is_html_markup("blah < blah")
+    assert not is_html_markup("blah > blah")
 
 
 @pytest.mark.parametrize("data", [[[0, 1, 2], [0, 1]], [[0, 1, 2], [0, 1, 2, 3]]])


### PR DESCRIPTION
## Summary by Sourcery

Convert core test modules from unittest.TestCase classes to pytest-style tests with fixtures and function-based test cases.

Enhancements:
- Refactor table, profile, location, info, and features core tests to use pytest idioms such as fixtures, parametrization, and direct assertions instead of unittest.TestCase.

Tests:
- Restructure a broad set of core tests (table, profile, location, info, features) from class-based unittest style to standalone pytest tests, preserving coverage while simplifying test structure.