### PR TITLE
ENH: available_seq_formats() displays supported formats, fixes #1634

### DIFF
--- a/doc/api/__init__/cogent3.__init__.available_seq_formats.rst
+++ b/doc/api/__init__/cogent3.__init__.available_seq_formats.rst
@@ -1,0 +1,6 @@
+available_seq_formats
+======================
+
+.. currentmodule:: cogent3.__init__
+
+.. autofunction:: available_seq_formats

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -80,6 +80,7 @@ These are all top level imports. For example,
     __init__/cogent3.__init__.available_moltypes
     __init__/cogent3.__init__.available_models
     __init__/cogent3.__init__.available_apps
+    __init__/cogent3.__init__.available_seq_formats
 
 ************************
 Major cogent3 Data Types

--- a/doc/cookbook/loading_sequences.rst
+++ b/doc/cookbook/loading_sequences.rst
@@ -170,6 +170,17 @@ The ``cogent3`` load functions support loading from a url. We load the above fas
         moltype="dna",
     )
 
+Discovering the supported file formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``available_seq_formats()`` to see the formats that ``load_seq()``, ``load_aligned_seqs()`` and ``load_unaligned_seqs()`` can read. The "suffixes" column lists the filename suffixes that map to each format.
+
+.. jupyter-execute::
+
+    from cogent3 import available_seq_formats
+
+    available_seq_formats()
+
 Specifying the file format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/cogent3/__init__.py
+++ b/src/cogent3/__init__.py
@@ -57,6 +57,7 @@ _import_mapping = {
     "available_datasets": "_dataset",
     "get_dataset": "_dataset",
     "set_storage_defaults": "_plugin",
+    "available_seq_formats": "_plugin",
     "make_aligned_seqs": "core.alignment",
     "make_unaligned_seqs": "core.alignment",
     "load_annotations": "core.annotation_db",
@@ -266,6 +267,9 @@ def load_seq(
     Returns **one** sequence from a file. Use load_aligned_seqs or
     load_unaligned_seqs to get a collection.
 
+    Use cogent3.available_seq_formats() to see the supported formats and
+    file suffixes.
+
     Returns
     -------
     ``Sequence``
@@ -391,6 +395,11 @@ def load_unaligned_seqs(
         The latter induces a progress bar for number of files processed when
         filename is a glob pattern.
 
+    Notes
+    -----
+    Use cogent3.available_seq_formats() to see the supported formats and
+    file suffixes.
+
     Returns
     -------
     ``SequenceCollection``
@@ -478,6 +487,11 @@ def load_aligned_seqs(
         optional arguments for the parser
     kwargs
         passed to make_aligned_seqs
+
+    Notes
+    -----
+    Use cogent3.available_seq_formats() to see the supported formats and
+    file suffixes.
 
     Returns
     -------

--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -169,7 +169,7 @@ def available_seq_formats() -> "Table":
     )
     rows = []
     for ext in mgr.extensions:
-        plugin = ext.plugin()
+        plugin = ext.obj
         rows.append(
             [
                 plugin.name,

--- a/src/cogent3/_plugin.py
+++ b/src/cogent3/_plugin.py
@@ -10,6 +10,7 @@ import stevedore
 if TYPE_CHECKING:  # pragma: no cover
     from cogent3.core.annotation_db import AnnotationDbLoaderBase
     from cogent3.core.seq_storage import AlignedSeqsDataABC, SeqsDataABC
+    from cogent3.core.table import Table
     from cogent3.core.tree import PhyloNode
     from cogent3.evolve.fast_distance import DistanceMatrix
     from cogent3.format.sequence import SequenceWriterBase
@@ -156,6 +157,32 @@ def get_seq_format_parser_plugin(
 
     msg = f"Unknown parser for format {format_name!r} or file suffix {file_suffix!r}"
     raise ValueError(msg)
+
+
+def available_seq_formats() -> "Table":
+    """returns Table of sequence file formats that can be loaded"""
+    from cogent3.core.table import Table
+
+    mgr = stevedore.ExtensionManager(
+        namespace=SEQ_PARSER_ENTRY_POINT,
+        invoke_on_load=True,
+    )
+    rows = []
+    for ext in mgr.extensions:
+        plugin = ext.plugin()
+        rows.append(
+            [
+                plugin.name,
+                ", ".join(sorted(plugin.supported_suffixes)),
+                plugin.supports_aligned,
+                plugin.supports_unaligned,
+            ]
+        )
+
+    header = ["name", "suffixes", "aligned", "unaligned"]
+    title = "Specify a format by its name or a file by one of its suffixes."
+    result = Table(header=header, data=rows, title=title, index_name="name")
+    return result.sorted(columns="name")
 
 
 # registry for writing sequence file formats

--- a/tests/test_app/test_plugins.py
+++ b/tests/test_app/test_plugins.py
@@ -369,3 +369,14 @@ def test_registered_formatters_exist(seq_formatter):
     get_formatter = cogent3._plugin.get_seq_format_writer_plugin
     # this should not fail
     _ = get_formatter(format_name=seq_formatter)
+
+
+def test_available_seq_formats_returns_table():
+    table = cogent3.available_seq_formats()
+    assert isinstance(table, Table)
+    assert table.columns.order == ("name", "suffixes", "aligned", "unaligned")
+
+
+def test_available_seq_formats_lists_registered_parser(seq_parser):
+    table = cogent3.available_seq_formats()
+    assert seq_parser in table.columns["name"]


### PR DESCRIPTION
## Summary by Sourcery

Add a public helper to list supported sequence file formats and integrate it into the sequence-loading API and documentation.

New Features:
- Introduce available_seq_formats() to return a table of registered sequence parser formats and their supported suffixes and capabilities.

Enhancements:
- Expose available_seq_formats via the top-level cogent3 namespace for convenient access.
- Reference available_seq_formats() in load_seq, load_unaligned_seqs, and load_aligned_seqs docstrings to guide users on supported formats.

Documentation:
- Add API documentation entry for cogent3.available_seq_formats and link it from sequence loading docs.

Tests:
- Add tests verifying available_seq_formats() returns a Table with the expected schema and includes registered sequence parsers.