### PR TITLE
MAINT: move developer deps to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          export ruff_version=$(python -c 'import tomllib; print([line for line in tomllib.load(open("pyproject.toml","rb"))["project"]["optional-dependencies"]["test"] if "ruff" in line][0])')
+          export ruff_version=$(python -c 'import tomllib; print([line for line in tomllib.load(open("pyproject.toml","rb"))["dependency-groups"]["test"] if "ruff" in line][0])')
           echo "Click version: $ruff_version"
           python -m pip install $ruff_version
       - name: Format code using ruff

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -97,7 +97,7 @@ jobs:
       - name: "Run Type Checking for ${{ matrix.python-version }}"
         run: |
           uv venv venv -p python${{ matrix.python-version }}
-          uv pip install -p venv -e .[typing]
+          uv pip install -p venv -e . --group typing
           venv/bin/mypy src/cogent3/core/alignment.py src/cogent3/core/alphabet.py src/cogent3/core/annotation.py src/cogent3/core/genetic_code.py src/cogent3/core/location.py src/cogent3/core/moltype.py src/cogent3/core/seq_storage.py src/cogent3/core/sequence.py src/cogent3/core/seqview.py src/cogent3/core/slice_record.py src/cogent3/core/tree.py
 
 

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ which skips the data visualisation and notebook support.
 
 ### Install with developer tools
 
-Everything we use for `cogent3` development.
+Everything we use for `cogent3` development. Run this from a clone of the repository.
 
 ```bash
-$ pip install "cogent3[dev]"
+$ pip install -e . --group dev
 ```
 
 > **Note:** Installs all dependencies that can be installed using `pip`.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,11 +24,11 @@ If you don't need plotting, such as if you're running on a high-performance comp
 Install with developer tools
 ============================
 
-Everything we use for ``cogent3`` development.
+Everything we use for ``cogent3`` development. Run this from a clone of the repository.
 
 .. code-block:: bash
 
-   $ pip install "cogent3[dev]"
+   $ pip install -e . --group dev
 
 .. note:: Installs all dependencies that can be installed using ``pip``.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ def fmt(session: nox.Session) -> None:
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_slow(session):
-    session.install("-e.[test]")
+    session.install("-e", ".", "--group", "test")
     session.chdir("tests")
     session.run(
         "pytest",
@@ -30,7 +30,7 @@ def test_slow(session):
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test(session):
-    session.install("-e.[test]")
+    session.install("-e", ".", "--group", "test")
     session.run("pip", "list")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
@@ -58,7 +58,7 @@ def test(session):
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def test_module_docs(session):
     """doctest examples in a module"""
-    session.install("-e.[test]")
+    session.install("-e", ".", "--group", "test")
     # doctest modules within cogent3/app
     session.chdir("src/cogent3/app")
     session.run(
@@ -74,7 +74,7 @@ def test_module_docs(session):
 @nox.session(python=[f"3.{v}" for v in _py_versions])
 def testdocs(session):
     py = pathlib.Path(session.bin_paths[0]) / "python"
-    session.install("-e.[doc]")
+    session.install("-e", ".", "--group", "doc")
     session.chdir("doc")
     for docdir in ("app", "cookbook", "draw", "examples"):
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,20 @@ Documentation = "https://www.cogent3.org/"
 Changelog = "https://github.com/cogent3/cogent3/blob/develop/changelog.md"
 
 [project.optional-dependencies]
+extra = [
+    "ipykernel",
+    "ipython",
+    "ipywidgets",
+    "jupyterlab",
+    "kaleido",
+    "notebook",
+    "pandas",
+    "pillow",
+    "plotly",
+    "psutil",
+]
+
+[dependency-groups]
 test = [
     "cogent3-h5seqs>=0.8.0",
     "piqtree>=0.8.0; python_version > '3.11'",
@@ -92,27 +106,15 @@ doc = [
     "sphinxcontrib-video",
     "iplotx>=1.7.1",
 ]
-extra = [
-    "ipykernel",
-    "ipython",
-    "ipywidgets",
-    "jupyterlab",
-    "kaleido",
-    "notebook",
-    "pandas",
-    "pillow",
-    "plotly",
-    "psutil",
-]
 dev = [
     "flit",
     "nox",
     "numpydoc",
     "scriv",
     "types-tqdm",
-    "cogent3[doc]",
-    "cogent3[test]",
-    "cogent3[typing]",
+    { include-group = "doc" },
+    { include-group = "test" },
+    { include-group = "typing" },
 ]
 
 [tool.flit.sdist]


### PR DESCRIPTION
[CHANGED] Move test, typing, doc and dev out of optional-dependencies
    into dependency-groups; keep the user-facing extra install. Update
    nox, CI workflows and install docs to use --group.

## Summary by Sourcery

Adopt PEP 735 dependency groups for internal test, doc, typing, and dev dependencies while preserving the user-facing extra install.

Enhancements:
- Define PEP 735 dependency groups for test, doc, typing, and dev, and restructure dev to include other groups instead of extras.

Build:
- Update pyproject configuration to move developer-related extras into dependency-groups and keep only the user-facing extra group.
- Update nox sessions and README developer install instructions to use editable installs with --group instead of extras.

CI:
- Update GitHub workflows to read the test dependency group from pyproject and install typing dependencies via --group typing.

Documentation:
- Refresh installation documentation in README to describe the new developer install command based on dependency groups.