### PR TITLE
BUG: Table methods handle empty tables gracefully, fixes #721

### DIFF
--- a/src/cogent3/core/table.py
+++ b/src/cogent3/core/table.py
@@ -1293,6 +1293,9 @@ class Table:
         if isinstance(columns, str):
             columns = [columns]
 
+        if not columns:
+            return CategoryCounter({})
+
         groups = _group_indices(self, columns)
         if len(columns) == 1:
             data = {key[0]: len(indices) for key, indices in groups.items()}
@@ -1626,7 +1629,7 @@ class Table:
         arrays = []
         for c in columns:
             col = self.columns[c].copy()
-            if c in reverse:
+            if c in reverse and col.size:
                 func = _reverse_num if array_is_num_type(col) else _reverse_str
                 col = numpy.vectorize(func)(col)
             arrays.append(col)
@@ -1705,6 +1708,15 @@ class Table:
             formatted = [self.header]
         return formatted
 
+    def _header_and_rows(
+        self, missing_data: str = "", stripped: bool = False
+    ) -> tuple[list[str], list[list[str]]] | None:
+        """returns (header, body rows) as formatted strings, or None if no columns"""
+        if not self.header:
+            return None
+        formatted = self._formatted(missing_data=missing_data, stripped=stripped)
+        return formatted[0], formatted[1:]
+
     def to_csv(self, with_title: bool = False, with_legend: bool = False) -> str:
         """return table formatted as comma separated values
 
@@ -1715,8 +1727,10 @@ class Table:
         with_legend
             include table legend
         """
-        formatted_table = self._formatted(stripped=True)
-        header = formatted_table.pop(0)
+        formatted = self._header_and_rows(stripped=True)
+        if formatted is None:
+            return ""
+        header, formatted_table = formatted
         title = self.title if with_title else None
         legend = self.legend if with_legend else None
         return table_format.separator_format(
@@ -1760,8 +1774,10 @@ class Table:
         The \\caption*{} command is provided with the caption package. See
         https://ctan.org/pkg/caption for more details.
         """
-        formatted_table = self._formatted()
-        header = formatted_table.pop(0)
+        formatted = self._header_and_rows()
+        if formatted is None:
+            return ""
+        header, formatted_table = formatted
         caption = (self.title if with_title else None) or None
         legend = (self.legend if with_legend else None) or None
         if concat_title_legend and (caption or legend):
@@ -1794,8 +1810,10 @@ class Table:
         -------
         str
         """
-        formatted_table = self._formatted()
-        header = formatted_table.pop(0)
+        formatted = self._header_and_rows()
+        if formatted is None:
+            return ""
+        header, formatted_table = formatted
         return table_format.markdown(
             header,
             formatted_table,
@@ -1821,8 +1839,10 @@ class Table:
             include the table legend
         """
         stripped = csv_table
-        formatted_table = self._formatted(stripped=stripped)
-        header = formatted_table.pop(0)
+        formatted = self._header_and_rows(stripped=stripped)
+        if formatted is None:
+            return ""
+        header, formatted_table = formatted
         title = self.title if with_title else None
         legend = self.legend if with_legend else None
         if csv_table:
@@ -1882,6 +1902,8 @@ class Table:
         If format is bedgraph, assumes that column headers are chrom, start,
         end, value. In that order!
         """
+        if not self.header:
+            return ""
         fmt: str = format_name or ""
         if fmt == "bedgraph":
             # TODO remove requirement for column order
@@ -1982,8 +2004,10 @@ class Table:
         with_legend
             include table legend
         """
-        formatted_table = self._formatted(stripped=True)
-        header = formatted_table.pop(0)
+        formatted = self._header_and_rows(stripped=True)
+        if formatted is None:
+            return ""
+        header, formatted_table = formatted
         title = self.title if with_title else None
         legend = self.legend if with_legend else None
         return table_format.separator_format(
@@ -2280,6 +2304,14 @@ class Table:
             current column name containing data to be used
             as the header. Defaults to the first column.
         """
+        if not self.columns.order:
+            attr = self._get_persistent_attrs()
+            del attr["index_name"]
+            attr |= kwargs
+            result = self.__class__(**attr)
+            result.columns[new_column_name] = []
+            return result
+
         select_as_header = select_as_header or self.columns.order[0]
         assert select_as_header in self.columns, (
             f'"{select_as_header}" not in table header'

--- a/src/cogent3/format/table.py
+++ b/src/cogent3/format/table.py
@@ -179,7 +179,7 @@ def latex(
     """
 
     if not justify:
-        numcols = [len(header), len(rows[0])][not header]
+        numcols = len(header) if header else len(rows[0])
         justify = "r" * numcols
 
     justify = "{{ {} }}".format(" ".join(list(justify)))
@@ -358,6 +358,8 @@ _pipe = re.compile(r"\|")
 
 def _escape_pipes(formatted_table, header):
     """returns text with | replaced by \\|, adjusting column widths"""
+    if not formatted_table:
+        return formatted_table, header
     resized = False
     widths = list(map(len, formatted_table[0]))
     num_rows = len(formatted_table)

--- a/src/cogent3/format/table.py
+++ b/src/cogent3/format/table.py
@@ -177,6 +177,8 @@ def latex(
     The \\caption*{} command is provided with the caption package. See
     https://ctan.org/pkg/caption for more details.
     """
+    if not header and not rows:
+        return ""
 
     if not justify:
         numcols = len(header) if header else len(rows[0])

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -2557,3 +2557,119 @@ def test_sorted_reverse_mixed_columns():
     )
     result = table.sorted(columns=["Region", "Ratio"], reverse="Ratio")
     assert result.shape == table.shape
+
+
+# empty-table behaviour, issue #721
+# case A: header present, zero rows; case B: no columns at all
+
+
+def _empty_a():
+    return Table(header=["a", "b"], data=[])
+
+
+@pytest.mark.parametrize("table", [_empty_a(), make_table()])
+def test_empty_count_unique(table):
+    got = table.count_unique()
+    assert len(got) == 0
+
+
+def test_empty_distinct_values():
+    t = _empty_a()
+    assert t.distinct_values("a") == set()
+
+
+def test_empty_with_new_column():
+    t = _empty_a()
+    got = t.with_new_column("c", lambda row: row[0], columns="a")
+    assert "c" in got.header
+    assert got.shape[0] == 0
+
+
+def test_empty_sum_columns():
+    t = _empty_a()
+    assert t.sum_columns() == [0, 0]
+
+
+def test_empty_sum_rows():
+    t = _empty_a()
+    assert t.sum_rows() == []
+
+
+@pytest.mark.parametrize("by_row", [True, False])
+def test_empty_normalized(by_row):
+    t = _empty_a()
+    got = t.normalized(by_row=by_row)
+    assert got.shape == (0, 2)
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"columns": "a"}, {"reverse": "a"}])
+def test_empty_sorted(kwargs):
+    # reverse variant is a regression test for numpy.vectorize on size 0
+    t = _empty_a()
+    got = t.sorted(**kwargs)
+    assert got.shape == (0, 2)
+
+
+@pytest.mark.parametrize(("method", "expect"), [("to_csv", "a,b"), ("to_tsv", "a\tb")])
+def test_empty_to_delimited(method, expect):
+    # header only, no data rows
+    t = _empty_a()
+    assert getattr(t, method)() == expect
+
+
+def test_empty_to_markdown():
+    # regression test for IndexError on empty body
+    t = _empty_a()
+    got = t.to_markdown()
+    assert got == "| a | b |\n|---|---|"
+
+
+@pytest.mark.parametrize("method", ["to_string", "to_latex", "to_rst"])
+def test_empty_display_formats(method):
+    # header present, zero rows still renders without raising
+    t = _empty_a()
+    got = getattr(t, method)()
+    assert "a" in got
+    assert "b" in got
+
+
+def test_empty_to_dict():
+    t = _empty_a()
+    assert t.to_dict() == {}
+
+
+def test_empty_to_rich_dict_roundtrip():
+    t = _empty_a()
+    rd = t.to_rich_dict()
+    assert rd["data"]["order"] == ["a", "b"]
+    got = pickle.loads(pickle.dumps(t))  # noqa: S301
+    assert got.shape == (0, 2)
+    assert list(got.header) == ["a", "b"]
+
+
+@pytest.mark.skipif(DataFrame is None, reason="pandas not installed")
+def test_empty_to_pandas():
+    t = _empty_a()
+    df = t.to_pandas()
+    assert list(df.columns) == ["a", "b"]
+    assert len(df) == 0
+
+
+def test_empty_transposed():
+    t = _empty_a()
+    got = t.transposed("x")
+    assert list(got.header) == ["x"]
+
+
+@pytest.mark.parametrize(
+    "method", ["to_csv", "to_tsv", "to_markdown", "to_string", "to_latex", "to_rst"]
+)
+def test_zero_column_output_empty_string(method):
+    t = make_table()
+    assert getattr(t, method)() == ""
+
+
+def test_zero_column_transposed():
+    t = make_table()
+    got = t.transposed("x")
+    assert got.shape[0] == 0

--- a/tests/test_core/test_table.py
+++ b/tests/test_core/test_table.py
@@ -26,6 +26,7 @@ from cogent3.format.table import (
     formatted_array,
     get_continuation_tables_headers,
     is_html_markup,
+    latex,
 )
 from cogent3.parse.table import FilteringParser
 
@@ -2673,3 +2674,9 @@ def test_zero_column_transposed():
     t = make_table()
     got = t.transposed("x")
     assert got.shape[0] == 0
+
+
+@pytest.mark.parametrize("header", [[], None])
+def test_latex_formatter_no_columns(header):
+    # direct formatter call with no header and no rows must not raise
+    assert latex([], header=header) == ""


### PR DESCRIPTION
## Summary by Sourcery

Handle empty and zero-column tables gracefully across core table operations and output formats, closing edge-case failures like #721.

New Features:
- Support transposing zero-column tables by creating a new table with a single named column.
- Provide a helper for retrieving formatted header and body rows, used by multiple output methods.

Bug Fixes:
- Return an empty CategoryCounter when count_unique is called with no columns.
- Avoid numpy.vectorize errors when sorting empty columns with reverse specified.
- Ensure CSV, TSV, LaTeX, Markdown, RST, and string renderers return sensible output for empty tables and zero-column tables instead of raising or misformatting.
- Fix LaTeX justification calculation when only header or only body rows are present.
- Prevent IndexError in Markdown pipe escaping when there are no formatted body rows.

Tests:
- Add comprehensive tests covering empty tables with headers and zero-column tables for aggregation, normalization, sorting, transposition, serialization, and all display formats.