### PR TITLE
DEV: bump version to 2026.9.10

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,17 @@
 
+<a id='changelog-2026.9.10'></a>
+# Changes in release "2026.9.10"
+
+A maintenance release.
+
+## Contributors
+
+- @GavinHuttley
+
+## Deprecations
+
+- All code marked for removal by 2026.9 has now been deleted.
+
 <a id='changelog-2026.8.26'></a>
 # Changes in release "2026.8.26"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 [project]
 name = "cogent3"
 description = """COmparative GENomics Toolkit 3: genomic sequence analysis within notebooks or on compute systems with 1000s of CPUs."""
-version = "2026.8.26"
+version = "2026.9.10"
 
 authors = [{ name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "cogent3"
-version = "2026.8.26"
+version = "2026.9.10"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary by Sourcery

Prepare the 2026.9.10 maintenance release and complete the scheduled deprecation cleanup.

Enhancements:
- Remove all code previously scheduled for removal in the 2026.9 cycle.

Build:
- Bump the project and lockfile versions to 2026.9.10.

Documentation:
- Add changelog entries for the 2026.9.10 maintenance release and its completed deprecations.